### PR TITLE
Allow deleting providers, scaling actors from dashboard

### DIFF
--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -206,8 +206,7 @@ defmodule HostCore.Actors.ActorModule do
 
     Logger.info("Subscribing to #{topic}")
     {:ok, subscription} = Gnat.sub(:lattice_nats, self(), topic, queue_group: topic)
-    Agent.update(agent, fn state -> %State{state | subscription: subscription} end)
-    Agent.update(agent, fn state -> %State{state | ociref: oci} end)
+    Agent.update(agent, fn state -> %State{state | subscription: subscription, ociref: oci} end)
 
     Process.send_after(self(), :do_health, @thirty_seconds)
 

--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -21,7 +21,8 @@ defmodule HostCore.Actors.ActorModule do
       :api_version,
       :invocation,
       :claims,
-      :subscription
+      :subscription,
+      :ociref
     ]
   end
 
@@ -50,6 +51,10 @@ defmodule HostCore.Actors.ActorModule do
 
   def instance_id(pid) do
     GenServer.call(pid, :get_instance_id)
+  end
+
+  def ociref(pid) do
+    GenServer.call(pid, :get_ociref)
   end
 
   def halt(pid) do
@@ -113,6 +118,10 @@ defmodule HostCore.Actors.ActorModule do
 
   def handle_call(:get_instance_id, _from, agent) do
     {:reply, Agent.get(agent, fn content -> content.instance_id end), agent}
+  end
+
+  def handle_call(:get_ociref, _from, agent) do
+    {:reply, Agent.get(agent, fn content -> content.ociref end), agent}
   end
 
   @impl true
@@ -198,6 +207,7 @@ defmodule HostCore.Actors.ActorModule do
     Logger.info("Subscribing to #{topic}")
     {:ok, subscription} = Gnat.sub(:lattice_nats, self(), topic, queue_group: topic)
     Agent.update(agent, fn state -> %State{state | subscription: subscription} end)
+    Agent.update(agent, fn state -> %State{state | ociref: oci} end)
 
     Process.send_after(self(), :do_health, @thirty_seconds)
 

