### PR TITLE
Implemented health check for providers

### DIFF
--- a/capability-providers/Makefile
+++ b/capability-providers/Makefile
@@ -38,7 +38,7 @@ keyvalue-windows: create-build-dir ## Build the keyvalue capability provider for
 build-all: httpserver-linux keyvalue-linux httpserver-mac keyvalue-mac httpserver-windows keyvalue-windows ## Build httpserver and keyvalue for linux, mac, and windows
 
 pars: par-httpserver par-redis ## Build the httpserver and redis provider with linux, mac, and windows binaries
-par-httpserver: build-all ## Build the httpserver provider archive with linux, mac, and windows binaries
+par-httpserver:  httpserver-linux httpserver-mac httpserver-windows ## Build the httpserver provider archive with linux, mac, and windows binaries
 	wash par create --arch x86_64-macos \
 		--binary _build/httpserver-mac \
 		--capid wasmcloud:httpserver \
@@ -57,7 +57,7 @@ par-httpserver: build-all ## Build the httpserver provider archive with linux, m
 		--arch x86_64-windows \
 		--binary _build/httpserver-windows.exe
 
-par-redis: build-all ## Build the redis provider archive with linux, mac, and windows binaries
+par-redis: keyvalue-linux keyvalue-mac keyvalue-windows ## Build the redis provider archive with linux, mac, and windows binaries
 	wash par create --arch x86_64-macos \
 		--binary _build/wasmcloud-redis-mac \
 		--capid wasmcloud:keyvalue \

--- a/capability-providers/keyvalue/rust/src/main.rs
+++ b/capability-providers/keyvalue/rust/src/main.rs
@@ -162,6 +162,11 @@ fn main() -> Result<()> {
         lattice_rpc_prefix, provider_key, link_name
     );
 
+    let health_topic = format!(
+        "wasmbus.rpc.{}.{}.{}.health",
+        lattice_rpc_prefix, provider_key, link_name
+    );
+
     let nc = nats::connect(&host_data.lattice_rpc_url)?; // TODO: use credentials from the host_data struct
 
     let _sub = nc
@@ -169,6 +174,15 @@ fn main() -> Result<()> {
         .with_handler(move |msg| {
             println!("Received request for linkdefs.");
             msg.respond(serialize(&*LINKDEFS.read().unwrap()).unwrap())
+                .unwrap();
+            Ok(())
+        });
+
+    let _sub = nc
+        .subscribe(&health_topic)?
+        .with_handler(move |msg| {
+            println!("Received health check request.");
+            msg.respond(serialize(vec![true]).unwrap())
                 .unwrap();
             Ok(())
         });


### PR DESCRIPTION
As @stevelr mentioned the Rust provider automatically responds to health checks with the new smithy trait, but just for testing and to satisfy the health check I added simple responders in our providers for now.

Fixes #145 