### PR TITLE
remove code to allow method names without prefix in builtin providers

### DIFF
--- a/host_core/lib/host_core/providers/builtin/logging.ex
+++ b/host_core/lib/host_core/providers/builtin/logging.ex
@@ -1,7 +1,7 @@
 defmodule HostCore.Providers.Builtin.Logging do
   require Logger
 
-  def invoke(actor, method, payload) when method in ["Logging.WriteLog", "WriteLog"] do
+  def invoke(actor, "Logging.WriteLog", payload) do
     msg = Msgpax.unpack!(payload)
     text = "[#{actor}] #{msg["text"]}"
 

--- a/host_core/lib/host_core/providers/builtin/numbergen.ex
+++ b/host_core/lib/host_core/providers/builtin/numbergen.ex
@@ -1,11 +1,9 @@
 defmodule HostCore.Providers.Builtin.Numbergen do
-  def invoke(method, _payload)
-      when method in ["NumberGen.GenerateGuid", "GenerateGuid"] do
+  def invoke("NumberGen.GenerateGuid", _payload) do
     IO.iodata_to_binary(Msgpax.pack!(UUID.uuid4()))
   end
 
-  def invoke(method, payload)
-      when method in ["NumberGen.RandomInRange", "RandomInRange"] do
+  def invoke("NumberGen.RandomInRange", payload) do
     params = Msgpax.unpack!(payload)
 
     min = max(params["min"], 0)
@@ -13,8 +11,7 @@ defmodule HostCore.Providers.Builtin.Numbergen do
     IO.iodata_to_binary(Msgpax.pack!(Enum.random(min..max)))
   end
 
-  def invoke(method, _payload)
-      when method in ["NumberGen.Random32", "Random32"] do
+  def invoke("NumberGen.Random32", _payload) do
     IO.iodata_to_binary(Msgpax.pack!(Enum.random(0..4_294_967_295)))
   end
 end


### PR DESCRIPTION
The acceptance of both format method names was intended to be temporary. All the actors have been updated to use the prefix. Tested with builtins test actor.

Signed-off-by: stevelr <steve@cosmonic.com>