--- a/host_core/lib/host_core/actors/actor_supervisor.ex
+++ b/host_core/lib/host_core/actors/actor_supervisor.ex
@@ -96,14 +96,19 @@ defmodule HostCore.Actors.ActorSupervisor do
   Ensures that the actor count is equal to the desired count by terminating instances
   or starting instances on the host.
   """
-  def scale_actor(public_key, desired_count) do
-    current_count = find_actor(public_key) |> Enum.count()
+  def scale_actor(public_key, desired_count, oci \\ nil) do
+    current_instances = find_actor(public_key)
+    current_count = current_instances |> Enum.count()
+
+    # Attempt to retrieve OCI reference from running actor if not supplied
+    ociref =
+      if oci != nil do
+        oci
+      else
+        ActorModule.ociref(current_instances |> List.first())
+      end
 
     diff = current_count - desired_count
-    IO.puts("trying to scale")
-    IO.inspect(current_count)
-    IO.inspect(desired_count)
-    IO.inspect(diff)
 
     cond do
       # Current count is desired actor count
@@ -115,8 +120,25 @@ defmodule HostCore.Actors.ActorSupervisor do
         terminate_actor(public_key, diff)
 
       # Current count is less than desired count, start more instances
+      diff < 0 && ociref != nil ->
+        case 1..abs(diff)
+             |> Enum.reduce_while("", fn _, _ ->
+               IO.puts("enumerating and gonna start actor")
+
+               case start_actor_from_oci(ociref) do
+                 {:stop, err} ->
+                   {:halt, "Error: #{err}"}
+
+                 _any ->
+                   {:cont, ""}
+               end
+             end) do
+          "" -> {:ok}
+          err -> {:error, err}
+        end
+
       diff < 0 ->
-        {"need to start actor"}
+        {:error, "Scaling actor up without an OCI reference is not currently supported"}
     end
   end
 

--- a/host_core/lib/host_core/actors/actor_supervisor.ex
+++ b/host_core/lib/host_core/actors/actor_supervisor.ex
@@ -118,7 +118,7 @@ defmodule HostCore.Actors.ActorSupervisor do
     cond do
       # Current count is desired actor count
       diff == 0 ->
-        {:ok}
+        :ok
 
       # Current count is greater than desired count, terminate instances
       diff > 0 ->
@@ -136,7 +136,7 @@ defmodule HostCore.Actors.ActorSupervisor do
                    {:cont, ""}
                end
              end) do
-          "" -> {:ok}
+          "" -> :ok
           err -> {:error, err}
         end
 

--- a/host_core/lib/host_core/actors/actor_supervisor.ex
+++ b/host_core/lib/host_core/actors/actor_supervisor.ex
@@ -92,6 +92,34 @@ defmodule HostCore.Actors.ActorSupervisor do
     Map.get(all_actors(), public_key, [])
   end
 
+  @doc """
+  Ensures that the actor count is equal to the desired count by terminating instances
+  or starting instances on the host.
+  """
+  def scale_actor(public_key, desired_count) do
+    current_count = find_actor(public_key) |> Enum.count()
+
+    diff = current_count - desired_count
+    IO.puts("trying to scale")
+    IO.inspect(current_count)
+    IO.inspect(desired_count)
+    IO.inspect(diff)
+
+    cond do
+      # Current count is desired actor count
+      diff == 0 ->
+        {:ok}
+
+      # Current count is greater than desired count, terminate instances
+      diff > 0 ->
+        terminate_actor(public_key, diff)
+
+      # Current count is less than desired count, start more instances
+      diff < 0 ->
+        {"need to start actor"}
+    end
+  end
+
   def terminate_actor(public_key, count) when count > 0 do
     children =
       Registry.lookup(Registry.ActorRegistry, public_key)

--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -132,7 +132,7 @@ defmodule HostCore.ControlInterface.Server do
       replicas = String.to_integer(scale_request["replicas"])
 
       case HostCore.Actors.ActorSupervisor.scale_actor(actor_id, replicas, actor_ref) do
-        {:ok} ->
+        :ok ->
           {:reply,
            Jason.encode!(%{
              host_id: host_id,

--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -212,6 +212,28 @@ defmodule HostCore.ControlInterface.Server do
     end
   end
 
+  # Scale Actor
+  # input: #{"actor_id" => "...", "host_id" => "...", "replicas" => <number>}
+  defp handle_request({"scale", "actor"}, body, _reply_to) do
+    scale_request = Jason.decode!(body)
+    host_id = scale_request["host_id"]
+
+    if host_id == HostCore.Host.host_key() do
+      # TODO: call scale
+      # %{
+      #   "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5" => [#PID<0.1381.0>,
+      #    #PID<0.4086.0>, #PID<0.4092.0>, #PID<0.4098.0>],
+      #   "MCFMFDWFHGKELOXPCNCDXKK5OFLHBVEWRAOXR5JSQUD2TOFRE3DFPM7E" => [#PID<0.6026.0>]
+      # }
+    else
+      {:reply,
+       Jason.encode!(%{
+         host_id: host_id,
+         failure: "Command received by incorrect host and could not be processed"
+       })}
+    end
+  end
+
   # Auction Provider
   # input: #{"actor_ref" => "...", "constraints" => %{}}
   defp handle_request({"auction", "provider"}, body, _reply_to) do

--- a/wasmcloud_host/assets/vendor/wasmcloud/js/tooltips.js
+++ b/wasmcloud_host/assets/vendor/wasmcloud/js/tooltips.js
@@ -1,0 +1,19 @@
+import { Tooltip } from "../../@coreui/coreui-pro/js/coreui.bundle.min";
+document
+  .querySelectorAll('[data-toggle="tooltip"]')
+  .forEach(function (element) {
+    // eslint-disable-next-line no-new
+    new Tooltip(element, {
+      offset: function offset(_ref) {
+        var placement = _ref.placement,
+          reference = _ref.reference,
+          popper = _ref.popper;
+
+        if (placement === "bottom") {
+          return [0, popper.height / 2];
+        } else {
+          return [];
+        }
+      },
+    });
+  });

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/actor_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/actor_row_component.ex
@@ -7,12 +7,7 @@ defmodule ActorRowComponent do
 
   def render(assigns) do
     ~L"""
-    <tr>
-      <%= for {k, v} <- @claims do %>
-        <%= if k == @actor do %>
-          <td><%= v.name %> </td>
-        <% end %>
-      <% end %>
+      <td><%= @name %> </td>
       <td><%= @count %></td>
       <td>
         <span class="badge <%= case @status do
@@ -27,7 +22,7 @@ defmodule ActorRowComponent do
           <%= String.slice(@actor, 0..4) %>...
           <svg class="c-icon">
             <use xlink:href="/coreui/free.svg#cil-copy"></use>
-          </svg>&nbsp;
+          </svg>
         </button>
       </td>
       <td>
