### PR TITLE
Renamed public_key field to sub for claims

### DIFF
--- a/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
@@ -115,9 +115,9 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
 
     cmap =
       if cmd == "put" do
-        Map.put(state.claims, claims.public_key, claims)
+        Map.put(state.claims, claims.sub, claims)
       else
-        Map.delete(state.claims, claims.public_key)
+        Map.delete(state.claims, claims.sub)
       end
 
     PubSub.broadcast(WasmcloudHost.PubSub, "lattice:state", {:claims, cmap})


### PR DESCRIPTION
This was causing a bug with the claims when starting an actor where we were looking for `public_key` and instead needed to look for the claims field `sub`.

@stevelr This is a small fix but just make sure that it works for your testing 👍🏻 