### PR TITLE
Lattice dashboard view

### DIFF
--- a/wasmcloud_host/assets/css/app.scss
+++ b/wasmcloud_host/assets/css/app.scss
@@ -1,6 +1,7 @@
 /* This file is for your main application css. */
 @import "./coreui/style.min.css";
 
+
 /* LiveView specific classes for your customizations */
 .phx-no-feedback.invalid-feedback,
 .phx-no-feedback .invalid-feedback {
@@ -112,4 +113,10 @@ Custom modal styles that don't hide when page is re-rendered
 // Hide backdrop behind content when not shown
 #phoenix-modal-backdrop:not(.show) {
   height: 0;
+}
+
+.container, .container-lg, .container-md, .container-sm, .container-xl, .container-xxl{
+  @media (min-width: 1680px) {
+    max-width: 1600px;
+  }
 }

--- a/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
@@ -312,6 +312,7 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
       end
 
     hosts = Map.put(state.hosts, source_host, host)
+    PubSub.broadcast(WasmcloudHost.PubSub, "lattice:state", {:hosts, hosts})
     %State{state | hosts: hosts}
   end
 

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/metrics_live.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/metrics_live.ex
@@ -1,0 +1,134 @@
+defmodule WasmcloudHostWeb.MetricsLive do
+  use Phoenix.LiveView
+
+  def render(assigns) do
+    ~L"""
+    <main class="c-main">
+      <div class="container-fluid">
+        <div class="fade-in">
+          <div class="row">
+              <div class="col-sm-12 col-md-12">
+                <div class="card">
+                    <div class="col-lg-12 col-md-12 col-sm-12">
+                      <div class="card-header">
+                          Erlang Metrics for
+                          <button class="btn btn-secondary btn-sm" type="button" onClick="navigator.clipboard.writeText('<%= HostCore.Host.host_key() %>')" data-toggle="popover" data-trigger="focus" title="" data-content="Copied!">
+                            <%= String.slice(HostCore.Host.host_key(), 0..4) %>...
+                            <svg class="c-icon">
+                                <use xlink:href="/coreui/free.svg#cil-copy"></use>
+                            </svg>
+                          </button>
+                      </div>
+                      <div class="card-body">
+                          <div class="row">
+                            <div class="col-sm-6 col-md-2">
+                                <div class="card text-white bg-gradient-info">
+                                  <div class="card-body">
+                                      <div class="text-muted text-right mb-4">
+                                        <svg class="c-icon c-icon-2xl">
+                                            <use xlink:href="/coreui/free.svg#cil-data-transfer-down"></use>
+                                        </svg>
+                                      </div>
+                                      <div class="text-value-lg"><%= {{:input, num}, _out} = :erlang.statistics(:io); num / 1_000_000 |> Float.round(2)%> MB</div>
+                                      <small class="text-muted text-uppercase font-weight-bold">Input</small>
+                                  </div>
+                                </div>
+                            </div>
+                            <!-- /.col-->
+                            <div class="col-sm-6 col-md-2">
+                                <div class="card text-white bg-gradient-success">
+                                  <div class="card-body">
+                                      <div class="text-muted text-right mb-4">
+                                        <svg class="c-icon c-icon-2xl">
+                                            <use xlink:href="/coreui/free.svg#cil-data-transfer-up"></use>
+                                        </svg>
+                                      </div>
+                                      <div class="text-value-lg"><%= {_input, {:output, num}} = :erlang.statistics(:io); num / 1_000_000 |> Float.round(2)%> MB</div>
+                                      <small class="text-muted text-uppercase font-weight-bold">Output</small>
+                                  </div>
+                                </div>
+                            </div>
+                            <!-- /.col-->
+                            <div class="col-sm-6 col-md-2">
+                                <div class="card text-white bg-gradient-warning">
+                                  <div class="card-body">
+                                      <div class="text-muted text-right mb-4">
+                                        <svg class="c-icon c-icon-2xl">
+                                            <use xlink:href="/coreui/free.svg#cil-vector"></use>
+                                        </svg>
+                                      </div>
+                                      <div class="text-value-lg"><%= processes = :erlang.system_info(:process_count); processes %></div>
+                                      <small class="text-muted text-uppercase font-weight-bold">OTP Processes</small>
+                                  </div>
+                                </div>
+                            </div>
+                            <!-- /.col-->
+                            <div class="col-sm-6 col-md-2">
+                                <div class="card text-white bg-gradient-danger">
+                                  <div class="card-body">
+                                      <div class="text-muted text-right mb-4">
+                                        <svg class="c-icon c-icon-2xl">
+                                            <use xlink:href="/coreui/free.svg#cil-clock"></use>
+                                        </svg>
+                                      </div>
+                                      <div class="text-value-lg">
+                                        <%= {time, _since_last} = :erlang.statistics(:wall_clock)
+                                            seconds = round(time / 1_000)
+                                            minutes = floor(seconds / 60)
+
+                                            seconds = rem(seconds, 60)
+                                            hours = floor(minutes / 60)
+                                            minutes = rem(minutes, 60)
+                                            "#{hours}H #{minutes}M #{seconds}S"
+                                            %>
+                                      </div>
+                                      <small class="text-muted text-uppercase font-weight-bold">Host Uptime</small>
+                                  </div>
+                                </div>
+                            </div>
+                            <!-- /.col-->
+                            <div class="col-sm-6 col-md-2">
+                                <div class="card text-white bg-gradient-primary">
+                                  <div class="card-body">
+                                      <div class="text-muted text-right mb-4">
+                                        <svg class="c-icon c-icon-2xl">
+                                            <use xlink:href="/coreui/free.svg#cil-screen-desktop"></use>
+                                        </svg>
+                                      </div>
+                                      <div class="text-value-lg"><%= :erlang.system_info(:otp_release) %></div>
+                                      <small class="text-muted text-uppercase font-weight-bold">OTP Release</small>
+                                  </div>
+                                </div>
+                            </div>
+                            <!-- /.col-->
+                            <div class="col-sm-6 col-md-2">
+                                <div class="card text-white bg-gradient-success">
+                                  <div class="card-body">
+                                      <div class="text-muted text-right mb-4">
+                                        <img class="c-icon c-icon-2xl" src="/images/wasmcloud_inversed_square.png" alt="wasmCloud logo">
+                                      </div>
+                                      <div class="text-value-lg"><%= Application.get_env(:wasmcloud_host, :app_version) %></div>
+                                      <small class="text-muted text-uppercase font-weight-bold">wasmCloud Release</small>
+                                  </div>
+                                </div>
+                            </div>
+                            <!-- /.col-->
+                          </div>
+                      </div>
+                    </div>
+                    <div class="card-footer">
+                      Metrics are only currently supported for the host running alongside the dashboard.
+                    </div>
+                </div>
+              </div>
+          </div>
+        </div>
+      </div>
+    </main>
+    """
+  end
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+end

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
@@ -13,7 +13,8 @@ defmodule WasmcloudHostWeb.PageLive do
        hosts: WasmcloudHost.Lattice.StateMonitor.get_hosts(),
        linkdefs: WasmcloudHost.Lattice.StateMonitor.get_linkdefs(),
        claims: WasmcloudHost.Lattice.StateMonitor.get_claims(),