@@ -35,10 +30,9 @@ defmodule ActorRowComponent do
           <%= String.slice(@host_id, 0..4) %>...
           <svg class="c-icon">
             <use xlink:href="/coreui/free.svg#cil-copy"></use>
-          </svg>&nbsp;
+          </svg>
         </button>
       </td>
-    </tr>
     """
   end
 end

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/actor_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/actor_row_component.ex
@@ -7,6 +7,7 @@ defmodule ActorRowComponent do
 
   def render(assigns) do
     ~L"""
+    <tr>
       <td><%= @name %> </td>
       <td><%= @count %></td>
       <td>
@@ -33,6 +34,24 @@ defmodule ActorRowComponent do
           </svg>
         </button>
       </td>
+      <td>
+        <button class="btn btn-sm btn-warning"
+          data-toggle="tooltip"
+          data-placement="top"
+          title data-original-title="Scale Actor"
+          phx-click="show_modal"
+          phx-value-title='Scale "<%= @name %>"'
+          phx-value-component="ScaleActorComponent"
+          phx-value-id="scale_actor_modal"
+          phx-value-actor="<%= @actor %>"
+          phx-value-host="<%= @host_id %>"
+          phx-value-replicas="<%= @count %>">
+          <svg class="c-icon" style="color: white">
+            <use xlink:href="/coreui/free.svg#cil-equalizer"></use>
+          </svg>
+        </button>
+      </td>
+      </tr>
     """
   end
 end

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/link_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/link_row_component.ex
@@ -14,14 +14,14 @@ defmodule LinkRowComponent do
           <%= String.slice(@actor_id, 0..4) %>...
           <svg class="c-icon">
             <use xlink:href="/coreui/free.svg#cil-copy"></use>
-          </svg>&nbsp;
+          </svg>
         </button></td>
       <td>
         <button class="btn btn-primary btn-sm" type="button" onClick="navigator.clipboard.writeText('<%= @provider_key %>')" data-toggle="popover" data-trigger="focus" title="" data-content="Copied!">
           <%= String.slice(@provider_key, 0..4) %>...
           <svg class="c-icon">
             <use xlink:href="/coreui/free.svg#cil-copy"></use>
-          </svg>&nbsp;
+          </svg>
         </button>
       </td>
     </tr>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/provider_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/provider_row_component.ex
@@ -5,6 +5,13 @@ defmodule ProviderRowComponent do
     {:ok, socket}
   end
 
+  def handle_event("delete_provider", params, socket) do
+    provider = params["provider"]
+    link_name = params["link_name"]
+    HostCore.Providers.ProviderSupervisor.terminate_provider(provider, link_name)
+    {:noreply, socket}
+  end
+
   def render(assigns) do
     ~L"""
     <tr>
@@ -33,6 +40,20 @@ defmodule ProviderRowComponent do
             </svg>
           </button>
         <% end %>
