### PR TITLE
Adds the  function to the HostCore.Host

### DIFF
--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -6,7 +6,7 @@ defmodule HostCore.Host do
   # by a mix release.
 
   defmodule State do
-    defstruct [:host_key, :host_seed, :labels, :lattice_prefix]
+    defstruct [:host_key, :host_seed, :lattice_prefix]
   end
 
   @doc """
@@ -42,14 +42,10 @@ defmodule HostCore.Host do
 
     Logger.info("Host #{host_key} started.")
 
-    labels = HostCore.WasmCloud.Native.detect_core_host_labels()
-    labels = Map.merge(labels, get_env_host_labels())
-
     {:ok,
      %State{
        host_key: host_key,
        host_seed: host_seed,
-       labels: labels,
        lattice_prefix: opts[:lattice_prefix]
      }}
   end
@@ -80,7 +76,10 @@ defmodule HostCore.Host do
 
   @impl true
   def handle_call(:get_labels, _from, state) do
-    {:reply, state.labels, state}
+    labels = get_env_host_labels()
+    labels = Map.merge(labels, HostCore.WasmCloud.Native.detect_core_host_labels())
+
+    {:reply, labels, state}
   end
 
   defp start_gnat(opts) do

--- a/host_core/lib/host_core/wasmcloud/native.ex
+++ b/host_core/lib/host_core/wasmcloud/native.ex
@@ -20,6 +20,7 @@ defmodule HostCore.WasmCloud.Native do
   def get_oci_bytes(_oci_ref, _allow_latest, _allowed_insecure), do: error()
   def par_from_bytes(_bytes), do: error()
   def par_cache_path(_subject, _rev), do: error()
+  def detect_core_host_labels(), do: error()
 
   # When the NIF is loaded, it will override functions in this module.
   # Calling error is handles the case when the nif could not be loaded.

--- a/host_core/test/host_core_test.exs
+++ b/host_core/test/host_core_test.exs
@@ -15,7 +15,7 @@ defmodule HostCoreTest do
     family_target =
       case :os.type() do
         {:unix, _linux} -> "unix"
-        {:unix, :darwin} -> "mac"
+        {:unix, :darwin} -> "unix"
         {:win32, :nt} -> "windows"
       end
 

--- a/host_core/test/host_core_test.exs
+++ b/host_core/test/host_core_test.exs
@@ -5,4 +5,22 @@ defmodule HostCoreTest do
   test "greets the world" do
     assert HostCore.hello() == :world
   end
+
+  test "Host stores intrinsic values" do
+    # should never appear
+    System.put_env("hostcore.osfamily", "fakeroo")
+    System.put_env("HOST_TESTING", "42")
+    labels = HostCore.Host.host_labels()
+
+    family_target =
+      case :os.type() do
+        {:unix, _linux} -> "unix"
+        {:unix, :darwin} -> "mac"
+        {:win32, :nt} -> "windows"
+      end
+
+    assert family_target == labels["hostcore.osfamily"]
+    # HOST_ prefix removed.
+    assert "42" == labels["testing"]
+  end
 end


### PR DESCRIPTION
This will be used later for scheduling.

When starting iex (or the main application) with an environment variable like `HOST_TEST=23`, then we get the following host labels:
```
 HostCore.Host.host_labels
%{
  "hostcore.arch" => "x86_64",
  "hostcore.os" => "linux",
  "hostcore.osfamily" => "unix",
  "test" => "21"
}
```
Closes #20 