-       open_modal: nil
+       open_modal: nil,
+       selected_host: nil
      )}
   end
 
@@ -36,6 +37,15 @@ defmodule WasmcloudHostWeb.PageLive do
 
   def handle_info(:hide_modal, socket) do
     {:noreply, assign(socket, open_modal: nil)}
+  end
+
+  @impl true
+  def handle_event("select_host", %{"host" => host}, socket) do
+    {:noreply, assign(socket, :selected_host, host)}
+  end
+
+  def handle_event("show_all_hosts", _values, socket) do
+    {:noreply, assign(socket, :selected_host, nil)}
   end
 
   @impl true

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
@@ -1,3 +1,19 @@
+<!--
+
+Move metrics into a different pane, "Local Host metrics"?
+
+Main view should include all information for hosts across the lattice, perhaps a quick enumeration of hosts as buttons, and you can click to filter
+only by that host? Otherwise a dropdown should suffice.
+
+Need a "selected_host" attribute in the PageLive view, and shown information will need to be filtered by that host.
+Essentially, if there's a selected_host then we just don't enumerate every host and instead Map.get(@hosts, @selected_host_id)
+
+I think I may need to bring in the full <body> tag into this file, simply because the entire dashboard can be influenced by state
+This shouldn't be an issue (might need to sort out some @conn things)
+If I do that, widgets can go into a LiveComponent and there are other ways that I can cut down on the length of this file
+
+-->
+
 <%# Widgets Row %>
 <div class="row">
   <div class="col-sm-6 col-md-2">
@@ -37,7 +53,7 @@
           </svg>
         </div>
         <div class="text-value-lg"><%= processes = :erlang.system_info(:process_count); processes %></div>
-        <small class="text-muted text-uppercase font-weight-bold">Running Processes (OTP)</small>
+        <small class="text-muted text-uppercase font-weight-bold">OTP Processes</small>
       </div>
     </div>
   </div>
@@ -139,7 +155,7 @@
           </thead>
           <tbody>
             <%= for {host_id, host_map} <- @hosts do %>
-            <%= for {actor, info_map} <- Map.get(host_map, :actors) do %>
+            <%= for {actor, info_map} <- Map.get(host_map, :actors, %{}) do %>
               <% actor_name = @claims |> Enum.find(fn {k, _v} -> k == actor end) |> elem(1) |> Map.get(:name) %>
                 <% count = Map.get(info_map, :count) %>
                 <% status = Map.get(info_map, :status) %>
