### PR TITLE
Dashboard query resources on startup

### DIFF
--- a/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
@@ -200,9 +200,9 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
            type: "com.wasmcloud.lattice.provider_started"
          }
        ) do
-    providers = add_provider(pk, link_name, contract_id, source_host, state.providers)
-    PubSub.broadcast(WasmcloudHost.PubSub, "lattice:state", {:providers, providers})
-    %State{state | providers: providers}
+    hosts = add_provider(pk, link_name, contract_id, source_host, state.hosts)
+    PubSub.broadcast(WasmcloudHost.PubSub, "lattice:state", {:hosts, hosts})
+    %State{state | hosts: hosts}
   end
 
   defp process_event(
@@ -237,23 +237,47 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
 
     current_host = Map.get(state.hosts, source_host)
 
+    # TODO: Also ensure that actors don't exist in the dashboard that aren't in the health check
     actor_map =
       actors
       |> Enum.reduce(%{}, fn actor, actor_map ->
-        Map.put(actor_map, Map.get(actor, "actor"), %{
-          count: Map.get(actor, "instances"),
-          status: "Awaiting"
-        })
+        actor_id = Map.get(actor, "actor")
+        existing_actor = current_host |> Map.get(:actors) |> Map.get(actor_id)
+
+        if existing_actor != nil && Map.get(existing_actor, :count) == Map.get(actor, "instances") do
+          Map.put(actor_map, actor_id, existing_actor)
+        else
+          Map.put(actor_map, actor_id, %{
+            count: Map.get(actor, "instances"),
+            status: "Awaiting"
+          })
+        end
       end)
 
+    # TODO: Also ensure that providers don't exist in the dashboard that aren't in the health check
+    # Provider map is keyed by a tuple of the form
+    # {public_key, link_name}
     provider_map =
       providers
       |> Enum.reduce(%{}, fn provider, provider_map ->
-        Map.put(provider_map, Map.get(provider, "public_key"), %{
-          contract_id: Map.get(provider, "contract_id"),
-          link_name: Map.get(provider, "link_name"),
-          status: "Awaiting"
-        })
+        provider_id = Map.get(provider, "public_key")
+        link_name = Map.get(provider, "link_name")
+
+        existing_provider =
+          current_host |> Map.get(:providers) |> Map.get({provider_id, link_name})
+
+        if existing_provider != nil do
+          Map.put(provider_map, {provider_id, link_name}, existing_provider)
+        else
+          Map.put(
+            provider_map,
+            {Map.get(provider, "public_key"), Map.get(provider, "link_name")},
+            %{
+              contract_id: Map.get(provider, "contract_id"),
+              status: "Awaiting"
+            }
+          )
+        end
       end)
 
     host =
@@ -279,15 +303,17 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
   defp process_event(
          state,
          %Cloudevents.Format.V_1_0.Event{
-           data: %{"public_key" => public_key},
+           data: data,
            datacontenttype: "application/json",
            source: source_host,
            type: "com.wasmcloud.lattice.health_check_passed"
          }
        ) do
+    public_key = Map.get(data, "public_key")
     Logger.info("Handling successful health check for #{public_key}")
+    link_name = Map.get(data, "link_name")
 
-    case update_status(public_key, source_host, state.hosts, "Healthy") do
+    case update_status(public_key, link_name, source_host, state.hosts, "Healthy") do
       {:hosts, hosts} ->
         PubSub.broadcast(WasmcloudHost.PubSub, "lattice:state", {:hosts, hosts})
         %State{state | hosts: hosts}
@@ -300,15 +326,17 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
   defp process_event(
          state,
          %Cloudevents.Format.V_1_0.Event{
-           data: %{"public_key" => public_key},
+           data: data,
            datacontenttype: "application/json",
            source: source_host,
            type: "com.wasmcloud.lattice.health_check_failed"
          }
        ) do
+    public_key = Map.get(data, "public_key")
     Logger.info("Handling failed health check for #{public_key}")
+    link_name = Map.get(data, "link_name")
 
-    case update_status(public_key, source_host, state.hosts, "Unhealthy") do
+    case update_status(public_key, link_name, source_host, state.hosts, "Unhealthy") do
       {:hosts, hosts} ->
         PubSub.broadcast(WasmcloudHost.PubSub, "lattice:state", {:hosts, hosts})
         %State{state | hosts: hosts}
@@ -319,13 +347,13 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
     end
   end
 
-  defp update_status(public_key, source_host, hosts, new_status) do
+  defp update_status(public_key, link_name, source_host, hosts, new_status) do
     host_map = Map.get(hosts, source_host, %{})
     actors = Map.get(host_map, :actors, %{})
     providers = Map.get(host_map, :providers, %{})
 
     actor_map = Map.get(actors, public_key, nil)
-    provider_map = Map.get(providers, public_key, nil)
+    provider_map = Map.get(providers, {public_key, link_name}, nil)
 
     cond do
       actor_map != nil ->
@@ -336,30 +364,11 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
         {:hosts, hosts}
 
       provider_map != nil ->
-        provider_map =
-          provider_map
-          |> Enum.map(
-            fn instance = %{
-                 link_name: link_name,
-                 contract_id: contract_id,
-                 host_ids: host_ids,
-                 status: _status
-               } ->
-              if Enum.member?(host_ids, source_host) do
-                %{
-                  link_name: link_name,
-                  contract_id: contract_id,
-                  host_ids: host_ids,
-                  status: new_status
-                }
-              else
-                instance
-              end
-            end
-          )
-
-        providers = Map.put(providers, public_key, provider_map)
-        {:providers, providers}
+        provider_map = Map.put(provider_map, :status, new_status)
+        providers = Map.put(providers, {public_key, link_name}, provider_map)
+        host_map = Map.put(host_map, :providers, providers)
+        hosts = Map.put(hosts, source_host, host_map)
+        {:hosts, hosts}
 
       true ->
         {:error, "Public key did not match running provider or actor"}
@@ -369,6 +378,7 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
   # This map is keyed by provider public key, which contains a list of
   # maps with the keys "link_name", "contract_id", and "host_ids", as
   # shown below.
+  # TODO: This is wrong
   #
   # %{
   #     "Vxxxx":  [
@@ -386,41 +396,29 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
   #         },
   #    ]
   # }
-  def add_provider(pk, link_name, contract_id, host, previous_map) do
-    # This logic will add in a new entry for every call
-    # It shouldn't add information if it's a duplicate, and it should only
-    # append a host_id to the list if the link_name + contract_id already exists
-    previous_instances = Map.get(previous_map, pk, [])
+  def add_provider(pk, link_name, contract_id, source_host, previous_map) do
+    # Get the source host and its current running providers
+    host_map = Map.get(previous_map, source_host, %{})
+    providers_map = Map.get(host_map, :providers, %{})
 
-    # Check for existence of link_name and contract_id pair
-    existing_instance =
-      previous_instances
-      |> Enum.filter(fn info ->
-        Map.get(info, :link_name) == link_name && Map.get(info, :contract_id) == contract_id
-      end)
-      |> List.first()
+    provider_map = Map.get(providers_map, {pk, link_name}, nil)
 
-    cond do
-      # new instance of provider, add to provider list
-      existing_instance == nil ->
-        provider_list = [
-          %{link_name: link_name, contract_id: contract_id, host_ids: [host], status: "Starting"}
-          | previous_instances
-        ]
+    if provider_map == nil do
+      providers_map =
+        Map.put(
+          provider_map,
+          {pk, link_name},
+          %{
+            contract_id: contract_id,
+            status: "Awaiting"
+          }
+        )
 
-        Map.put(previous_map, pk, provider_list)
-
-      # provider is already running with the same link and contract id on this host
-      # This condition shouldn't be reached, as this attempt should be stopped at the host level
-      existing_instance != nil &&
-          existing_instance
-          |> Map.get(:host_ids)
-          |> Enum.any?(fn id -> id == host end) ->
-        {:error, "Provider instance already exists"}
-
-      # provider with this contract_id and link_name is not running on this host, append new host
-      true ->
-        Map.put(existing_instance, :host_ids, [host | Map.get(existing_instance, :host_ids)])
+      host_map = Map.put(host_map, :providers, providers_map)
+      Map.put(previous_map, source_host, host_map)
+    else
+      # Provider already exists with that link name and public key, no-op
+      previous_map
     end
   end
 

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/actor_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/actor_row_component.ex
@@ -12,7 +12,7 @@ defmodule ActorRowComponent do
       <td><%= @count %></td>
       <td>
         <span class="badge <%= case @status do
-          "Starting" -> "badge-secondary"
+          "Awaiting" -> "badge-secondary"
           "Healthy" -> "badge-success"
           "Unhealthy" -> "badge-danger"
           end%>">

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/define_link_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/define_link_component.ex
@@ -75,12 +75,10 @@ defmodule DefineLinkComponent do
         <div class="col-md-9">
           <select class="form-control select2-single" id="select2-1" name="actor_id">
             <option hidden disabled selected value> -- select an actor -- </option>
-            <%= for {actor, _host_map} <- @actors do %>
               <%= for {k, v} <- @claims do %>
-                <%= if k == actor do %>
-                  <option value="<%= actor %>"><%= v.name %> (<%= String.slice(actor, 0..4) %>...) </option>
+                <%= if String.starts_with?(k, "M") && String.length(k) == 56 do %>
+                  <option value="<%= k %>"><%= v.name %> (<%= String.slice(k, 0..4) %>...) </option>
                 <% end %>
-              <% end %>
             <% end %>
           </select>
         </div>
@@ -94,12 +92,12 @@ defmodule DefineLinkComponent do
             document.getElementById('linkdef-linkname-input').value = data['linkname']
             document.getElementById('linkdef-contractid-input').value = data['contractid']">
             <option hidden disabled selected value> -- select a provider -- </option>
-            <%= for {provider, instances} <- @providers do %>
-              <%= for instance <- instances do  %>
+            <%= for {_host_id, host_map} <- @hosts do %>
+            <%= for {{provider, link_name}, info_map} <- Map.get(host_map, :providers, %{}) do %>
                 <option value="<%= provider %>"
-                  data-linkname="<%= Map.get(instance, :link_name)%>"
-                  data-contractid="<%= Map.get(instance, :contract_id)%>">
-                  <%= String.slice(provider, 0..4) %>... (<%= Map.get(instance, :link_name) %>)
+                  data-linkname="<%= link_name %>"
+                  data-contractid="<%= Map.get(info_map, :contract_id)%>">
+                  <%= String.slice(provider, 0..4) %>... (<%= link_name %>)
                 </option>
               <% end %>
             <% end %>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/provider_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/provider_row_component.ex
@@ -19,7 +19,7 @@ defmodule ProviderRowComponent do
       <td><%= @contract_id %></td>
       <td>
         <span class="badge <%= case @status do
-            "Starting" -> "badge-secondary"
+            "Awaiting" -> "badge-secondary"
             "Healthy" -> "badge-success"
             "Unhealthy" -> "badge-danger"
             end%>">
@@ -32,14 +32,12 @@ defmodule ProviderRowComponent do
           </svg>
         </button></td>
       <td>
-        <%= for hid <- @host_ids do %>
-          <button class="btn btn-primary btn-sm" type="button" onClick="navigator.clipboard.writeText('<%= hid %>')" data-toggle="popover" data-trigger="focus" title="" data-content="Copied!">
-            <%= String.slice(hid, 0..4) %>...
-            <svg class="c-icon">
-              <use xlink:href="/coreui/free.svg#cil-copy"></use>
-            </svg>
-          </button>
-        <% end %>
+        <button class="btn btn-primary btn-sm" type="button" onClick="navigator.clipboard.writeText('<%= @host_id %>')" data-toggle="popover" data-trigger="focus" title="" data-content="Copied!">
+          <%= String.slice(@host_id, 0..4) %>...
+          <svg class="c-icon">
+            <use xlink:href="/coreui/free.svg#cil-copy"></use>
+          </svg>
+        </button>
       </td>
       <td>
       <button class="btn btn-sm btn-danger"

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
@@ -10,24 +10,14 @@ defmodule WasmcloudHostWeb.PageLive do
     {:ok,
      socket
      |> assign(
-       actors: WasmcloudHost.Lattice.StateMonitor.get_actors(),
-       providers: WasmcloudHost.Lattice.StateMonitor.get_providers(),
+       hosts: WasmcloudHost.Lattice.StateMonitor.get_hosts(),
        linkdefs: WasmcloudHost.Lattice.StateMonitor.get_linkdefs(),
        claims: WasmcloudHost.Lattice.StateMonitor.get_claims(),
-       hosts: WasmcloudHost.Lattice.StateMonitor.get_hosts(),
        open_modal: nil
      )}
   end
 
   @impl true
-  def handle_info({:actors, actors}, socket) do
-    {:noreply, assign(socket, actors: actors)}
-  end
-
-  def handle_info({:providers, providers}, socket) do
-    {:noreply, assign(socket, providers: providers)}
-  end
-
   def handle_info({:linkdefs, linkdefs}, socket) do
     {:noreply, assign(socket, linkdefs: linkdefs)}
   end

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
@@ -36,6 +36,10 @@ defmodule WasmcloudHostWeb.PageLive do
     {:noreply, assign(socket, claims: claims)}
   end
 
+  def handle_info({:hosts, hosts}, socket) do
+    {:noreply, assign(socket, hosts: hosts)}
+  end
+
   def handle_info({:open_modal, modal}, socket) do
     {:noreply, assign(socket, open_modal: modal)}
   end

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
@@ -14,6 +14,7 @@ defmodule WasmcloudHostWeb.PageLive do
        providers: WasmcloudHost.Lattice.StateMonitor.get_providers(),
        linkdefs: WasmcloudHost.Lattice.StateMonitor.get_linkdefs(),
        claims: WasmcloudHost.Lattice.StateMonitor.get_claims(),
+       hosts: WasmcloudHost.Lattice.StateMonitor.get_hosts(),
        open_modal: nil
      )}
   end

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
@@ -138,11 +138,11 @@
             </tr>
           </thead>
           <tbody>