+      </td>
+      <td>
+      <button class="btn btn-sm btn-danger"
+        data-toggle="tooltip"
+        data-placement="top"
+        title data-original-title="Delete Provider"
+        phx-target="<%= @myself %>"
+        phx-click="delete_provider"
+        phx-value-provider="<%= @provider %>"
+        phx-value-link_name="<%= @link_name %>">
+      <svg class="c-icon" style="color: white">
+        <use xlink:href="/coreui/free.svg#cil-trash"></use>
+      </svg>
+    </button>
       </td>
     </tr>
     """

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/provider_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/provider_row_component.ex
@@ -22,7 +22,7 @@ defmodule ProviderRowComponent do
           <%= String.slice(@provider, 0..4) %>...
           <svg class="c-icon">
             <use xlink:href="/coreui/free.svg#cil-copy"></use>
-          </svg>&nbsp;
+          </svg>
         </button></td>
       <td>
         <%= for hid <- @host_ids do %>
@@ -30,7 +30,7 @@ defmodule ProviderRowComponent do
             <%= String.slice(hid, 0..4) %>...
             <svg class="c-icon">
               <use xlink:href="/coreui/free.svg#cil-copy"></use>
-            </svg>&nbsp;
+            </svg>
           </button>
         <% end %>
       </td>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
@@ -1,0 +1,61 @@
+defmodule ScaleActorComponent do
+  use Phoenix.LiveComponent
+
+  def mount(socket) do
+    {:ok,
+     socket
+     |> assign(:error_msg, nil)}
+  end
+
+  def handle_event("validate", _params, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "scale_actor",
+        params,
+        socket
+      ) do
+    current = socket.replicas
+    desired = String.to_integer(params.replicas)
+
+    # case error_msg do
+    #   nil ->
+    #     {:noreply, assign(socket, error_msg: "Please select a file")}
+
+    #   "" ->
+    #     Phoenix.PubSub.broadcast(WasmcloudHost.PubSub, "frontend", :hide_modal)
+    #     {:noreply, assign(socket, error_msg: nil)}
+
+    #   msg ->
+    #     {:noreply, assign(socket, error_msg: msg)}
+    # end
+    {:noreply, socket}
+  end
+
+  def render(assigns) do
+    replicas = 1
+
+    ~L"""
+    <form class="form-horizontal" phx-submit="scale_actor" phx-change="validate" phx-target="<%= @myself %>">
+      <input name="_csrf_token" type="hidden" value="<%= Phoenix.Controller.get_csrf_token() %>">
+      <div class="form-group row">
+        <label class="col-md-3 col-form-label" for="text-input">Replicas</label>
+        <div class="col-md-9">
+          <input class="form-control" id="number-input" type="number" name="replicas" value="<%= replicas %>" min="0">
+          <span class="help-block">Enter how many instances of this actor you want</span>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" type="button" phx-click="hide_modal">Close</button>
+        <button class="btn btn-primary" type="submit">Submit</button>
+      </div>
+    </form>
+    <%= if @error_msg != nil do %>
+    <div class="alert alert-danger">
+    <%= @error_msg %>
+    </div>
+    <% end %>
+    """
+  end
+end

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
@@ -21,7 +21,7 @@ defmodule ScaleActorComponent do
 
     error_msg =
       case HostCore.Actors.ActorSupervisor.scale_actor(actor_id, desired) do
-        {:ok} -> ""
+        :ok -> ""
         {:error, err} -> err
       end
 

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
@@ -16,33 +16,36 @@ defmodule ScaleActorComponent do
         params,
         socket
       ) do
-    current = socket.replicas
-    desired = String.to_integer(params.replicas)
+    desired = String.to_integer(Map.get(params, "desired_replicas"))
+    actor_id = Map.get(params, "actor_id")
+    # host_id = Map.get(params, "host_id")
 
-    # case error_msg do
-    #   nil ->
-    #     {:noreply, assign(socket, error_msg: "Please select a file")}
+    error_msg =
+      case HostCore.Actors.ActorSupervisor.scale_actor(actor_id, desired) do
+        {:ok} -> ""
+        _any -> "omg error"
+      end
 
-    #   "" ->
-    #     Phoenix.PubSub.broadcast(WasmcloudHost.PubSub, "frontend", :hide_modal)
-    #     {:noreply, assign(socket, error_msg: nil)}
+    case error_msg do
+      "" ->
+        Phoenix.PubSub.broadcast(WasmcloudHost.PubSub, "frontend", :hide_modal)
+        {:noreply, assign(socket, error_msg: nil)}
 
-    #   msg ->
-    #     {:noreply, assign(socket, error_msg: msg)}
-    # end
-    {:noreply, socket}
+      msg ->
+        {:noreply, assign(socket, error_msg: msg)}
+    end
   end
 
   def render(assigns) do
-    replicas = 1
-
     ~L"""
     <form class="form-horizontal" phx-submit="scale_actor" phx-change="validate" phx-target="<%= @myself %>">
       <input name="_csrf_token" type="hidden" value="<%= Phoenix.Controller.get_csrf_token() %>">
+      <input name="actor_id" type="hidden" value='<%= Map.get(@modal, "actor") %>'>
+      <input name="host_id" type="hidden" value='<%= Map.get(@modal, "host") %>'>
       <div class="form-group row">
         <label class="col-md-3 col-form-label" for="text-input">Replicas</label>
         <div class="col-md-9">
-          <input class="form-control" id="number-input" type="number" name="replicas" value="<%= replicas %>" min="0">
+          <input class="form-control" id="number-input" type="number" name="desired_replicas" value='<%= Map.get(@modal, "replicas") %>' min="0">
           <span class="help-block">Enter how many instances of this actor you want</span>
         </div>
       </div>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
@@ -18,12 +18,11 @@ defmodule ScaleActorComponent do
       ) do
     desired = String.to_integer(Map.get(params, "desired_replicas"))
     actor_id = Map.get(params, "actor_id")
-    # host_id = Map.get(params, "host_id")
 
     error_msg =
       case HostCore.Actors.ActorSupervisor.scale_actor(actor_id, desired) do
         {:ok} -> ""
-        _any -> "omg error"
+        {:error, err} -> err
       end
 
     case error_msg do
