### PR TITLE
Fix manual release action

### DIFF
--- a/.github/workflows/build_tarballs_manual.yml
+++ b/.github/workflows/build_tarballs_manual.yml
@@ -1,6 +1,9 @@
 name: Build Linux and Mac Tarballs
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
 
 env:
   working-directory: wasmcloud_host
@@ -86,7 +89,6 @@ jobs:
   # When event type is release published, also run release workflow
   release-linux:
     needs: [build]
-    if: github.event.payload.ref_type == 'tag' # Triggers on tag push only
     name: Release Linux Tarball and Docker Image
     runs-on: ubuntu-18.04
     env:
@@ -102,50 +104,51 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to AzureCR
-        uses: azure/docker-login@v1
-        with:
-          login-server: ${{ secrets.AZURECR_PUSH_URL }}
-          username: ${{ secrets.AZURECR_PUSH_USER }}
-          password: ${{ secrets.AZURECR_PUSH_PASSWORD }}
+       - name: Login to AzureCR
+         uses: azure/docker-login@v1
+         with:
+           login-server: ${{ secrets.AZURECR_PUSH_URL }}
+           username: ${{ secrets.AZURECR_PUSH_USER }}
+           password: ${{ secrets.AZURECR_PUSH_PASSWORD }}
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_PUSH_USER }}
+          password: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}
 
       - name: Determine version
-        run: echo "wasmcloud_host_version=$(grep 'version:' ${{env.working-directory}}/mix.exs | cut -d '"' -f2)" > $GITHUB_ENV
+        run: echo "wasmcloud_host_version=$(grep '@app_vsn "' ${{env.working-directory}}/mix.exs | cut -d '"' -f2)" > $GITHUB_ENV
 
       - name: Build tarball image
         uses: docker/build-push-action@v2
         with:
           context: .
-          load: true
+          push: true
           file: ${{env.working-directory}}/Dockerfile
           build-args: |
             NIF_IMAGE=rust:1.53-slim-buster 
             NIF_INSTALL=apt-nif-install.sh 
             BUILDER_IMAGE=elixir:1.12.2-slim 
             BUILD_INSTALL=apt-build-install.sh 
-            RUSTARCH=x86_64 
-            RUSTTARGET=unknown-linux-gnu 
+            RUST_ARCH=x86_64 
+            RUST_TARGET=unknown-linux-gnu 
             APP_NAME=wasmcloud_host
             APP_VSN=${{ env.wasmcloud_host_version }}
             SECRET_KEY_BASE=${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}
           tags: |
-            wasmcloud_host_tarball:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
+            wasmcloud.azurecr.io/build/wasmcloud_host_tarball:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
 
       - name: Build and release image
         uses: docker/build-push-action@v2
         with:
           context: .
           push: false # Note here that the image will NOT be pushed to our container registries
+          load: true
           file: ${{env.working-directory}}/Dockerfile.release
           build-args: |
-            BUILD_IMAGE=wasmcloud_host_tarball:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
-            RELEASE_IMAGE=debian:buster-slim  
+            BUILD_IMAGE=wasmcloud.azurecr.io/build/wasmcloud_host_tarball:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
+            RELEASE_IMAGE=debian:buster-slim 
             RELEASE_INSTALL=apt-release-install.sh 
             APP_NAME=wasmcloud_host
             APP_VSN=${{ env.wasmcloud_host_version }}
@@ -195,7 +198,7 @@ jobs:
           node-version: "14"
 
       - name: Determine version
-        run: echo "wasmcloud_host_version=$(grep 'version:' ${{env.working-directory}}/mix.exs | cut -d '"' -f2)" > $GITHUB_ENV
+        run: echo "wasmcloud_host_version=$(grep '@app_vsn "' ${{env.working-directory}}/mix.exs | cut -d '"' -f2)" > $GITHUB_ENV
 
       - name: Install erlang and elixir
         run: |

--- a/.github/workflows/build_tarballs_manual.yml
+++ b/.github/workflows/build_tarballs_manual.yml
@@ -103,10 +103,12 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver: docker
 
-       - name: Login to AzureCR
-         uses: azure/docker-login@v1
-         with:
+      - name: Login to AzureCR
+        uses: azure/docker-login@v1
+        with:
            login-server: ${{ secrets.AZURECR_PUSH_URL }}
            username: ${{ secrets.AZURECR_PUSH_USER }}
            password: ${{ secrets.AZURECR_PUSH_PASSWORD }}
@@ -124,7 +126,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
+          load: true
           file: ${{env.working-directory}}/Dockerfile
           build-args: |
             NIF_IMAGE=rust:1.53-slim-buster 
@@ -138,7 +140,12 @@ jobs:
             SECRET_KEY_BASE=${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}
           tags: |
             wasmcloud.azurecr.io/build/wasmcloud_host_tarball:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
+            wasmcloud_host:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
 
+      - name: Inspect
+        run: |
+          docker image ls -a
+          
       - name: Build and release image
         uses: docker/build-push-action@v2
         with:
@@ -154,9 +161,9 @@ jobs:
             APP_VSN=${{ env.wasmcloud_host_version }}
             SECRET_KEY_BASE=${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}
           tags: |
-            wasmcloud.azurecr.io/wasmcloud_host:${{ env.wasmcloud_host_version }}-rc0
+            wasmcloud.azurecr.io/wasmcloud_host:${{ env.wasmcloud_host_version }}
             wasmcloud.azurecr.io/wasmcloud_host:latest
