### PR TITLE
bump version of placeholder actor + provider

### DIFF
--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_actor_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_actor_component.ex
@@ -148,7 +148,7 @@ defmodule StartActorComponent do
         <label class="col-md-3 col-form-label" for="file-input">OCI reference</label>
         <div class="col-md-9">
           <input class="form-control" id="text-input" type="text" name="actor_ociref"
-            placeholder="wasmcloud.azurecr.io/echo:0.2.0" value="" required>
+            placeholder="wasmcloud.azurecr.io/echo:0.2.1" value="" required>
           <span class="help-block">Enter an OCI reference</span>
         </div>
       </div>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_provider_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_provider_component.ex
@@ -141,7 +141,7 @@ defmodule StartProviderComponent do
         <label class="col-md-3 col-form-label" for="file-input">OCI Reference</label>
         <div class="col-md-9">
           <input class="form-control" id="provider-ociref-input" type="text" name="provider_ociref"
-            placeholder="wasmcloud.azurecr.io/httpserver:0.12.1" value="" required>
+            placeholder="wasmcloud.azurecr.io/httpserver:0.13.1" value="" required>
           <span class="help-block">Enter an OCI reference</span>
         </div>
       </div>


### PR DESCRIPTION
The 0.12.1 provider is an old-style shared library capability provider rather than a stand-alone executable.

This flummoxed me for a bit, until I found 0.13.1 in https://deploy-preview-51--epic-wiles-f93118.netlify.app/app-dev/create-actor/run/ (I couldn't find any way to list actor versions, other than spamming `docker pull` with random version numbers).

Hopefully this saves the next person some time.

