### PR TITLE
Restructured provider information and updated UI

### DIFF
--- a/wasmcloud_host/lib/wasmcloud_host_web/controllers/provider_controller.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/controllers/provider_controller.ex
@@ -17,13 +17,16 @@ defmodule WasmcloudHostWeb.ProviderController do
     File.write!(tmp_file, bytes)
     File.chmod(tmp_file, 0o755)
 
-    {:ok, _pid} =
-      HostCore.Providers.ProviderSupervisor.start_executable_provider(
-        tmp_file,
-        key,
-        link_name,
-        contract_id
-      )
+    # TODO: Define error controller
+    case HostCore.Providers.ProviderSupervisor.start_executable_provider(
+           tmp_file,
+           key,
+           link_name,
+           contract_id
+         ) do
+      {:ok, _pid} -> :ok
+      {:error, _reason} -> :error
+    end
 
     conn |> redirect(to: "/")
   end

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
@@ -175,31 +175,30 @@
             </tr>
           </thead>
           <tbody>
-            <%= for provider <- @providers do %>
-              <tr>
-                <%= if {id, map} = provider do %>
-                  <%= for {ld, hids} <- map do %>
-                    <td><button class="btn btn-primary btn-sm" type="button" onClick="navigator.clipboard.writeText('<%= id %>')" data-toggle="popover" data-trigger="focus" title="" data-content="Copied!">
-                        <%= String.slice(id, 0..4) %>...
+            <%# One row per-provider instance, which is a public key, contract id and link name combination %>
+            <%= for {provider, instances} <- @providers do %>
+              <%= for instance <- instances do  %>
+                <tr>
+                  <td><button class="btn btn-primary btn-sm" type="button" onClick="navigator.clipboard.writeText('<%= provider%>')" data-toggle="popover" data-trigger="focus" title="" data-content="Copied!">
+                      <%= String.slice(provider, 0..4) %>...
+                      <svg class="c-icon">
+                        <use xlink:href="/coreui/free.svg#cil-copy"></use>
+                      </svg>&nbsp;
+                    </button></td>
+                  <td><%= Map.get(instance, :link_name) %></td>
+                  <td><%= Map.get(instance, :contract_id) %></td>
+                  <td>
+                    <%= for hid <- Map.get(instance, :host_ids) do %>
+                      <button class="btn btn-primary btn-sm" type="button" onClick="navigator.clipboard.writeText('<%= hid %>')" data-toggle="popover" data-trigger="focus" title="" data-content="Copied!">
+                        <%= String.slice(hid, 0..4) %>...
                         <svg class="c-icon">
                           <use xlink:href="/coreui/free.svg#cil-copy"></use>
                         </svg>&nbsp;
-                      </button></td>
-                    <td><%= ld %></td>
-                    <td>wasmcloud:idk</td>
-                    <td>
-                      <%= for hid <- hids do %>
-                        <button class="btn btn-primary btn-sm" type="button" onClick="navigator.clipboard.writeText('<%= hid %>')" data-toggle="popover" data-trigger="focus" title="" data-content="Copied!">
-                          <%= String.slice(hid, 0..4) %>...
-                          <svg class="c-icon">
-                            <use xlink:href="/coreui/free.svg#cil-copy"></use>
-                          </svg>&nbsp;
-                        </button>
-                      <% end %>
-                    </td>
-                  <% end %>
-                <% end %>
-              </tr>
+                      </button>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
             <% end %>
           </tbody>
         </table>


### PR DESCRIPTION
Previously, the information provided to the UI did not include contract_id, this PR adds that information to the providers list. In order to accommodate this, the provider map structure has been changed to a list of what I've been calling "instances", which is the combination of a link_name, contract_id, and the host_Id of the host that the provider is running on.