@@ -202,7 +218,7 @@
           <tbody>
             <%# One row per-provider instance, which is a public key, contract id and link name combination %>
             <%= for {host_id, host_map} <- @hosts do %>
-              <%= for {{provider, link_name}, info_map} <- Map.get(host_map, :providers) do %>
+              <%= for {{provider, link_name}, info_map} <- Map.get(host_map, :providers, %{}) do %>
                 <%= live_component ProviderRowComponent,
                   id: "#{provider} (#{link_name})",
                   provider: provider,

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.leex
@@ -1,282 +1,275 @@
-<!--
-
-Move metrics into a different pane, "Local Host metrics"?
-
-Main view should include all information for hosts across the lattice, perhaps a quick enumeration of hosts as buttons, and you can click to filter
-only by that host? Otherwise a dropdown should suffice.
-
-Need a "selected_host" attribute in the PageLive view, and shown information will need to be filtered by that host.
-Essentially, if there's a selected_host then we just don't enumerate every host and instead Map.get(@hosts, @selected_host_id)
-
-I think I may need to bring in the full <body> tag into this file, simply because the entire dashboard can be influenced by state
-This shouldn't be an issue (might need to sort out some @conn things)
-If I do that, widgets can go into a LiveComponent and there are other ways that I can cut down on the length of this file
-
--->
-
-<%# Widgets Row %>
-<div class="row">
-  <div class="col-sm-6 col-md-2">
-    <div class="card text-white bg-gradient-info">
-      <div class="card-body">
-        <div class="text-muted text-right mb-4">
-          <svg class="c-icon c-icon-2xl">
-            <use xlink:href="/coreui/free.svg#cil-data-transfer-down"></use>
-          </svg>
-        </div>
-        <div class="text-value-lg"><%= {{:input, num}, _out} = :erlang.statistics(:io); num / 1_000_000 |> Float.round(2)%> MB</div>
-        <small class="text-muted text-uppercase font-weight-bold">Input</small>
-      </div>
-    </div>
-  </div>
-  <!-- /.col-->
-  <div class="col-sm-6 col-md-2">
-    <div class="card text-white bg-gradient-success">
-      <div class="card-body">
-        <div class="text-muted text-right mb-4">
-          <svg class="c-icon c-icon-2xl">
-            <use xlink:href="/coreui/free.svg#cil-data-transfer-up"></use>
-          </svg>
-        </div>
-        <div class="text-value-lg"><%= {_input, {:output, num}} = :erlang.statistics(:io); num / 1_000_000 |> Float.round(2)%> MB</div>
-        <small class="text-muted text-uppercase font-weight-bold">Output</small>
-      </div>
-    </div>
-  </div>
-  <!-- /.col-->
-  <div class="col-sm-6 col-md-2">
-    <div class="card text-white bg-gradient-warning">
-      <div class="card-body">
-        <div class="text-muted text-right mb-4">
-          <svg class="c-icon c-icon-2xl">
-            <use xlink:href="/coreui/free.svg#cil-vector"></use>
-          </svg>
-        </div>
-        <div class="text-value-lg"><%= processes = :erlang.system_info(:process_count); processes %></div>
-        <small class="text-muted text-uppercase font-weight-bold">OTP Processes</small>
-      </div>
-    </div>
-  </div>
-  <!-- /.col-->
-  <div class="col-sm-6 col-md-2">
-    <div class="card text-white bg-gradient-danger">
-      <div class="card-body">
-        <div class="text-muted text-right mb-4">
-          <svg class="c-icon c-icon-2xl">
-            <use xlink:href="/coreui/free.svg#cil-clock"></use>
-          </svg>
-        </div>
-        <div class="text-value-lg">
-          <%= {time, _since_last} = :erlang.statistics(:wall_clock)
-          seconds = round(time / 1_000)
-          minutes = floor(seconds / 60)
-
-          seconds = rem(seconds, 60)
-          hours = floor(minutes / 60)
-          minutes = rem(minutes, 60)
-          "#{hours}H #{minutes}M #{seconds}S"
-        %>
-        </div>
-        <small class="text-muted text-uppercase font-weight-bold">Host Uptime</small>
-      </div>
-    </div>
-  </div>
-  <!-- /.col-->
-  <div class="col-sm-6 col-md-2">
-    <div class="card text-white bg-gradient-primary">
-      <div class="card-body">
-        <div class="text-muted text-right mb-4">
-          <svg class="c-icon c-icon-2xl">
-            <use xlink:href="/coreui/free.svg#cil-screen-desktop"></use>
-          </svg>
-        </div>
-        <div class="text-value-lg"><%= :erlang.system_info(:otp_release) %></div>
-        <small class="text-muted text-uppercase font-weight-bold">OTP Release</small>
-      </div>
-    </div>
-  </div>
-  <!-- /.col-->
-  <div class="col-sm-6 col-md-2">
-    <div class="card text-white bg-gradient-success">
-      <div class="card-body">
-        <div class="text-muted text-right mb-4">
-          <img class="c-icon c-icon-2xl" src="/images/wasmcloud_inversed_square.png" alt="wasmCloud logo">
-        </div>
-        <div class="text-value-lg"><%= Application.get_env(:wasmcloud_host, :app_version) %></div>
-        <small class="text-muted text-uppercase font-weight-bold">wasmCloud Release</small>
-      </div>
-    </div>
-  </div>
-  <!-- /.col-->
-</div>
-<%# Actors Row %>
-<div class="row">
-  <div class="col-xl-6 col-lg-12 col-md-12">
-    <div class="card">
-      <div class="card-header justify-content-between">
-        <div class="row justify-content-between">
-          <div class="col-lg-2 col-md-3 col-sm-3" style="max-width:200px">
-            <h3>Actors</h3>
-          </div>
-          <div class="mfe-2">
-            <div class="dropdown d-inline-block">
-              <button class="btn btn-secondary dropdown-toggle" id="dropdownMenuButton" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Start Actor</button>
-              <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                <button class="dropdown-item"
-                  phx-click="show_modal"
-                  phx-value-title="Start Actor from File"
-                  phx-value-component="StartActorComponent"
-                  phx-value-id="start_actor_file_modal">
-                  From File
-                </button>
-                <button class="dropdown-item"
-                  phx-click="show_modal"
-                  phx-value-title="Start Actor from OCI Registry"
-                  phx-value-component="StartActorComponent"
-                  phx-value-id="start_actor_ociref_modal">
-                  From Registry
-                </button>
-              </div>
+<main class="c-main">
+   <div class="container-fluid">
+      <div class="fade-in">
+         <div class="row">
+            <div class="col-xl-12 col-lg-12 col-md-12">
+               <div class="card">
+                  <div class="card-header justify-content-between">
+                     <div class="row">
+                        <div class="col-lg-12 col-md-12 col-sm-12">
+                           <strong>Host Selector</strong>
+                           <% button_color = if @selected_host == nil do "btn-outline-primary active" else "btn-outline-primary" end %>
+                           <button class="btn <%= button_color %>" type="button" phx-click="show_all_hosts">
+                           Show All
+                           </button>
+                           <%= for {host_id, _host_info} <- @hosts do %>
+                           <% button_color = if host_id == @selected_host do "btn-outline-primary active" else "btn-outline-primary" end%>
+                           <button class="btn <%= button_color %>" type="button" phx-click="select_host"phx-value-host="<%= host_id %>">
+                           <%= String.slice(host_id, 0..4) %>...
+                           </button>
+                           <% end %>
+                        </div>
+                     </div>
+                  </div>
+               </div>
             </div>