-            <%= for {actor, hosts_map} <- @actors do %>
+            <%= for {host_id, host_map} <- @hosts do %>
+            <%= for {actor, info_map} <- Map.get(host_map, :actors) do %>
               <% actor_name = @claims |> Enum.find(fn {k, _v} -> k == actor end) |> elem(1) |> Map.get(:name) %>
-              <%= for {host_id, host_info} <- hosts_map do %>
-                <% count = Map.get(host_info, :count) %>
-                <% status = Map.get(host_info, :status) %>
+                <% count = Map.get(info_map, :count) %>
+                <% status = Map.get(info_map, :status) %>
                 <%= live_component ActorRowComponent,
                   actor: actor,
                   host_id: host_id,

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
@@ -195,22 +195,21 @@
               <th>Contract ID</th>
               <th>Status</th>
               <th>Provider ID</th>
-              <th>Host IDs</th>
+              <th>Host ID</th>
               <th>Actions</th>
             </tr>
           </thead>
           <tbody>
             <%# One row per-provider instance, which is a public key, contract id and link name combination %>
-            <%= for {provider, instances} <- @providers do %>
-              <%= for instance <- instances do  %>
-                <% link_name = Map.get(instance, :link_name) %>
+            <%= for {host_id, host_map} <- @hosts do %>
+              <%= for {{provider, link_name}, info_map} <- Map.get(host_map, :providers) do %>
                 <%= live_component ProviderRowComponent,
                   id: "#{provider} (#{link_name})",
                   provider: provider,
                   link_name: link_name,
