### PR TITLE
Update actions, manual test

### DIFF
--- a/.github/workflows/build_tarballs_manual.yml
+++ b/.github/workflows/build_tarballs_manual.yml
@@ -2,8 +2,6 @@ name: Build Linux and Mac Tarballs
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main]
 
 env:
   working-directory: wasmcloud_host
@@ -278,15 +276,12 @@ jobs:
     - name: Download Release Tarballs
       uses: actions/download-artifact@v2
       with:
-        path: ${{ env.working-directory }}/build
-    
-    - name: Debug
-      run: ls -lahR ${{ env.working-directory }}/build
+        path: ${{ env.working-directory }}/release
 
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        files: ${{ env.working-directory }}/build/**/*.tar.gz
+        files: ${{ env.working-directory }}/release/**/*.tar.gz
         token: ${{ secrets.GITHUB_TOKEN }}
         prerelease: true
         draft: false

--- a/.github/workflows/build_tarballs_manual.yml
+++ b/.github/workflows/build_tarballs_manual.yml
@@ -267,22 +267,3 @@ jobs:
         with:
           name: x86_64-macos
           path: ${{env.working-directory}}/_build/x86_64-macos.tar.gz
-
-
-  github-release:
-    needs: [release-linux, release-macos]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download Release Tarballs
-      uses: actions/download-artifact@v2
-      with:
-        path: ${{ env.working-directory }}/release
-
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: ${{ env.working-directory }}/release/**/*.tar.gz
-        token: ${{ secrets.GITHUB_TOKEN }}
-        prerelease: true
-        draft: false
-        tag_name: build_tarball_manual

--- a/.github/workflows/build_tarballs_manual.yml
+++ b/.github/workflows/build_tarballs_manual.yml
@@ -2,6 +2,8 @@ name: Build Linux and Mac Tarballs
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main]
 
 env:
   working-directory: wasmcloud_host
@@ -84,9 +86,8 @@ jobs:
         continue-on-error: true # Don't fail entire action with dialyzer opportunities for now
         run: mix dialyzer --no-check
 
-  # When event type is release published, also run release workflow
   release-linux:
-    needs: [build]
+    needs: build
     name: Release Linux Tarball and Docker Image
     runs-on: ubuntu-18.04
     env:
@@ -140,10 +141,6 @@ jobs:
             wasmcloud.azurecr.io/build/wasmcloud_host_tarball:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
             wasmcloud_host:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
 
-      - name: Inspect
-        run: |
-          docker image ls -a
-          
       - name: Build and release image
         uses: docker/build-push-action@v2
         with:
@@ -170,16 +167,15 @@ jobs:
         run: |
           make tarball-x86_64-linux-gnu
 