-          </div>
-        </div>
-      </div>
-      <div class="card-body">
-        <table class="table table-responsive-sm table-bordered table-striped table-sm">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Count</th>
-              <th>Status</th>
-              <th>Actor ID</th>
-              <th>Host ID</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            <%= for {host_id, host_map} <- @hosts do %>
-            <%= for {actor, info_map} <- Map.get(host_map, :actors, %{}) do %>
-              <% actor_name = @claims |> Enum.find(fn {k, _v} -> k == actor end) |> elem(1) |> Map.get(:name) %>
-                <% count = Map.get(info_map, :count) %>
-                <% status = Map.get(info_map, :status) %>
-                <%= live_component ActorRowComponent,
-                  actor: actor,
-                  host_id: host_id,
-                  status: status,
-                  count: count,
-                  name: actor_name %>
-              <% end %>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-  <!-- /.col-->
-  <div class="col-xl-6 col-lg-12 col-md-12">
-    <div class="card">
-      <div class="card-header">
-        <div class="row justify-content-between">
-          <div class="col-lg-2 col-md-3 col-sm-3" style="max-width:200px">
-            <h3>Providers</h3>
-          </div>
-          <div class="mfe-2">
-            <div class="dropdown d-inline-block">
-              <button class="btn btn-secondary dropdown-toggle" id="dropdownMenuButton" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Start Provider</button>
-              <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                <button class="dropdown-item"
-                  phx-click="show_modal"
-                  phx-value-title="Start Provider from File"
-                  phx-value-component="StartProviderComponent"
-                  phx-value-id="start_provider_file_modal">
-                  From File
-                </button>
-                <button class="dropdown-item"
-                  phx-click="show_modal"
-                  phx-value-title="Start Provider from OCI Registry"
-                  phx-value-component="StartProviderComponent"
-                  phx-value-id="start_provider_ociref_modal">
-                  From Registry
-                </button>
-              </div>
+         </div>
+         <%# display_hosts map that either contains all hosts, or a specific host in the case of filtering by host %>
+         <% display_hosts = if @selected_host == nil do @hosts else %{@selected_host => @hosts |> Map.get(@selected_host, %{})} end %>
+         <div class="row">
+            <%# Actors Column%>
+            <div class="col-xl-6 col-lg-12 col-md-12">
+               <div class="card">
+                  <div class="card-header justify-content-between">
+                     <div class="row justify-content-between">
+                        <div class="col-lg-2 col-md-3 col-sm-3" style="max-width:250px">
+                           <h3>Actors</h3>
+                        </div>
+                        <div class="mfe-2">
+                           <div class="dropdown d-inline-block">
+                              <button class="btn btn-secondary dropdown-toggle" id="dropdownMenuButton" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Start Actor</button>
+                              <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                                 <button class="dropdown-item"
+                                    phx-click="show_modal"
+                                    phx-value-title="Start Actor from File"
+                                    phx-value-component="StartActorComponent"
+                                    phx-value-id="start_actor_file_modal">
+                                 From File
+                                 </button>
+                                 <button class="dropdown-item"
+                                    phx-click="show_modal"
+                                    phx-value-title="Start Actor from OCI Registry"
+                                    phx-value-component="StartActorComponent"
+                                    phx-value-id="start_actor_ociref_modal">
+                                 From Registry
+                                 </button>
+                              </div>
+                           </div>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="card-body">
+                     <table class="table table-responsive-sm table-bordered table-striped table-sm">
+                        <thead>
+                           <tr>
+                              <th>Name</th>
+                              <th>Count</th>
+                              <th>Status</th>
+                              <th>Actor ID</th>
+                              <th>Host ID</th>
+                              <th>Actions</th>
+                           </tr>
+                        </thead>
+                        <tbody>
+                           <%= for {host_id, host_map} <- display_hosts do %>
+                           <%= for {actor, info_map} <- Map.get(host_map, :actors, %{}) do %>
+                           <% actor_name = @claims |> Enum.find(fn {k, _v} -> k == actor end) |> elem(1) |> Map.get(:name) %>
+                           <% count = Map.get(info_map, :count) %>
+                           <% status = Map.get(info_map, :status) %>
+                           <%= live_component ActorRowComponent,
+                              actor: actor,
+                              host_id: host_id,
+                              status: status,
+                              count: count,
+                              name: actor_name %>
+                           <% end %>
+                           <% end %>
+                        </tbody>
+                     </table>
+                  </div>
+               </div>
             </div>
