### PR TITLE
Support OCI environment variables

### DIFF
--- a/host_core/lib/host_core/actors/actor_supervisor.ex
+++ b/host_core/lib/host_core/actors/actor_supervisor.ex
@@ -32,7 +32,11 @@ defmodule HostCore.Actors.ActorSupervisor do
   end
 
   def start_actor_from_oci(oci) do
-    case HostCore.WasmCloud.Native.get_oci_bytes(oci, HostCore.Oci.allow_latest(), HostCore.Oci.allowed_insecure()) do
+    case HostCore.WasmCloud.Native.get_oci_bytes(
+           oci,
+           HostCore.Oci.allow_latest(),
+           HostCore.Oci.allowed_insecure()
+         ) do
       {:error, err} ->
         Logger.error("Failed to download OCI bytes for #{oci}")
         {:stop, err}
@@ -43,7 +47,12 @@ defmodule HostCore.Actors.ActorSupervisor do
   end
 
   def live_update(oci) do
-    with {:ok, bytes} <- HostCore.WasmCloud.Native.get_oci_bytes(oci, HostCore.Oci.allow_latest(), HostCore.Oci.allowed_insecure()),
+    with {:ok, bytes} <-
+           HostCore.WasmCloud.Native.get_oci_bytes(
+             oci,
+             HostCore.Oci.allow_latest(),
+             HostCore.Oci.allowed_insecure()
+           ),
          {:ok, new_claims} <-
            HostCore.WasmCloud.Native.extract_claims(bytes |> IO.iodata_to_binary()),
          {:ok, old_claims} <- HostCore.Claims.Manager.lookup_claims(new_claims.public_key),

--- a/host_core/lib/host_core/actors/actor_supervisor.ex
+++ b/host_core/lib/host_core/actors/actor_supervisor.ex
@@ -8,7 +8,7 @@ defmodule HostCore.Actors.ActorSupervisor do
   end
 
   @impl true
-  def init(_init_arg) do
+  def init(_opts) do
     Process.flag(:trap_exit, true)
     DynamicSupervisor.init(strategy: :one_for_one)
   end
@@ -32,8 +32,7 @@ defmodule HostCore.Actors.ActorSupervisor do
   end
 
   def start_actor_from_oci(oci) do
-    # TODO use configuration for enabling insecure OCI and 'latest'
-    case HostCore.WasmCloud.Native.get_oci_bytes(oci, false, []) do
+    case HostCore.WasmCloud.Native.get_oci_bytes(oci, HostCore.Oci.allow_latest(), HostCore.Oci.allowed_insecure()) do
       {:error, err} ->
         Logger.error("Failed to download OCI bytes for #{oci}")
         {:stop, err}
@@ -44,7 +43,7 @@ defmodule HostCore.Actors.ActorSupervisor do
   end
 
   def live_update(oci) do
-    with {:ok, bytes} <- HostCore.WasmCloud.Native.get_oci_bytes(oci, false, []),
+    with {:ok, bytes} <- HostCore.WasmCloud.Native.get_oci_bytes(oci, HostCore.Oci.allow_latest(), HostCore.Oci.allowed_insecure()),
          {:ok, new_claims} <-
            HostCore.WasmCloud.Native.extract_claims(bytes |> IO.iodata_to_binary()),
          {:ok, old_claims} <- HostCore.Claims.Manager.lookup_claims(new_claims.public_key),

--- a/host_core/lib/host_core/application.ex
+++ b/host_core/lib/host_core/application.ex
@@ -38,7 +38,8 @@ defmodule HostCore.Application do
           {:provider_delay, "WASMCLOUD_PROV_SHUTDOWN_DELAY_MS",
            default: 300, map: &String.to_integer/1},
           {:allow_latest, "WASMCLOUD_OCI_ALLOW_LATEST", default: false, map: &String.to_atom/1},
-          {:allowed_insecure, "WASMCLOUD_OCI_ALLOWED_INSECURE", default: [], map: &String.split(&1,",")}
+          {:allowed_insecure, "WASMCLOUD_OCI_ALLOWED_INSECURE",
+           default: [], map: &String.split(&1, ",")}
         ]
       }
     ]
@@ -63,7 +64,10 @@ defmodule HostCore.Application do
       ),
       {HostCore.HeartbeatEmitter, config},
       {HostCore.Providers.ProviderSupervisor, strategy: :one_for_one, name: ProviderRoot},
-      {HostCore.Actors.ActorSupervisor, strategy: :one_for_one, allow_latest: config.allow_latest, allowed_insecure: config.allowed_insecure},
+      {HostCore.Actors.ActorSupervisor,
+       strategy: :one_for_one,
+       allow_latest: config.allow_latest,
+       allowed_insecure: config.allowed_insecure},
       {HostCore.Claims.Manager, strategy: :one_for_one, name: ClaimsManager},
       {HostCore.Linkdefs.Manager, strategy: :one_for_one, name: LinkdefsManager},
       # Handle advertised link definitions and corresponding queries

