### PR TITLE
Correct test OCI references

### DIFF
--- a/host_core/test/host_core/providers_test.exs
+++ b/host_core/test/host_core/providers_test.exs
@@ -4,7 +4,7 @@ defmodule HostCore.ProvidersTest do
   @httpserver_path "test/fixtures/providers/httpserver.par.gz"
   @httpserver_key "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M"
   @httpserver_link "default"
-  @httpserver_oci "wasmcloud.azurecr.io/httpserver-test:0.13.1"
+  @httpserver_oci "wasmcloud.azurecr.io/httpserver:0.13.1"
 
   test "can load provider from file" do
     {:ok, _pid} =

--- a/host_core/test/host_core/wasmcloud/native_test.exs
+++ b/host_core/test/host_core/wasmcloud/native_test.exs
@@ -2,7 +2,7 @@ defmodule HostCore.WasmCloud.NativeTest do
   @httpserver_key "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M"
   @httpserver_link "default"
   @httpserver_contract "wasmcloud:httpserver"
-  @httpserver_oci "wasmcloud.azurecr.io/httpserver-test:0.13.0"
+  @httpserver_oci "wasmcloud.azurecr.io/httpserver:0.13.1"
   @official_issuer "ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW"
   @httpserver_vendor "wasmCloud"
 
@@ -21,13 +21,13 @@ defmodule HostCore.WasmCloud.NativeTest do
     target_bytes =
       case :os.type() do
         {:unix, :darwin} ->
-          7_823_168
+          7_827_360
 
         {:unix, _linux} ->
-          7_912_517
+          7_916_857
 
         {:win32, :nt} ->
-          7_867_904
+          7_875_072
       end
 
     assert byte_size(par.target_bytes |> IO.iodata_to_binary()) == target_bytes


### PR DESCRIPTION
I was cleaning out some old azurecr references including the `httpserver-test` asset which I thought we weren't using anymore, turns out we were still using it for tests.

I think in the future it's not necessary to clean out old references and we should keep it read-only, that was my mistake. I think we should be testing against our actual providers regardless.