-          </div>
-        </div>
-      </div>
-      <div class="card-body">
-        <table class="table table-responsive-sm table-bordered table-striped table-sm">
-          <thead>
-            <tr>
-              <th>Link Name</th>
-              <th>Contract ID</th>
-              <th>Status</th>
-              <th>Provider ID</th>
-              <th>Host ID</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            <%# One row per-provider instance, which is a public key, contract id and link name combination %>
-            <%= for {host_id, host_map} <- @hosts do %>
-              <%= for {{provider, link_name}, info_map} <- Map.get(host_map, :providers, %{}) do %>
-                <%= live_component ProviderRowComponent,
-                  id: "#{provider} (#{link_name})",
-                  provider: provider,
-                  link_name: link_name,
-                  contract_id: Map.get(info_map, :contract_id),
-                  status: Map.get(info_map, :status),
-                  host_id: host_id%>
-              <% end %>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-</div>
-<%# Link Definitions row %>
-<div class="row">
-  <div class="col-xl-6 col-lg-12 col-md-12">
-    <div class="card">
-      <div class="card-header">
-        <div class="row justify-content-between">
-          <div class="col-lg-6 col-md-6 col-sm-6" style="max-width:200px">
-            <h3>Link Definitions</h3>
-          </div>
-          <div class="mfe-2">
-            <div class="dropdown d-inline-block">
-              <button class="btn btn-secondary"
-                  phx-click="show_modal"
-                  phx-value-title="Define Link Definition"
-                  phx-value-component="DefineLinkComponent"
-                  phx-value-id="define_link_modal">
-                Define Link
-                <svg class="c-icon c-icon-sm">
-                  <use xlink:href="/coreui/free.svg#cil-link"></use>
-                </svg>
-              </button>
+            <!-- /.col-->
+            <%# Providers Column %>
+            <div class="col-xl-6 col-lg-12 col-md-12">
+               <div class="card">
+                  <div class="card-header">
+                     <div class="row justify-content-between">
+                        <div class="col-lg-2 col-md-3 col-sm-3" style="max-width:250px">
+                           <h3>Providers</h3>
+                        </div>
+                        <div class="mfe-2">
+                           <div class="dropdown d-inline-block">
+                              <button class="btn btn-secondary dropdown-toggle" id="dropdownMenuButton" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Start Provider</button>
+                              <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                                 <button class="dropdown-item"
+                                    phx-click="show_modal"
+                                    phx-value-title="Start Provider from File"
+                                    phx-value-component="StartProviderComponent"
+                                    phx-value-id="start_provider_file_modal">
+                                 From File
+                                 </button>
+                                 <button class="dropdown-item"
+                                    phx-click="show_modal"
+                                    phx-value-title="Start Provider from OCI Registry"
+                                    phx-value-component="StartProviderComponent"
+                                    phx-value-id="start_provider_ociref_modal">
+                                 From Registry
+                                 </button>
+                              </div>
+                           </div>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="card-body">
+                     <table class="table table-responsive-sm table-bordered table-striped table-sm">
+                        <thead>
+                           <tr>
+                              <th>Link Name</th>
+                              <th>Contract ID</th>
+                              <th>Status</th>
+                              <th>Provider ID</th>
+                              <th>Host ID</th>
+                              <th>Actions</th>
+                           </tr>
+                        </thead>
+                        <tbody>
+                           <%# One row per-provider instance, which is a public key, contract id and link name combination %>
+                           <%= for {host_id, host_map} <- display_hosts do %>
+                           <%= for {{provider, link_name}, info_map} <- Map.get(host_map, :providers, %{}) do %>
+                           <%= live_component ProviderRowComponent,
+                              id: "#{provider} (#{link_name})",
+                              provider: provider,
+                              link_name: link_name,
+                              contract_id: Map.get(info_map, :contract_id),
+                              status: Map.get(info_map, :status),
+                              host_id: host_id%>
+                           <% end %>
+                           <% end %>
+                        </tbody>
+                     </table>
+                  </div>
+               </div>
             </div>