-                  contract_id: Map.get(instance, :contract_id),
-                  status: Map.get(instance, :status),
-                  host_ids: Map.get(instance, :host_ids)%>
+                  contract_id: Map.get(info_map, :contract_id),
+                  status: Map.get(info_map, :status),
+                  host_id: host_id%>
               <% end %>
             <% end %>
           </tbody>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
@@ -37,7 +37,7 @@
           </svg>
         </div>
         <div class="text-value-lg"><%= processes = :erlang.system_info(:process_count); processes %></div>
-        <small class="text-muted text-uppercase font-weight-bold">Running Processes</small>
+        <small class="text-muted text-uppercase font-weight-bold">Running Processes (OTP)</small>
       </div>
     </div>
   </div>

--- a/wasmcloud_host/lib/wasmcloud_host_web/templates/layout/live.html.leex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/templates/layout/live.html.leex
@@ -27,7 +27,7 @@
               <% "StartProviderComponent" ->  %>
               <%= live_component StartProviderComponent, id: modal_id %>
               <% "DefineLinkComponent" ->  %>
-              <%= live_component DefineLinkComponent, id: modal_id, actors: @actors, providers: @providers, claims: @claims %>
+              <%= live_component DefineLinkComponent, id: modal_id, hosts: @hosts, claims: @claims %>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
Fixes #166 

This PR took a good bit of refactoring to take on a new structure for the StateMonitor, but overall enables much easier resolutions for #171's sub-issues.

Notable changes:
- In the StateMonitor, we no longer track actors and providers that have host IDs associated with them, rather it's a `hosts` map that is keyed by the host's public key, and contains maps that mimic an inventory for `actors`, `providers`, and `labels`. This will enable a filtering mode to only show resources on a specific host
- The dashboard will query claims and link definitions upon startup (thanks to Jetstream). Established link definitions are immediately shown on the dashboard, and claims are used for further context in the UI. Link definitions, and claims are listened for using the cache loader #169 