-            wasmcloud/wasmcloud_host:${{ env.wasmcloud_host_version }}-rc0
+            wasmcloud/wasmcloud_host:${{ env.wasmcloud_host_version }}
             wasmcloud/wasmcloud_host:latest
 
       # This make step retrieves the tarball from the build image

--- a/.github/workflows/build_tarballs_manual.yml
+++ b/.github/workflows/build_tarballs_manual.yml
@@ -2,8 +2,6 @@ name: Build Linux and Mac Tarballs
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main]
 
 env:
   working-directory: wasmcloud_host

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -105,6 +105,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver: docker
 
       - name: Login to AzureCR
         uses: azure/docker-login@v1
@@ -133,14 +135,19 @@ jobs:
             NIF_INSTALL=apt-nif-install.sh 
             BUILDER_IMAGE=elixir:1.12.2-slim 
             BUILD_INSTALL=apt-build-install.sh 
-            RUSTARCH=x86_64 
-            RUSTTARGET=unknown-linux-gnu 
+            RUST_ARCH=x86_64 
+            RUST_TARGET=unknown-linux-gnu 
             APP_NAME=wasmcloud_host
             APP_VSN=${{ env.wasmcloud_host_version }}
             SECRET_KEY_BASE=${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}
           tags: |
-            wasmcloud_host_tarball:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
+            wasmcloud.azurecr.io/build/wasmcloud_host_tarball:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
+            wasmcloud_host:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
 
+      - name: Inspect
+        run: |
+          docker image ls -a
+          
       - name: Build and release image
         uses: docker/build-push-action@v2
         with:
@@ -148,16 +155,16 @@ jobs:
           push: true
           file: ${{env.working-directory}}/Dockerfile.release
           build-args: |
-            BUILD_IMAGE=wasmcloud_host_tarball:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
-            RELEASE_IMAGE=debian:buster-slim  
+            BUILD_IMAGE=wasmcloud.azurecr.io/build/wasmcloud_host_tarball:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
+            RELEASE_IMAGE=debian:buster-slim 
             RELEASE_INSTALL=apt-release-install.sh 
             APP_NAME=wasmcloud_host
             APP_VSN=${{ env.wasmcloud_host_version }}
             SECRET_KEY_BASE=${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}
           tags: |
-            wasmcloud.azurecr.io/wasmcloud_host:${{ env.wasmcloud_host_version }}-rc0
+            wasmcloud.azurecr.io/wasmcloud_host:${{ env.wasmcloud_host_version }}
             wasmcloud.azurecr.io/wasmcloud_host:latest
-            wasmcloud/wasmcloud_host:${{ env.wasmcloud_host_version }}-rc0
+            wasmcloud/wasmcloud_host:${{ env.wasmcloud_host_version }}
             wasmcloud/wasmcloud_host:latest
 
       # This make step retrieves the tarball from the build image
@@ -172,6 +179,7 @@ jobs:
         with:
           name: wasmcloud_host-v${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
           path: ${{env.working-directory}}/rel/artifacts/wasmcloud_host/${{ env.wasmcloud_host_version }}/x86_64-linux-gnu.tar.gz
+
 
   release-macos:
     name: Release MacOS Tarball

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -120,7 +120,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Determine version
-        run: echo "wasmcloud_host_version=$(grep 'version:' ${{env.working-directory}}/mix.exs | cut -d '"' -f2)" > $GITHUB_ENV
+        run: echo "wasmcloud_host_version=$(grep '@app_vsn "' ${{env.working-directory}}/mix.exs | cut -d '"' -f2)" > $GITHUB_ENV
 
       - name: Build tarball image
         uses: docker/build-push-action@v2
@@ -200,7 +200,7 @@ jobs:
           node-version: "14"
 
       - name: Determine version
-        run: echo "wasmcloud_host_version=$(grep 'version:' ${{env.working-directory}}/mix.exs | cut -d '"' -f2)" > $GITHUB_ENV
+        run: echo "wasmcloud_host_version=$(grep '@app_vsn "' ${{env.working-directory}}/mix.exs | cut -d '"' -f2)" > $GITHUB_ENV
 
       - name: Install erlang and elixir
         run: |

--- a/wasmcloud_host/Makefile
+++ b/wasmcloud_host/Makefile
@@ -46,7 +46,7 @@ tarball-x86_64-linux-gnu: ## Retrieve tarball artifact
 		--env TARGET=x86_64-linux-gnu \
 		--env NAME=$(NAME) \
 		--env VERSION=$(VERSION) \
-		--rm -it $(NAME):$(VERSION)-x86_64-linux-gnu /host/rel/scripts/copy-release.sh
+		--rm $(NAME):$(VERSION)-x86_64-linux-gnu /host/rel/scripts/copy-release.sh
 
 run: ## Run the docker compose with specified image tag
 	cd ../ && \


### PR DESCRIPTION
This PR introduces the `build_tarballs_manual` action, which is essentially a copy of the release section of the `wasmcloud_host` action that can be invoked manually from the Actions tab in Github. This will be useful to produce the tarball artifacts that we plan to use for distribution before we tag an official release in github.

The release image is also built, however it is not pushed to docker.io or azurecr.io. This can be easily changed but I figured we can keep our registry from having pre-release images by just not pushing for the time being.

I've also updated the wasmcloud_host action to reflect the fixes that I discovered, like that docker buildx needs to use the `docker` driver and not the default (`docker-container`, I know, confusing) in order to use the intermediate image that I built.