-          </div>
-        </div>
-      </div>
-      <div class="card-body">
-        <table class="table table-responsive-sm table-bordered table-striped table-sm">
-          <thead>
-            <tr>
-              <th>Link Name</th>
-              <th>Contract ID</th>
-              <th>Actor ID</th>
-              <th>Provider ID</th>
-            </tr>
-          </thead>
-          <tbody>
-            <%= for { {actor_id, contract_id, link_name},v} <- @linkdefs do %>
-              <%= live_component LinkRowComponent, link_name: link_name, contract_id: contract_id, actor_id: actor_id, provider_key: v.provider_key %>
+         </div>
+         <div class="row">
+            <%# Link Definitions column%>
+            <div class="col-xl-6 col-lg-12 col-md-12">
+               <div class="card">
+                  <div class="card-header">
+                     <div class="row justify-content-between">
+                        <div class="col-lg-6 col-md-6 col-sm-6" style="max-width:250px">
+                           <h3>Link Definitions</h3>
+                        </div>
+                        <div class="mfe-2">
+                           <div class="dropdown d-inline-block">
+                              <button class="btn btn-secondary"
+                                 phx-click="show_modal"
+                                 phx-value-title="Define Link Definition"
+                                 phx-value-component="DefineLinkComponent"
+                                 phx-value-id="define_link_modal">
+                                 Define Link
+                                 <svg class="c-icon c-icon-sm">
+                                    <use xlink:href="/coreui/free.svg#cil-link"></use>
+                                 </svg>
+                              </button>
+                           </div>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="card-body">
+                     <table class="table table-responsive-sm table-bordered table-striped table-sm">
+                        <thead>
+                           <tr>
+                              <th>Link Name</th>
+                              <th>Contract ID</th>
+                              <th>Actor ID</th>
+                              <th>Provider ID</th>
+                           </tr>
+                        </thead>
+                        <tbody>
+                           <%= for { {actor_id, contract_id, link_name},v} <- @linkdefs do %>
+                           <%= live_component LinkRowComponent, link_name: link_name, contract_id: contract_id, actor_id: actor_id, provider_key: v.provider_key %>
+                           <% end %>
+                        </tbody>
+                     </table>
+                  </div>
+               </div>
+            </div>
+            <!-- /.col-->
+            <% host_id = @selected_host %>
+            <%# Hosts Column %>
+            <%= if host_id != nil do %>
+            <div class="col-xl-6 col-lg-12 col-md-12">
+               <div class="card">
+                  <div class="card-header">
+                     <div class="row justify-content-between">
+                        <div class="col-lg-6 col-md-6 col-sm-6" style="max-width:250px">
+                           <h3>Host Info</h3>
+                        </div>
+                        <div class="mfe-2">
+                           <button class="btn btn-secondary" type="button" onClick="navigator.clipboard.writeText('<%= host_id %>')" data-toggle="popover" data-trigger="focus" title="" data-content="Copied!">
+                              <%= String.slice(host_id, 0..4) %>...
+                              <svg class="c-icon">
+                                 <use xlink:href="/coreui/free.svg#cil-copy"></use>
+                              </svg>
+                           </button>
+                        </div>
+                     </div>
+                  </div>
+                  <div class="card-body">
+                     <table class="table table-responsive-sm table-bordered table-striped table-sm">
+                        <thead>
+                           <tr>
+                              <th>Label</th>
+                              <th>Value</th>
+                           </tr>
+                        </thead>
+                        <tbody>
+                           <%= for {k, v} <- Map.get(Map.get(@hosts, host_id, %{}), :labels, %{}) do %>
+                           <tr>
+                              <td><%= k %></td>
+                              <td><%= v %></td>
+                           </tr>
+                           <% end %>
+                        </tbody>
+                     </table>
+                     <table class="table table-responsive-sm table-bordered table-striped table-sm">
+                        <thead>
+                           <tr>
+                              <th>Lattice Prefix</th>
+                              <th>Local</th>
+                              <th>Actors</th>
+                              <th>Providers</th>
+                           </tr>
+                        </thead>
+                        <tbody>
+                           <tr>
+                              <td>
+                                 <%= HostCore.Host.lattice_prefix() %>
+                              </td>
+                              <td>
+                                 <%= host_id == HostCore.Host.host_key() %>
+                              </td>
+                              <td>
+                                 <%= Map.get(@hosts, host_id, %{})
+                                    |> Map.get(:actors, %{})
+                                    |> Enum.map(fn {_actor_id, info} -> Map.get(info, :count, 0) end)
+                                    |> Enum.reduce(0, fn count, acc -> count + acc end) %>
+                              </td>
+                              <td>
+                                 <%= Map.get(@hosts, host_id, %{})
+                                    |> Map.get(:providers, %{})
+                                    |> Enum.count() %>
+                              </td>
+                           </tr>
+                        </tbody>
+                     </table>
+                  </div>
+               </div>
+            </div>
             <% end %>
