### PR TITLE
Using contract ID and link name for provider executable path

### DIFF
--- a/host_core/lib/host_core/providers/provider_supervisor.ex
+++ b/host_core/lib/host_core/providers/provider_supervisor.ex
@@ -27,7 +27,12 @@ defmodule HostCore.Providers.ProviderSupervisor do
 
   defp extract_executable_to_tmp(par, link_name) do
     cache_path =
-      HostCore.WasmCloud.Native.par_cache_path(par.claims.public_key, par.claims.revision)
+      HostCore.WasmCloud.Native.par_cache_path(
+        par.claims.public_key,
+        par.claims.revision,
+        par.contract_id,
+        link_name
+      )
 
     provider_running =
       case HostCore.Providers.lookup_provider(par.contract_id, link_name) do

--- a/host_core/lib/host_core/wasmcloud/native.ex
+++ b/host_core/lib/host_core/wasmcloud/native.ex
@@ -19,7 +19,7 @@ defmodule HostCore.WasmCloud.Native do
 
   def get_oci_bytes(_oci_ref, _allow_latest, _allowed_insecure), do: error()
   def par_from_bytes(_bytes), do: error()
-  def par_cache_path(_subject, _rev), do: error()
+  def par_cache_path(_subject, _rev, _contract_id, _link_name), do: error()
   def detect_core_host_labels(), do: error()
 
   # When the NIF is loaded, it will override functions in this module.

--- a/host_core/native/hostcore_wasmcloud_native/src/lib.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/lib.rs
@@ -89,21 +89,30 @@ fn get_oci_bytes(
 fn par_from_bytes(binary: Binary) -> Result<(Atom, ProviderArchiveResource), Error> {
     match ProviderArchive::try_load(binary.as_slice()) {
         Ok(par) => {
-            return Ok((atoms::ok(), ProviderArchiveResource {
-                claims: par::extract_claims(&par)?,
-                target_bytes: par::extract_target_bytes(&par)?,
-                contract_id: par::get_capid(&par)?,
-                vendor: par::get_vendor(&par)?,
-            }))
+            return Ok((
+                atoms::ok(),
+                ProviderArchiveResource {
+                    claims: par::extract_claims(&par)?,
+                    target_bytes: par::extract_target_bytes(&par)?,
+                    contract_id: par::get_capid(&par)?,
+                    vendor: par::get_vendor(&par)?,
+                },
+            ))
         }
         Err(_) => Err(Error::BadArg),
     }
 }
 
 #[rustler::nif]
-fn par_cache_path(subject: String, rev: u32) -> Result<String, Error> {
-    par::cache_path(subject, rev)
+fn par_cache_path(
+    subject: String,
+    rev: u32,
+    contract_id: String,
+    link_name: String,
+) -> Result<String, Error> {
+    par::cache_path(subject, rev, contract_id, link_name)
 }
+
 /// Extracts the claims from the raw bytes of a _signed_ WebAssembly module/actor and returns them
 /// in the form of a simple struct that will bubble its way up to Elixir as a native struct
 #[rustler::nif]

--- a/host_core/native/hostcore_wasmcloud_native/src/par.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/par.rs
@@ -48,18 +48,38 @@ pub(crate) fn extract_target_bytes(par: &ProviderArchive) -> Result<Vec<u8>, Err
     }
 }
 
-pub(crate) fn cache_path(subject: String, rev: u32) -> Result<String, Error> {
+pub(crate) fn cache_path(
+    subject: String,
+    rev: u32,
+    contract_id: String,
+    link_name: String,
+) -> Result<String, Error> {
     let mut path = temp_dir();
     path.push("wasmcloudcache");
     path.push(&subject);
     path.push(format!("{}", rev));
-    path.push(native_target());
+
+    let contract = normalize_for_filename(&contract_id);
+    let link_name = normalize_for_filename(&link_name);
+    let filename = if cfg!(windows) {
+        format!("{}_{}.exe", contract, link_name)
+    } else {
+        format!("{}_{}", contract, link_name)
+    };
+    path.push(filename);
+
     match path.into_os_string().into_string() {
         Ok(s) => Ok(s),
         Err(_e) => Err(Error::Term(Box::new(
             "FATAL - Could not convert path into string",
         ))),
     }
+}
+
+fn normalize_for_filename(input: &str) -> String {
+    input
+        .to_lowercase()
+        .replace(|c: char| !c.is_ascii_alphanumeric(), "_")
 }
 
 fn native_target() -> String {


### PR DESCRIPTION
See the linked issue for discussion around why I ended up going with the contract Id and link name for the filename instead of instance IDs.