### PR TITLE
Support for lattice prefix environment variable

### DIFF
--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -118,7 +118,7 @@ defmodule HostCore.Actors.ActorModule do
     topic = "wasmbus.rpc.#{prefix}.#{claims.public_key}"
 
     {:ok, subscription} = Gnat.sub(:lattice_nats, self(), topic, queue_group: topic)
-    Agent.update(agent, fn state -> %State{ state | subscription: subscription } end)
+    Agent.update(agent, fn state -> %State{state | subscription: subscription} end)
 
     imports = %{
       wapc: Imports.wapc_imports(agent),

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -2,6 +2,9 @@ defmodule HostCore.Host do
   use GenServer, restart: :transient
   require Logger
 
+  @prefix_var "WASMCLOUD_LATTICE_PREFIX"
+  @default_prefix "default"
+
   defmodule State do
     defstruct [:host_key, :host_seed, :labels, :lattice_prefix]
   end
@@ -42,7 +45,12 @@ defmodule HostCore.Host do
     # TODO - get namespace prefix from env/config
     # TODO - query intrinsic labels for OS/CPU family
     # TODO - append labels from env/config
-    {:ok, %State{host_key: host_key, host_seed: host_seed, lattice_prefix: "default"}}
+    {:ok,
+     %State{
+       host_key: host_key,
+       host_seed: host_seed,
+       lattice_prefix: System.get_env(@prefix_var, @default_prefix)
+     }}
   end
 
   @impl true

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -8,7 +8,7 @@ defmodule HostCore.Host do
   @default_prefix "default"
 
   defmodule State do
-    defstruct [:host_key, :host_seed, :labels, :lattice_prefix]
+    defstruct [:host_key, :host_seed, :labels]
   end
 
   @doc """
@@ -51,13 +51,12 @@ defmodule HostCore.Host do
      %State{
        host_key: host_key,
        host_seed: host_seed,
-       lattice_prefix: System.get_env(@prefix_var, @default_prefix)
      }}
   end
 
   @impl true
   def handle_call(:get_prefix, _from, state) do
-    {:reply, state.lattice_prefix, state}
+    {:reply, System.get_env(@prefix_var, @default_prefix), state}
   end
 
   @impl true

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -50,7 +50,7 @@ defmodule HostCore.Host do
     {:ok,
      %State{
        host_key: host_key,
-       host_seed: host_seed,
+       host_seed: host_seed
      }}
   end
 

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -2,6 +2,8 @@ defmodule HostCore.Host do
   use GenServer, restart: :transient
   require Logger
 
+  # To set this value in a release, edit the `env.sh` file that is generated
+  # by a mix release.
   @prefix_var "WASMCLOUD_LATTICE_PREFIX"
   @default_prefix "default"
 

--- a/host_core/test/host_core/actors_test.exs
+++ b/host_core/test/host_core/actors_test.exs
@@ -8,25 +8,27 @@ defmodule HostCore.ActorsTest do
 
   @echo_key "MADQAFWOOOCZFDKYEYHC7AUQKDJTP32XUC5TDSMN4JLTDTU2WXBVPG4G"
   @httpserver_key "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M"
+  @kvcounter_key "MCFMFDWFHGKELOXPCNCDXKK5OFLHBVEWRAOXR5JSQUD2TOFRE3DFPM7E"
   @httpserver_link "default"
   @httpserver_contract "wasmcloud:httpserver"
 
   test "can load actors" do
-    {:ok, bytes} = File.read("priv/actors/echo_s.wasm")
+    {:ok, bytes} = File.read("priv/actors/kvcounter_s.wasm")
     {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
     {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
     {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
     {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
     {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
+    Process.sleep(1_000)
 
     actor_count =
-      Map.get(HostCore.Actors.ActorSupervisor.all_actors(), @echo_key)
+      Map.get(HostCore.Actors.ActorSupervisor.all_actors(), @kvcounter_key)
       |> length
 
     assert actor_count == 5
-    HostCore.Actors.ActorSupervisor.terminate_actor(@echo_key, 5)
-
-    assert Map.get(HostCore.Actors.ActorSupervisor.all_actors(), @echo_key) == nil
+    HostCore.Actors.ActorSupervisor.terminate_actor(@kvcounter_key, 5)
+    Process.sleep(500)
+    assert Map.get(HostCore.Actors.ActorSupervisor.all_actors(), @kvcounter_key) == nil
   end
 
   test "can invoke the echo actor" do


### PR DESCRIPTION
You can now specify a lattice prefix via `WASMCLOUD_LATTICE_PREFIX`, with the default value being `default`