-          </tbody>
-        </table>
+         </div>
       </div>
-    </div>
-  </div>
-  <!-- /.col-->
-</div>
+   </div>
+</main>

--- a/wasmcloud_host/lib/wasmcloud_host_web/router.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/router.ex
@@ -20,6 +20,12 @@ defmodule WasmcloudHostWeb.Router do
     live "/", PageLive, :index
   end
 
+  scope "/metrics", WasmcloudHostWeb do
+    pipe_through :browser
+
+    live "/", MetricsLive, :index
+  end
+
   # Other scopes may use custom stacks.
   scope "/api", WasmcloudHostWeb do
     pipe_through :api

--- a/wasmcloud_host/lib/wasmcloud_host_web/templates/layout/root.html.leex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/templates/layout/root.html.leex
@@ -24,23 +24,35 @@
   </head>
   <!-- Main body -->
   <body class="c-app c-no-layout-transition">
-    <div class="c-sidebar c-sidebar-dark c-sidebar-fixed c-sidebar-lg-show c-sidebar-unfoldable" id="sidebar">
+    <div class="c-sidebar c-sidebar-dark c-sidebar-fixed c-sidebar-lg-show" id="sidebar">
       <div class="c-sidebar-brand d-md-down-none">
         <!-- Expanded logo -->
         <div class="c-sidebar-brand-full" alt="wasmCloud Horizontal">
-          <img width="200px" src="<%= Routes.static_path(@conn, "/images/wasmcloud_horizontal_white.png") %>">
+          <img width="200px" src="/images/wasmcloud_horizontal_white.png">
         </div>
         <!-- Collapsed logo -->
         <div class="c-sidebar-brand-minimized" alt="wasmCloud Minimized">
-          <img width="36px" src="<%= Routes.static_path(@conn, "/images/wasmcloud_inversed.png") %>">
+          <img width="36px" src="/images/wasmcloud_inversed.png">
         </div>
       </div>
       <!-- Navigation sidebar -->
       <ul class="c-sidebar-nav">
-        <li class="c-sidebar-nav-item"><a class="c-sidebar-nav-link" href="">
+        <li class="c-sidebar-nav-item">
+          <a class="c-sidebar-nav-link" href="/">
             <svg class="c-sidebar-nav-icon">
-              <use xlink:href="<%= Routes.static_path(@conn, "/coreui/free.svg#cil-speedometer") %>"></use>
-            </svg> Dashboard</a></li>
+              <use xlink:href="/coreui/free.svg#cil-speedometer"></use>
+            </svg>
+            Dashboard
+          </a>
+        </li>
+        <li class="c-sidebar-nav-item">
+          <a class="c-sidebar-nav-link" href="/metrics">
+            <svg class="c-sidebar-nav-icon">
+              <use xlink:href="/coreui/free.svg#cil-chart"></use>
+            </svg>
+            Metrics
+          </a>
+        </li>
       </ul>
       <!-- Toggles navigation collapse -->
       <button class="c-sidebar-minimizer c-class-toggler" type="button" data-target="_parent" data-class="c-sidebar-unfoldable"></button>
@@ -48,7 +60,7 @@
     <div class="c-sidebar c-sidebar-lg c-sidebar-light c-sidebar-right c-sidebar-overlaid" id="aside">
       <button class="c-sidebar-close c-class-toggler" type="button" data-target="_parent" data-class="c-sidebar-show">
         <svg class="c-icon">
-          <use xlink:href="<%= Routes.static_path(@conn, "/coreui/free.svg#cil-x") %>"></use>
+          <use xlink:href="/coreui/free.svg#cil-x"></use>
         </svg>
       </button>
     </div>
