### PR TITLE
Adding configurable RPC timeouts

### DIFF
--- a/host_core/lib/host_core/application.ex
+++ b/host_core/lib/host_core/application.ex
@@ -33,6 +33,7 @@ defmodule HostCore.Application do
           {:rpc_host, "WASMCLOUD_RPC_HOST", default: "0.0.0.0"},
           {:rpc_port, "WASMCLOUD_RPC_PORT", default: 4222, map: &String.to_integer/1},
           {:rpc_seed, "WASMCLOUD_RPC_SEED", default: ""},
+          {:rpc_timeout, "WASMCLOUD_RPC_TIMEOUT_MS", default: 2000, map: &String.to_integer/1},
           {:rpc_jwt, "WASMCLOUD_RPC_JWT", default: ""},
           {:prov_rpc_host, "WASMCLOUD_PROV_RPC_HOST", default: "0.0.0.0"},
           {:prov_rpc_port, "WASMCLOUD_PROV_RPC_PORT", default: 4222, map: &String.to_integer/1},

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -115,7 +115,7 @@ defmodule HostCore.Host do
   end
 
   def rpc_timeout() do
-    case :ets.lookup(:rpc_timeout, :config) do
+    case :ets.lookup(:config_table, :config) do
       [config: config_map] -> config_map[:rpc_timeout]
       _ -> 2_000
     end

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -114,6 +114,13 @@ defmodule HostCore.Host do
     end
   end
 
+  def rpc_timeout() do
+    case :ets.lookup(:rpc_timeout, :config) do
+      [config: config_map] -> config_map[:rpc_timeout]
+      _ -> 2_000
+    end
+  end
+
   def host_labels() do
     GenServer.call(__MODULE__, :get_labels)
   end

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -134,7 +134,7 @@ defmodule HostCore.Providers.ProviderModule do
 
     res =
       try do
-        Gnat.request(:lattice_nats, topic, payload, receive_timeout: 2_000)
+        Gnat.request(:lattice_nats, topic, payload, receive_timeout: HostCore.Host.rpc_timeout())
       rescue
         _e -> {:error, "Received no response on health check topic from provider"}
       end

--- a/host_core/lib/host_core/web_assembly/imports.ex
+++ b/host_core/lib/host_core/web_assembly/imports.ex
@@ -298,7 +298,9 @@ defmodule HostCore.WebAssembly.Imports do
 
   defp perform_rpc_invoke(inv_bytes, target_subject) do
     # Perform RPC invocation over lattice
-    case Gnat.request(:lattice_nats, target_subject, inv_bytes, receive_timeout: 2_000) do
+    case Gnat.request(:lattice_nats, target_subject, inv_bytes,
+           receive_timeout: HostCore.Host.rpc_timeout()
+         ) do
       {:ok, %{body: body}} -> body
       {:error, :timeout} -> :fail
     end


### PR DESCRIPTION
Worth noting that we have not added a timeout to the `linkdefs.put` and `linkdefs.del` RPC calls because those are publishes, not requests, and that's because it's entirely possible (and likely) that capability providers may not actually be up and running at the time the definition is removed or created.

host call RPC timeouts, however, are applicable.