@@ -42,6 +41,7 @@ defmodule ScaleActorComponent do
       <input name="_csrf_token" type="hidden" value="<%= Phoenix.Controller.get_csrf_token() %>">
       <input name="actor_id" type="hidden" value='<%= Map.get(@modal, "actor") %>'>
       <input name="host_id" type="hidden" value='<%= Map.get(@modal, "host") %>'>
+      <input name="actor_ociref" type="hidden" value='<%= Map.get(@modal, "oci") %>'>
       <div class="form-group row">
         <label class="col-md-3 col-form-label" for="text-input">Replicas</label>
         <div class="col-md-9">

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_actor_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_actor_component.ex
@@ -117,7 +117,7 @@ defmodule StartActorComponent do
       </div>
       <div class="modal-footer">
         <button class="btn btn-secondary" type="button" phx-click="hide_modal">Close</button>
-        <button class="btn btn-primary" type="submit" >Submit</button>
+        <button class="btn btn-primary" type="submit">Submit</button>
       </div>
     </form>
     <%= if @error_msg != nil do %>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_actor_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_actor_component.ex
@@ -61,17 +61,26 @@ defmodule StartActorComponent do
       ) do
     replicas = 1..String.to_integer(replicas)
 
+    # Much more efficient to download the oci_bytes and start from bytes
     error_msg =
-      replicas
-      |> Enum.reduce_while("", fn _, _ ->
-        case HostCore.Actors.ActorSupervisor.start_actor_from_oci(actor_ociref) do
-          {:stop, err} ->
-            {:halt, "Error: #{err}"}
+      case HostCore.WasmCloud.Native.get_oci_bytes(actor_ociref, false, []) do
+        {:error, _err} ->
+          "Failed to download OCI bytes for #{actor_ociref}"
 
-          _any ->
-            {:cont, ""}
-        end
-      end)
+        {:ok, bytes} ->
+          actor_bytes = bytes |> IO.iodata_to_binary()
+
+          replicas
+          |> Enum.reduce_while("", fn _, _ ->
+            case HostCore.Actors.ActorSupervisor.start_actor(actor_bytes, actor_ociref) do
+              {:stop, err} ->
+                {:halt, "Error: #{err}"}
+
+              _any ->
+                {:cont, ""}
+            end
+          end)
+      end
 
     if error_msg != "" do
       {:noreply, assign(socket, error_msg: error_msg)}

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_provider_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_provider_component.ex
@@ -60,7 +60,6 @@ defmodule StartProviderComponent do
            ) do
         {:ok, _pid} -> nil
         {:error, reason} -> reason
-        {:stop, reason} -> reason
       end
 
     if error_msg == nil do
@@ -92,7 +91,7 @@ defmodule StartProviderComponent do
       <div class="form-group row">
         <label class="col-md-3 col-form-label" for="file-input">OCI Reference</label>
         <div class="col-md-9">
-          <input class="form-control" id="provider-ociref-input" type="text" name="provider_ociref" placeholder="wasmcloud.azurecr.io/httpserver:0.12.1" value="">
+          <input class="form-control" id="provider-ociref-input" type="text" name="provider_ociref" placeholder="wasmcloud.azurecr.io/httpserver:0.12.1" value="" required>
           <span class="help-block">Enter an OCI reference</span>
         </div>
       </div>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
@@ -54,7 +54,6 @@ defmodule WasmcloudHostWeb.PageLive do
         modal,
         socket
       ) do
-    IO.inspect(modal)
     {:noreply, assign(socket, :open_modal, modal)}
   end
 

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
@@ -49,6 +49,16 @@ defmodule WasmcloudHostWeb.PageLive do
   end
 
   @impl true
+  def handle_event(
+        "show_modal",
+        modal,
+        socket
+      ) do
+    IO.inspect(modal)
+    {:noreply, assign(socket, :open_modal, modal)}
+  end
+
+  @impl true
   def handle_event("hide_modal", _value, socket) do
     {:noreply, assign(socket, :open_modal, nil)}
   end

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
@@ -139,36 +139,17 @@
           </thead>
           <tbody>
             <%= for {actor, hosts_map} <- @actors do %>