--- a/host_core/lib/host_core/application.ex
+++ b/host_core/lib/host_core/application.ex
@@ -36,7 +36,9 @@ defmodule HostCore.Application do
           {:cluster_seed, "WASMCLOUD_CLUSTER_SEED", default: def_cluster_seed},
           {:cluster_issuers, "WASMCLOUD_CLUSTER_ISSUERS", default: def_cluster_key},
           {:provider_delay, "WASMCLOUD_PROV_SHUTDOWN_DELAY_MS",
-           default: 300, map: &String.to_integer/1}
+           default: 300, map: &String.to_integer/1},
+          {:allow_latest, "WASMCLOUD_OCI_ALLOW_LATEST", default: false, map: &String.to_atom/1},
+          {:allowed_insecure, "WASMCLOUD_OCI_ALLOWED_INSECURE", default: [], map: &String.split(&1,",")}
         ]
       }
     ]
@@ -61,7 +63,7 @@ defmodule HostCore.Application do
       ),
       {HostCore.HeartbeatEmitter, config},
       {HostCore.Providers.ProviderSupervisor, strategy: :one_for_one, name: ProviderRoot},
-      {HostCore.Actors.ActorSupervisor, strategy: :one_for_one, name: ActorRoot},
+      {HostCore.Actors.ActorSupervisor, strategy: :one_for_one, allow_latest: config.allow_latest, allowed_insecure: config.allowed_insecure},
       {HostCore.Claims.Manager, strategy: :one_for_one, name: ClaimsManager},
       {HostCore.Linkdefs.Manager, strategy: :one_for_one, name: LinkdefsManager},
       # Handle advertised link definitions and corresponding queries

--- a/host_core/lib/host_core/oci.ex
+++ b/host_core/lib/host_core/oci.ex
@@ -1,0 +1,15 @@
+defmodule HostCore.Oci do
+  def allow_latest() do
+    case :ets.lookup(:config_table, :config) do
+      [config: config_map] -> config_map[:allow_latest]
+      _ -> false
+    end
+  end
+
+  def allowed_insecure() do
+    case :ets.lookup(:config_table, :config) do
+      [config: config_map] -> config_map[:allowed_insecure]
+      _ -> []
+    end
+  end
+end

--- a/host_core/lib/host_core/providers/provider_supervisor.ex
+++ b/host_core/lib/host_core/providers/provider_supervisor.ex
@@ -60,7 +60,12 @@ defmodule HostCore.Providers.ProviderSupervisor do
   end
 
   def start_provider_from_oci(oci, link_name) do
-    with {:ok, bytes} <- HostCore.WasmCloud.Native.get_oci_bytes(oci, HostCore.Oci.allow_latest(), HostCore.Oci.allowed_insecure()),
+    with {:ok, bytes} <-
+           HostCore.WasmCloud.Native.get_oci_bytes(
+             oci,
+             HostCore.Oci.allow_latest(),
+             HostCore.Oci.allowed_insecure()
+           ),
          {:ok, par} <- HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary()),
          {:ok, path} <- extract_executable_to_tmp(par, link_name) do
       start_executable_provider(path, par.claims.public_key, link_name, par.contract_id, oci)

--- a/host_core/lib/host_core/providers/provider_supervisor.ex
+++ b/host_core/lib/host_core/providers/provider_supervisor.ex
@@ -60,8 +60,8 @@ defmodule HostCore.Providers.ProviderSupervisor do
   end
 
   def start_provider_from_oci(oci, link_name) do
-    with {:ok, bytes} <- HostCore.WasmCloud.Native.get_oci_bytes(oci, false, []),
-         par <- HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary()),
+    with {:ok, bytes} <- HostCore.WasmCloud.Native.get_oci_bytes(oci, HostCore.Oci.allow_latest(), HostCore.Oci.allowed_insecure()),
+         {:ok, par} <- HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary()),
          {:ok, path} <- extract_executable_to_tmp(par, link_name) do
       start_executable_provider(path, par.claims.public_key, link_name, par.contract_id, oci)
     else
@@ -72,7 +72,7 @@ defmodule HostCore.Providers.ProviderSupervisor do
 
   def start_provider_from_file(path, link_name) do
     with {:ok, bytes} <- File.read(path),
