### PR TITLE
change 'uptime' to 'uptime_seconds' in get hosts response

### DIFF
--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -23,7 +23,7 @@ defmodule HostCore.ControlInterface.Server do
 
     res = %{
       id: HostCore.Host.host_key(),
-      uptime: div(total, 1000)
+      uptime_seconds: div(total, 1000)
     }
 
     {:reply, Jason.encode!(res)}


### PR DESCRIPTION
Signed-off-by: steve <dev@somecool.net>

as discussed over slack