-              <tr>
-                <% actor_name = @claims |> Enum.find(fn {k, v} -> k == actor end) |> elem(1) |> Map.get(:name) %>
-                <%= for {host_id, host_info} <- hosts_map do %>
-                  <% count = Map.get(host_info, :count) %>
-                  <% status = Map.get(host_info, :status) %>
-                  <%= live_component ActorRowComponent,
+              <% actor_name = @claims |> Enum.find(fn {k, _v} -> k == actor end) |> elem(1) |> Map.get(:name) %>
+              <%= for {host_id, host_info} <- hosts_map do %>
+                <% count = Map.get(host_info, :count) %>
+                <% status = Map.get(host_info, :status) %>
+                <%= live_component ActorRowComponent,
                   actor: actor,
                   host_id: host_id,
                   status: status,
                   count: count,
                   name: actor_name %>
-                  <td>
-                    <button class="btn btn-sm btn-warning"
-                      data-toggle="tooltip"
-                      data-placement="top"
-                      title data-original-title="Scale Actor"
-                      phx-click="show_modal"
-                      phx-value-title='Scale "<%= actor_name %>"'
-                      phx-value-component="ScaleActorComponent"
-                      phx-value-id="scale_actor_modal"
-                      phx-value-actor="<%= actor %>"
-                      phx-value-host="<%= host_id %>"
-                      phx-value-replicas="<%= count %>">
-                      <svg class="c-icon" style="color: white">
-                        <use xlink:href="/coreui/free.svg#cil-equalizer"></use>
-                      </svg>
-                    </button>
-                  </td>
-                <% end %>
-              </tr>
+              <% end %>
             <% end %>
           </tbody>
         </table>
@@ -215,15 +196,18 @@
               <th>Status</th>
               <th>Provider ID</th>
               <th>Host IDs</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
             <%# One row per-provider instance, which is a public key, contract id and link name combination %>
             <%= for {provider, instances} <- @providers do %>
               <%= for instance <- instances do  %>
+                <% link_name = Map.get(instance, :link_name) %>
                 <%= live_component ProviderRowComponent,
+                  id: "#{provider} (#{link_name})",
                   provider: provider,
-                  link_name: Map.get(instance, :link_name),
+                  link_name: link_name,
                   contract_id: Map.get(instance, :contract_id),
                   status: Map.get(instance, :status),
                   host_ids: Map.get(instance, :host_ids)%>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
@@ -140,13 +140,15 @@
           <tbody>
             <%= for {actor, hosts_map} <- @actors do %>
               <tr>
-                <%= actor_name = @claims |> Enum.find(fn {k, v} -> k == actor end) |> elem(1) |> Map.get(:name) %>
+                <% actor_name = @claims |> Enum.find(fn {k, v} -> k == actor end) |> elem(1) |> Map.get(:name) %>
                 <%= for {host_id, host_info} <- hosts_map do %>
+                  <% count = Map.get(host_info, :count) %>
+                  <% status = Map.get(host_info, :status) %>
                   <%= live_component ActorRowComponent,
                   actor: actor,
                   host_id: host_id,
-                  status: Map.get(host_info, :status),
-                  count: Map.get(host_info, :count),
+                  status: status,
+                  count: count,
                   name: actor_name %>
                   <td>
                     <button class="btn btn-sm btn-warning"
@@ -154,10 +156,12 @@
                       data-placement="top"
                       title data-original-title="Scale Actor"
                       phx-click="show_modal"
-                      phx-value-title="Scale Actor"
+                      phx-value-title='Scale "<%= actor_name %>"'
                       phx-value-component="ScaleActorComponent"
                       phx-value-id="scale_actor_modal"
-                      phx-value-actor="<%= actor %>">
+                      phx-value-actor="<%= actor %>"
+                      phx-value-host="<%= host_id %>"
+                      phx-value-replicas="<%= count %>">
                       <svg class="c-icon" style="color: white">
                         <use xlink:href="/coreui/free.svg#cil-equalizer"></use>
                       </svg>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
@@ -106,8 +106,20 @@
             <div class="dropdown d-inline-block">
               <button class="btn btn-secondary dropdown-toggle" id="dropdownMenuButton" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Start Actor</button>
               <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                <button class="dropdown-item" phx-click="show_modal" phx-value-modal="start_actor_file">From File</button>
-                <button class="dropdown-item" phx-click="show_modal" phx-value-modal="start_actor_ociref">From Registry</button>
+                <button class="dropdown-item"
+                  phx-click="show_modal"
+                  phx-value-title="Start Actor from File"
+                  phx-value-component="StartActorComponent"
+                  phx-value-id="start_actor_file_modal">
+                  From File
+                </button>
+                <button class="dropdown-item"
+                  phx-click="show_modal"
+                  phx-value-title="Start Actor from OCI Registry"
+                  phx-value-component="StartActorComponent"
+                  phx-value-id="start_actor_ociref_modal">
+                  From Registry
+                </button>
               </div>
             </div>
           </div>
