### PR TITLE
accept new-style method prefixes and old-style method-only names.

### DIFF
--- a/host_core/lib/host_core/providers/builtin/logging.ex
+++ b/host_core/lib/host_core/providers/builtin/logging.ex
@@ -1,7 +1,7 @@
 defmodule HostCore.Providers.Builtin.Logging do
   require Logger
 
-  def invoke(actor, method, payload) when method == "Logging.WriteLog" or method == "WriteLog" do
+  def invoke(actor, method, payload) when method in ["Logging.WriteLog", "WriteLog"] do
     msg = Msgpax.unpack!(payload)
     text = "[#{actor}] #{msg["text"]}"
 

--- a/host_core/lib/host_core/providers/builtin/logging.ex
+++ b/host_core/lib/host_core/providers/builtin/logging.ex
@@ -1,7 +1,7 @@
 defmodule HostCore.Providers.Builtin.Logging do
   require Logger
 
-  def invoke(actor, method, payload) when method=="Logging.WriteLog" or method=="WriteLog" do
+  def invoke(actor, method, payload) when method == "Logging.WriteLog" or method == "WriteLog" do
     msg = Msgpax.unpack!(payload)
     text = "[#{actor}] #{msg["text"]}"
 

--- a/host_core/lib/host_core/providers/builtin/logging.ex
+++ b/host_core/lib/host_core/providers/builtin/logging.ex
@@ -1,7 +1,7 @@
 defmodule HostCore.Providers.Builtin.Logging do
   require Logger
 
-  def invoke(actor, "WriteLog", payload) do
+  def invoke(actor, method, payload) when method=="Logging.WriteLog" or method=="WriteLog" do
     msg = Msgpax.unpack!(payload)
     text = "[#{actor}] #{msg["text"]}"
 

--- a/host_core/lib/host_core/providers/builtin/numbergen.ex
+++ b/host_core/lib/host_core/providers/builtin/numbergen.ex
@@ -1,9 +1,9 @@
 defmodule HostCore.Providers.Builtin.Numbergen do
-  def invoke("GenerateGuid", _payload) do
+  def invoke(method, _payload) when method=="NumberGen.GenerateGuid" or method=="GenerateGuid" do
     IO.iodata_to_binary(Msgpax.pack!(UUID.uuid4()))
   end
 
-  def invoke("RandomInRange", payload) do
+  def invoke(method, payload) when method=="NumberGen.RandomInRange" or method=="RandomInRange" do
     params = Msgpax.unpack!(payload)
 
     min = max(params["min"], 0)
@@ -11,7 +11,7 @@ defmodule HostCore.Providers.Builtin.Numbergen do
     IO.iodata_to_binary(Msgpax.pack!(Enum.random(min..max)))
   end
 
-  def invoke("Random32", _payload) do
+  def invoke(method, _payload) when method=="NumberGen.Random32" or method=="RandomRandom32" do
     IO.iodata_to_binary(Msgpax.pack!(Enum.random(0..4_294_967_295)))
   end
 end

--- a/host_core/lib/host_core/providers/builtin/numbergen.ex
+++ b/host_core/lib/host_core/providers/builtin/numbergen.ex
@@ -1,11 +1,11 @@
 defmodule HostCore.Providers.Builtin.Numbergen do
   def invoke(method, _payload)
-      when method == "NumberGen.GenerateGuid" or method == "GenerateGuid" do
+      when method in ["NumberGen.GenerateGuid", "GenerateGuid"] do
     IO.iodata_to_binary(Msgpax.pack!(UUID.uuid4()))
   end
 
   def invoke(method, payload)
-      when method == "NumberGen.RandomInRange" or method == "RandomInRange" do
+      when method in ["NumberGen.RandomInRange", "RandomInRange"] do
     params = Msgpax.unpack!(payload)
 
     min = max(params["min"], 0)
@@ -14,7 +14,7 @@ defmodule HostCore.Providers.Builtin.Numbergen do
   end
 
   def invoke(method, _payload)
-      when method == "NumberGen.Random32" or method == "RandomRandom32" do
+      when method in ["NumberGen.Random32", "Random32"] do
     IO.iodata_to_binary(Msgpax.pack!(Enum.random(0..4_294_967_295)))
   end
 end

--- a/host_core/lib/host_core/providers/builtin/numbergen.ex
+++ b/host_core/lib/host_core/providers/builtin/numbergen.ex
@@ -1,9 +1,11 @@
 defmodule HostCore.Providers.Builtin.Numbergen do
-  def invoke(method, _payload) when method=="NumberGen.GenerateGuid" or method=="GenerateGuid" do
+  def invoke(method, _payload)
+      when method == "NumberGen.GenerateGuid" or method == "GenerateGuid" do
     IO.iodata_to_binary(Msgpax.pack!(UUID.uuid4()))
   end
 
-  def invoke(method, payload) when method=="NumberGen.RandomInRange" or method=="RandomInRange" do
+  def invoke(method, payload)
+      when method == "NumberGen.RandomInRange" or method == "RandomInRange" do
     params = Msgpax.unpack!(payload)
 
     min = max(params["min"], 0)
@@ -11,7 +13,8 @@ defmodule HostCore.Providers.Builtin.Numbergen do
     IO.iodata_to_binary(Msgpax.pack!(Enum.random(min..max)))
   end
 
-  def invoke(method, _payload) when method=="NumberGen.Random32" or method=="RandomRandom32" do
+  def invoke(method, _payload)
+      when method == "NumberGen.Random32" or method == "RandomRandom32" do
     IO.iodata_to_binary(Msgpax.pack!(Enum.random(0..4_294_967_295)))
   end
 end


### PR DESCRIPTION
accept both "Service.Method" and "Method" for invoking methods, e.g., "NumberGen.Random32" and "Random32"

This change allows the host to support new code and is backwards-compatible with old (yesterday's) actors. Once all the interfaces have been regenerated and all the examples updated, we can remove the support for non-prefixed method names.

Signed-off-by: stevelr <steve@cosmonic.com>