-         par <- HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary()),
+         {:ok, par} <- HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary()),
          {:ok, tmp_path} <- extract_executable_to_tmp(par, link_name) do
       start_executable_provider(
         tmp_path,

--- a/host_core/native/hostcore_wasmcloud_native/src/lib.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/lib.rs
@@ -80,21 +80,21 @@ fn get_oci_bytes(
     task::TOKIO.block_on(async {
         match oci::fetch_oci_bytes(&oci_ref, allow_latest, allowed_insecure).await {
             Ok(b) => Ok((atoms::ok(), b)),
-            Err(_e) => Err(rustler::Error::Term(Box::new("Failed to fetch OCI bytes"))),
+            Err(e) => Err(rustler::Error::Term(Box::new(format!("{}", e)))),
         }
     })
 }
 
 #[rustler::nif]
-fn par_from_bytes(binary: Binary) -> Result<ProviderArchiveResource, Error> {
+fn par_from_bytes(binary: Binary) -> Result<(Atom, ProviderArchiveResource), Error> {
     match ProviderArchive::try_load(binary.as_slice()) {
         Ok(par) => {
-            return Ok(ProviderArchiveResource {
+            return Ok((atoms::ok(), ProviderArchiveResource {
                 claims: par::extract_claims(&par)?,
                 target_bytes: par::extract_target_bytes(&par)?,
                 contract_id: par::get_capid(&par)?,
                 vendor: par::get_vendor(&par)?,
-            })
+            }))
         }
         Err(_) => Err(Error::BadArg),
     }

--- a/host_core/test/e2e/echo_test.exs
+++ b/host_core/test/e2e/echo_test.exs
@@ -18,7 +18,7 @@ defmodule HostCore.E2E.EchoTest do
       )
 
     {:ok, bytes} = File.read(@httpserver_path)
-    par = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
+    {:ok, par} = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
     httpserver_key = par.claims.public_key
     httpserver_contract = par.contract_id
 

--- a/host_core/test/e2e/kvcounter_test.exs
+++ b/host_core/test/e2e/kvcounter_test.exs
@@ -26,7 +26,7 @@ defmodule HostCore.E2E.KVCounterTest do
       )
 
     {:ok, bytes} = File.read(@httpserver_path)
-    par = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
+    {:ok, par} = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
     httpserver_key = par.claims.public_key
     httpserver_contract = par.contract_id
 
@@ -41,7 +41,7 @@ defmodule HostCore.E2E.KVCounterTest do
       )
 
     {:ok, bytes} = File.read(@redis_path)
-    par = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
+    {:ok, par} = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
     redis_key = par.claims.public_key
     redis_contract = par.contract_id
 
@@ -103,7 +103,7 @@ defmodule HostCore.E2E.KVCounterTest do
       )
 
     {:ok, bytes} = File.read(@httpserver_path)
-    par = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
+    {:ok, par} = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
     httpserver_key = par.claims.public_key
     httpserver_contract = par.contract_id
 
@@ -118,7 +118,7 @@ defmodule HostCore.E2E.KVCounterTest do
       )
 
     {:ok, bytes} = File.read(@redis_path)
-    par = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
+    {:ok, par} = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
     redis_key = par.claims.public_key
     redis_contract = par.contract_id
 

--- a/host_core/test/host_core/actors_test.exs
+++ b/host_core/test/host_core/actors_test.exs
@@ -234,7 +234,7 @@ defmodule HostCore.ActorsTest do
       )
     end)
 
-    {pub, seed} = HostCore.WasmCloud.Native.generate_key(:server)
+    {_pub, seed} = HostCore.WasmCloud.Native.generate_key(:server)
 
     req =
       %{

--- a/host_core/test/host_core/providers_test.exs
+++ b/host_core/test/host_core/providers_test.exs
@@ -14,7 +14,7 @@ defmodule HostCore.ProvidersTest do
       )
 
     {:ok, bytes} = File.read(@httpserver_path)
-    par = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
+    {:ok, par} = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
     httpserver_key = par.claims.public_key
 
     # Ensure provider is cleaned up regardless of test errors
@@ -66,7 +66,7 @@ defmodule HostCore.ProvidersTest do
       )
 
     {:ok, bytes} = File.read(@httpserver_path)
-    par = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
+    {:ok, par} = HostCore.WasmCloud.Native.par_from_bytes(bytes |> IO.iodata_to_binary())
     httpserver_key = par.claims.public_key
 
     # Ensure provider is cleaned up regardless of test errors

--- a/host_core/test/host_core/wasmcloud/native_test.exs
+++ b/host_core/test/host_core/wasmcloud/native_test.exs
@@ -12,7 +12,7 @@ defmodule HostCore.WasmCloud.NativeTest do
     {:ok, bytes} = HostCore.WasmCloud.Native.get_oci_bytes(@httpserver_oci, false, [])
     bytes = bytes |> IO.iodata_to_binary()
 
-    par = HostCore.WasmCloud.Native.ProviderArchive.from_bytes(bytes)
+    {:ok, par} = HostCore.WasmCloud.Native.ProviderArchive.from_bytes(bytes)
 
     assert par.claims.public_key == @httpserver_key
     assert par.claims.issuer == @official_issuer

--- a/host_core/test/host_core_test.exs
+++ b/host_core/test/host_core_test.exs
@@ -29,7 +29,7 @@ defmodule HostCoreTest do
   end
 
   test "Host purges actors and providers" do
-    {:ok, bytes} = File.read("test/fixtures/actors/echo_s.wasm")
+    {:ok, bytes} = File.read(@echo_path)
     {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
 
     {:ok, _pid} =


### PR DESCRIPTION
This PR introduces the `WASMCLOUD_OCI_ALLOW_LATEST` and `WASMCLOUD_OCI_ALLOWED_INSECURE` environment variables. allow_latest is a boolean to allow the `:latest` tag, and allowed_insecure is a comma-separated list of registries that should be accessed over HTTP rather than HTTPS. 

I also changed the `par_from_bytes` function to return `{:ok, par}` rather than just `par` so we can actually match against the `ok` condition.