@@ -122,18 +134,37 @@
               <th>Status</th>
               <th>Actor ID</th>
               <th>Host ID</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
             <%= for {actor, hosts_map} <- @actors do %>
-              <%= for {host_id, host_info} <- hosts_map do %>
-                <%= live_component ActorRowComponent,
+              <tr>
+                <%= actor_name = @claims |> Enum.find(fn {k, v} -> k == actor end) |> elem(1) |> Map.get(:name) %>
+                <%= for {host_id, host_info} <- hosts_map do %>
+                  <%= live_component ActorRowComponent,
                   actor: actor,
                   host_id: host_id,
                   status: Map.get(host_info, :status),
                   count: Map.get(host_info, :count),
-                  claims: @claims %>
-              <% end %>
+                  name: actor_name %>
+                  <td>
+                    <button class="btn btn-sm btn-warning"
+                      data-toggle="tooltip"
+                      data-placement="top"
+                      title data-original-title="Scale Actor"
+                      phx-click="show_modal"
+                      phx-value-title="Scale Actor"
+                      phx-value-component="ScaleActorComponent"
+                      phx-value-id="scale_actor_modal"
+                      phx-value-actor="<%= actor %>">
+                      <svg class="c-icon" style="color: white">
+                        <use xlink:href="/coreui/free.svg#cil-equalizer"></use>
+                      </svg>
+                    </button>
+                  </td>
+                <% end %>
+              </tr>
             <% end %>
           </tbody>
         </table>
@@ -152,8 +183,20 @@
             <div class="dropdown d-inline-block">
               <button class="btn btn-secondary dropdown-toggle" id="dropdownMenuButton" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Start Provider</button>
               <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                <button class="dropdown-item" phx-click="show_modal" phx-value-modal="start_provider_file">From File</button>
-                <button class="dropdown-item" phx-click="show_modal" phx-value-modal="start_provider_ociref">From Registry</button>
+                <button class="dropdown-item"
+                  phx-click="show_modal"
+                  phx-value-title="Start Provider from File"
+                  phx-value-component="StartProviderComponent"
+                  phx-value-id="start_provider_file_modal">
+                  From File
+                </button>
+                <button class="dropdown-item"
+                  phx-click="show_modal"
+                  phx-value-title="Start Provider from OCI Registry"
+                  phx-value-component="StartProviderComponent"
+                  phx-value-id="start_provider_ociref_modal">
+                  From Registry
+                </button>
               </div>
             </div>
           </div>
@@ -199,7 +242,11 @@
           </div>
           <div class="mfe-2">
             <div class="dropdown d-inline-block">
-              <button class="btn btn-secondary" type="button" phx-click="show_modal" phx-value-modal="define_link" aria-haspopup="true" aria-expanded="false">
+              <button class="btn btn-secondary"
+                  phx-click="show_modal"
+                  phx-value-title="Define Link Definition"
+                  phx-value-component="DefineLinkComponent"
+                  phx-value-id="define_link_modal">
                 Define Link
                 <svg class="c-icon c-icon-sm">
                   <use xlink:href="/coreui/free.svg#cil-link"></use>

--- a/wasmcloud_host/lib/wasmcloud_host_web/templates/layout/live.html.leex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/templates/layout/live.html.leex
@@ -8,78 +8,30 @@
   <%= @inner_content %>
   <%# Modal backdrop %>
   <div id="phoenix-modal-backdrop" class="modal-backdrop fade <%= if @open_modal != nil do "show" end %>"></div>
-  <%= case @open_modal do %>
-  <% "start_actor_file" -> %>
-    <div class="phoenix-modal phoenix-modal-open show fade" id="start_actor_file" tabindex="-1" role="dialog" aria-labelledby="start_actor_file_modal" aria-hidden="true">
+  <%# Modal template, replace body depending on desired modal to display %>
+  <%= if @open_modal != nil do %>
+    <% modal_id = String.to_atom(Map.get(@open_modal, "id")) %>
+    <div class="phoenix-modal phoenix-modal-open show fade" id="<%= modal_id %>" tabindex="-1" role="dialog" aria-labelledby="<%= modal_id %>_modal" aria-hidden="true">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
-            <h4 class="modal-title">Start actor from file</h4>
+            <h4 class="modal-title"><%= Map.get(@open_modal, "title") %></h4>
             <button class="close" type="button" phx-click="hide_modal" aria-label="Close"><span aria-hidden="true">×</span></button>
           </div>
           <div class="modal-body">