@@ -56,37 +68,37 @@
       <header class="c-header c-header-light c-header-fixed">
         <button class="c-header-toggler c-class-toggler d-lg-none mfe-auto" type="button" data-target="#sidebar" data-class="c-sidebar-show">
           <svg class="c-icon c-icon-lg">
-            <use xlink:href="<%= Routes.static_path(@conn, "/coreui/free.svg#cil-menu") %>"></use>
+            <use xlink:href="/coreui/free.svg#cil-menu"></use>
           </svg>
         </button><a class="c-header-brand d-lg-none c-header-brand-sm-up-center" href="#">
           <svg width="118" height="46" alt="CoreUI Logo">
-            <use xlink:href="<%= Routes.static_path(@conn, "/coreui/free.svg#full") %>"></use>
+            <use xlink:href="/coreui/free.svg#full"></use>
           </svg></a>
         <button class="c-header-toggler c-class-toggler mfs-3 d-md-down-none" type="button" data-target="#sidebar" data-class="c-sidebar-lg-show" responsive="true">
           <svg class="c-icon c-icon-lg">
-            <use xlink:href="<%= Routes.static_path(@conn, "/coreui/free.svg#cil-menu") %>"></use>
+            <use xlink:href="/coreui/free.svg#cil-menu"></use>
           </svg>
         </button>
         <div id="kowasmi-container" style="display: flex; align-items: center; flex-wrap: wrap; max-width: 528px">
           <svg id="kowasmi" class="c-icon" style="display: none">
-            <use xlink:href="<%= Routes.static_path(@conn, "/coreui/free.svg#cil-heart") %>"></use>
+            <use xlink:href="/coreui/free.svg#cil-heart"></use>
           </svg>
         </div>
         <ul class="c-header-nav mfs-auto">
           <li class="c-header-nav-item px-3 c-d-legacy-none">
             <button class="c-class-toggler c-header-nav-btn" type="button" id="header-tooltip" data-target="body" data-class="c-dark-theme" data-toggle="c-tooltip" data-placement="bottom" title="Toggle Light/Dark Mode">
               <svg class="c-icon c-d-dark-none">
-                <use xlink:href="<%= Routes.static_path(@conn, "/coreui/free.svg#cil-moon") %>"></use>
+                <use xlink:href="/coreui/free.svg#cil-moon"></use>
               </svg>
               <svg class="c-icon c-d-default-none">
-                <use xlink:href="<%= Routes.static_path(@conn, "/coreui/free.svg#cil-sun") %>"></use>
+                <use xlink:href="/coreui/free.svg#cil-sun"></use>
               </svg>
             </button>
           </li>
         </ul>
         <ul class="c-header-nav">
           <li class="c-header-nav-item dropdown"><a class="c-header-nav-link" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-              <div class="c-avatar"><img class="c-avatar-img" src="<%= Routes.static_path(@conn, "/images/wasmcloud_extraspace.png") %>" alt="wasmCloud logo"></div>
+              <div class="c-avatar"><img class="c-avatar-img" src="/images/wasmcloud_extraspace.png" alt="wasmCloud logo"></div>
             </a>
             <div class="dropdown-menu dropdown-menu-right pt-0">
               <a class="dropdown-item" href="#">
@@ -96,24 +108,9 @@
             </div>
           </li>
         </ul>
-        <div class="c-subheader justify-content-between px-3">
-          <!-- Breadcrumb-->
-          <ol class="breadcrumb border-0 m-0 px-0 px-md-3">
-            <li class="breadcrumb-item"><strong>Lattice (<%= HostCore.Host.lattice_prefix() %>)</strong></li>
-            <!-- Breadcrumb Menu-->
-          </ol>
-        </div>
       </header>
       <div class="c-body">
-        <main class="c-main">
-          <div class="container-fluid">
-            <div class="fade-in">
-              <!-- Displays view -->
-              <%= @inner_content %>
-              <!-- /.row-->
-            </div>
-          </div>
-        </main>
+        <%= @inner_content %>
       </div>
     </div>
     <!-- Transition on-load -->
@@ -121,7 +118,7 @@
       document.addEventListener("DOMContentLoaded", function(event) {
         setTimeout(function() {
           document.body.classList.remove('c-no-layout-transition')
-        }, 2000);
+        }, 1999);
       });
     </script>
   </body>


### PR DESCRIPTION
Fixes #68 

Most of the changes in this PR revolve around moving the metrics into a separate tab and adding logic to select a host from the list of discovered hosts in the UI. When you select a host, the `Host Info` card will appear with that hosts' labels, lattice prefix, a boolean denoting if it's the "local" host (e.g. the host launched with the dashboard) and a total count of actors and providers running on that host.

Looking for feedback on the code as well as how the UI looks. Does the host selector warrant a different color for the "local" host? Is the UI getting too crowded? Etc.