-      # Currently just attached to the action output, should be in the Release assets
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: wasmcloud_host-v${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
+          name: x86_64-linux-gnu
           path: ${{env.working-directory}}/rel/artifacts/wasmcloud_host/${{ env.wasmcloud_host_version }}/x86_64-linux-gnu.tar.gz
 
   release-macos:
     name: Release MacOS Tarball
-    needs: [build]
+    needs: build
     runs-on: macos-10.15
     env:
       MIX_ENV: prod
@@ -263,9 +259,35 @@ jobs:
         run: |
           mix distillery.release --verbose
 
-      # Currently just attached to the action output, should be in the Release assets
+      # It's currently output as `wasmcloud_host.tar.gz`, but we want it to be indicative of the ARCH-OS pair
+      - name: Rename release for Upload
+        run: |
+          mv ${{env.working-directory}}/_build/prod/rel/wasmcloud_host/releases/${{ env.wasmcloud_host_version }}/wasmcloud_host.tar.gz ${{env.working-directory}}/_build/x86_64-macos.tar.gz
+
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: wasmcloud_host-v${{ env.wasmcloud_host_version }}-x86_64-macos
-          path: ${{env.working-directory}}/_build/prod/rel/wasmcloud_host/releases/${{ env.wasmcloud_host_version }}/wasmcloud_host.tar.gz
+          name: x86_64-macos
+          path: ${{env.working-directory}}/_build/x86_64-macos.tar.gz
+
+
+  github-release:
+    needs: [release-linux, release-macos]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download Release Tarballs
+      uses: actions/download-artifact@v2
+      with:
+        path: ${{ env.working-directory }}/build
+    
+    - name: Debug
+      run: ls -lahR ${{ env.working-directory }}/build
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ${{ env.working-directory }}/build/**/*.tar.gz
+        token: ${{ secrets.GITHUB_TOKEN }}
+        prerelease: true
+        draft: false
+        tag_name: build_tarball_manual

--- a/.github/workflows/host_core.yml
+++ b/.github/workflows/host_core.yml
@@ -28,11 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2      
       
-      - name: Install and Run NATS
-        run: |
-          curl -L https://github.com/nats-io/nats-server/releases/download/v2.3.4/nats-server-v2.3.4-linux-amd64.zip -o nats-server.zip
-          unzip nats-server.zip -d nats-server
-          ./nats-server/nats-server-v2.3.4-linux-amd64/nats-server -js &
+      - id: run-nats
+        uses: wasmcloud/common-actions/run-nats@main
+        with:
+          options: '-js'
 
       - name: Setup elixir
         uses: actions/setup-elixir@v1

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -89,8 +89,8 @@ jobs:
 
   # When event type is release published, also run release workflow
   release-linux:
-    needs: [build]
-    if: github.event.payload.ref_type == 'tag' # Triggers on tag push only
+    needs: build
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     name: Release Linux Tarball and Docker Image
     runs-on: ubuntu-18.04
     env:
@@ -144,10 +144,6 @@ jobs:
             wasmcloud.azurecr.io/build/wasmcloud_host_tarball:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
             wasmcloud_host:${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
 
-      - name: Inspect
-        run: |
-          docker image ls -a
-          
       - name: Build and release image
         uses: docker/build-push-action@v2
         with:
@@ -180,11 +176,10 @@ jobs:
           name: wasmcloud_host-v${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
           path: ${{env.working-directory}}/rel/artifacts/wasmcloud_host/${{ env.wasmcloud_host_version }}/x86_64-linux-gnu.tar.gz
 
-
   release-macos:
     name: Release MacOS Tarball
-    needs: [build]
-    if: github.event.payload.ref_type == 'tag' # Triggers on tag push only
+    needs: build
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: macos-10.15
     env:
       MIX_ENV: prod
@@ -274,3 +269,21 @@ jobs:
         with:
           name: wasmcloud_host-v${{ env.wasmcloud_host_version }}-x86_64-macos
           path: ${{env.working-directory}}/_build/prod/rel/wasmcloud_host/releases/${{ env.wasmcloud_host_version }}/wasmcloud_host.tar.gz
+
+  github-release:
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    needs: [release-linux, release-macos]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download Release Tarballs
+      uses: actions/download-artifact@v2
+      with:
+        path: tarballs
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: tarballs/*.tar.gz
+        token: ${{ secrets.GITHUB_TOKEN }}
+        prerelease: true
+        draft: false

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: wasmcloud_host-v${{ env.wasmcloud_host_version }}-x86_64-linux-gnu
+          name: x86_64-linux-gnu
           path: ${{env.working-directory}}/rel/artifacts/wasmcloud_host/${{ env.wasmcloud_host_version }}/x86_64-linux-gnu.tar.gz
 
   release-macos:
@@ -263,27 +263,31 @@ jobs:
         run: |
           mix distillery.release --verbose
 
-      # Currently just attached to the action output, should be in the Release assets
+      # It's currently output as `wasmcloud_host.tar.gz`, but we want it to be indicative of the ARCH-OS pair
+      - name: Rename release for Upload
+        run: |
+          mv ${{env.working-directory}}/_build/prod/rel/wasmcloud_host/releases/${{ env.wasmcloud_host_version }}/wasmcloud_host.tar.gz ${{env.working-directory}}/_build/x86_64-macos.tar.gz
+
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: wasmcloud_host-v${{ env.wasmcloud_host_version }}-x86_64-macos
-          path: ${{env.working-directory}}/_build/prod/rel/wasmcloud_host/releases/${{ env.wasmcloud_host_version }}/wasmcloud_host.tar.gz
+          name: x86_64-macos
+          path: ${{env.working-directory}}/_build/x86_64-macos.tar.gz
 
   github-release:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     needs: [release-linux, release-macos]
     runs-on: ubuntu-latest
-    steps:
     - name: Download Release Tarballs
       uses: actions/download-artifact@v2
       with:
-        path: tarballs
+        path: ${{ env.working-directory }}/release
 
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        files: tarballs/*.tar.gz
+        files: ${{ env.working-directory }}/release/**/*.tar.gz
         token: ${{ secrets.GITHUB_TOKEN }}
-        prerelease: true
+        prerelease: false
         draft: false
+

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -278,6 +278,7 @@ jobs:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     needs: [release-linux, release-macos]
     runs-on: ubuntu-latest
+    steps:
     - name: Download Release Tarballs
       uses: actions/download-artifact@v2
       with:


### PR DESCRIPTION
This PR is going to run and create a Release that should include the macos and linux tarballs. Once that's verified as working well I'll delete that, revert the manual build to a workflow trigger, and prepare the other 2 actions for our actual release.

EDIT: I've gone through some iteration with this action and verified that now, when we create and push a tag, we will create a release with the name of the tag and the `x86_64-linux-gnu.tar.gz` and `x86_64-macos.tar.gz` artifacts will be attached to that release 🎉 . We can always do the same thing with the manual build action as well, but I've removed the ability to create a release from the manual build action as I don't want test artifacts mucking up the releases page. The artifacts can be found on the `build_tarball_action` page still.