-            <%= live_component StartActorComponent, id: :start_actor_file_modal %>
+            <%= case Map.get(@open_modal, "component") do %>
+              <% "StartActorComponent" ->  %>
+              <%= live_component StartActorComponent, id: modal_id %>
+              <% "ScaleActorComponent" ->  %>
+              <%= live_component ScaleActorComponent, id: modal_id, actor_info: Map.get(@open_modal, "actor_info") %>
+              <% "StartProviderComponent" ->  %>
+              <%= live_component StartProviderComponent, id: modal_id %>
+              <% "DefineLinkComponent" ->  %>
+              <%= live_component DefineLinkComponent, id: modal_id, actors: @actors, providers: @providers, claims: @claims %>
+            <% end %>
           </div>
         </div>
       </div>
     </div>
-  <% "start_actor_ociref" -> %>
-    <div class="phoenix-modal phoenix-modal-open show fade" id="start_actor_oci" tabindex="-1" role="dialog" aria-labelledby="start_actor_ociref_modal" aria-hidden="true">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title">Start actor from OCI registry</h4>
-            <button class="close" type="button" phx-click="hide_modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-          </div>
-          <div class="modal-body">
-            <%= live_component StartActorComponent, id: :start_actor_oci_modal %>
-          </div>
-        </div>
-      </div>
-    </div>
-  <% "start_provider_file" -> %>
-    <div class="phoenix-modal phoenix-modal-open show fade" id="start_provider_file" tabindex="-1" role="dialog" aria-labelledby="start_provider_file_modal" aria-hidden="true">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title">Start provider from file</h4>
-            <button class="close" type="button" phx-click="hide_modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-          </div>
-          <div class="modal-body">
-            <%= live_component StartProviderComponent, id: :start_provider_file_modal %>
-          </div>
-        </div>
-      </div>
-    </div>
-  <% "start_provider_ociref" -> %>
-    <div class="phoenix-modal phoenix-modal-open show fade" id="start_provider_oci" tabindex="-1" role="dialog" aria-labelledby="start_provider_ociref_modal" aria-hidden="true">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title">Start provider from registry</h4>
-            <button class="close" type="button" phx-click="hide_modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-          </div>
-          <div class="modal-body">
-            <%= live_component StartProviderComponent, id: :start_provider_ociref_modal %>
-          </div>
-        </div>
-      </div>
-    </div>
-  <% "define_link" -> %>
-    <div class="phoenix-modal phoenix-modal-open show fade" id="define_link" tabindex="-1" role="dialog" aria-labelledby="define_link_modal" aria-hidden="true">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title">Define link</h4>
-            <button class="close" type="button" phx-click="hide_modal" aria-label="Close"><span aria-hidden="true">×</span></button>
-          </div>
-          <div class="modal-body">
-            <%= live_component DefineLinkComponent, id: :define_link_modal, actors: @actors, providers: @providers, claims: @claims %>
-          </div>
-        </div>
-      </div>
-    </div>
-  <% nil -> %>
-  <%= "" %>
   <% end %>
 </main>

--- a/wasmcloud_host/lib/wasmcloud_host_web/templates/layout/live.html.leex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/templates/layout/live.html.leex
@@ -23,7 +23,7 @@
               <% "StartActorComponent" ->  %>
               <%= live_component StartActorComponent, id: modal_id %>
               <% "ScaleActorComponent" ->  %>
-              <%= live_component ScaleActorComponent, id: modal_id, actor_info: Map.get(@open_modal, "actor_info") %>
+              <%= live_component ScaleActorComponent, id: modal_id, modal: @open_modal %>
               <% "StartProviderComponent" ->  %>
               <%= live_component StartProviderComponent, id: modal_id %>
               <% "DefineLinkComponent" ->  %>


### PR DESCRIPTION
Fixes #132, fixes #85 

This PR allows deleting providers from the UI, and scaling actors up and down from the UI. The UI will now handle actor/provider stopped events appropriately, so it will update even if the stop command doesn't originate from the dashboard.

I've also implemented the control interface handler for scale actor, which is an addition but doesn't break anything about the current control interface. Its topic is `wasmbus.ctl.#{lattice_prefix}.cmd.#{host_id}.scale` and expects an actor ID, actor OCI reference, and desired number of replicas. I've designed the scale actor command to work regardless of ocireference for no scaling and scaling down, but in order to scale up an ocireference must be supplied.

If you attempt to scale an actor up that was started from a file in the UI, you will be shown an error message saying that's not supported at this time. 