### PR TITLE
fix logic error in console_log so it logs messages

### DIFF
--- a/host_core/lib/host_core/web_assembly/imports.ex
+++ b/host_core/lib/host_core/web_assembly/imports.ex
@@ -85,7 +85,8 @@ defmodule HostCore.WebAssembly.Imports do
   end
 
   defp console_log(_api_type, context, ptr, len) do
-    if txt = Wasmex.Memory.read_binary(context.memory, ptr, len) != nil do
+    txt = Wasmex.Memory.read_string(context.memory, ptr, len)
+    if txt != nil do
       Logger.info("Log from guest: #{txt}")
     end
 

--- a/host_core/lib/host_core/web_assembly/imports.ex
+++ b/host_core/lib/host_core/web_assembly/imports.ex
@@ -86,6 +86,7 @@ defmodule HostCore.WebAssembly.Imports do
 
   defp console_log(_api_type, context, ptr, len) do
     txt = Wasmex.Memory.read_string(context.memory, ptr, len)
+
     if txt != nil do
       Logger.info("Log from guest: #{txt}")
     end


### PR DESCRIPTION
Every actor call to console_log(msg) resulted in a log message "Log from guest: true", 
It was displaying 'true' instead of the message text because of a minor logic bug.

Also I think Wasmex.Memory.read_string should be used instead of read_binary since the mem pointer is a utf8 string.

For the record, console_log is not the recommended way to log from actors. The recommended way is to use a logging provider, but a logging provider doesn't exist for otp yet, so this is the only way to log from an actor. And now it works!