### PR TITLE
Replace zero revision with iat value

### DIFF
--- a/host_core/native/hostcore_wasmcloud_native/src/inv.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/inv.rs
@@ -14,7 +14,9 @@ use wascap::prelude::{Claims, KeyPair};
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 pub(crate) const URL_SCHEME: &str = "wasmbus";
+#[allow(unused)]
 pub(crate) const SYSTEM_ACTOR: &str = "system";
+#[allow(unused)]
 pub(crate) const OP_HALT: &str = "__halt";
 
 /// An immutable representation of an invocation within wasmcloud
@@ -95,6 +97,7 @@ impl Invocation {
     /// has both an origin and a target of SYSTEM_ACTOR. This has a net effect of making this invocation unroutable
     /// across a lattice, and therefore can only be produced internally. In other words, a remote host can't fabricate
     /// a halt invocation and send it to a provider or actor
+    #[allow(unused)]
     pub fn halt(hostkey: &KeyPair) -> Invocation {
         let subject = format!("{}", Uuid::new_v4());
         let issuer = hostkey.public_key();
@@ -210,6 +213,7 @@ impl WasmCloudEntity {
     }
 
     /// The unique (public) key of the entity
+    #[allow(unused)]
     pub fn key(&self) -> String {
         self.public_key.to_string()
     }
@@ -253,6 +257,7 @@ pub enum ReferenceType {
 }
 
 impl LinkDefinition {
+    #[allow(unused)]
     pub fn new(
         actor: &str,
         provider: &str,

--- a/host_core/native/hostcore_wasmcloud_native/src/oci.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/oci.rs
@@ -1,4 +1,3 @@
-use provider_archive::ProviderArchive;
 use std::env::temp_dir;
 use std::io::{Read, Write};
 use std::path::PathBuf;

--- a/host_core/native/hostcore_wasmcloud_native/src/par.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/par.rs
@@ -1,9 +1,8 @@
 use crate::{Claims, ProviderArchiveResource};
 
 use provider_archive::ProviderArchive;
-use rustler::{Binary, Env, Error, ResourceArc};
+use rustler::{Env, Error};
 use std::env::temp_dir;
-use wascap::jwt::CapabilityProvider;
 
 pub fn on_load(env: Env) -> bool {
     rustler::resource!(ProviderArchiveResource, env);
@@ -28,10 +27,11 @@ pub(crate) fn extract_claims(par: &ProviderArchive) -> Result<Claims, Error> {
     match par.claims() {
         Some(c) => {
             let metadata = c.metadata.unwrap_or_default();
+            let revision = crate::revision_or_iat(metadata.rev, c.issued_at);
             Ok(crate::Claims {
                 issuer: c.issuer,
                 public_key: c.subject,
-                revision: metadata.rev,
+                revision,
                 tags: None,
                 version: metadata.ver,
                 name: metadata.name,

--- a/host_core/test/host_core/wasmcloud/native_test.exs
+++ b/host_core/test/host_core/wasmcloud/native_test.exs
@@ -1,4 +1,10 @@
 defmodule HostCore.WasmCloud.NativeTest do
+  @kvcounter_oci HostCoreTest.Constants.kvcounter_ociref()
+  @kvcounter_key HostCoreTest.Constants.kvcounter_key()
+  @echo_oci HostCoreTest.Constants.echo_ociref()
+  @echo_key HostCoreTest.Constants.echo_key()
+  @httpserver_zero_revision_oci "wasmcloud.azurecr.io/httpserver:0.14.0"
+
   @httpserver_key HostCoreTest.Constants.httpserver_key()
   @httpserver_link HostCoreTest.Constants.default_link()
   @httpserver_contract HostCoreTest.Constants.httpserver_contract()
@@ -111,5 +117,31 @@ defmodule HostCore.WasmCloud.NativeTest do
     assert res ==
              {:error,
               "Validation of invocation/AF token failed: Issuer of this invocation is not among the list of valid issuers"}
+  end
+
+  test "missing or zero revision is replaced with iat" do
+    {:ok, bytes} = HostCore.WasmCloud.Native.get_oci_bytes(@echo_oci, false, [])
+    bytes = bytes |> IO.iodata_to_binary()
+    {:ok, claims} = HostCore.WasmCloud.Native.extract_claims(bytes)
+    assert claims.public_key == @echo_key
+    assert claims.issuer == @official_issuer
+    assert claims.revision == 4
+
+    {:ok, bytes} =
+      HostCore.WasmCloud.Native.get_oci_bytes(@httpserver_zero_revision_oci, false, [])
+
+    bytes = bytes |> IO.iodata_to_binary()
+    {:ok, par} = HostCore.WasmCloud.Native.ProviderArchive.from_bytes(bytes)
+
+    assert par.claims.public_key == @httpserver_key
+    assert par.claims.issuer == @official_issuer
+    assert par.claims.revision == 1_631_292_694
+
+    {:ok, bytes} = HostCore.WasmCloud.Native.get_oci_bytes(@kvcounter_oci, false, [])
+    bytes = bytes |> IO.iodata_to_binary()
+    {:ok, claims} = HostCore.WasmCloud.Native.extract_claims(bytes)
+    assert claims.public_key == @kvcounter_key
+    assert claims.issuer == @official_issuer
+    assert claims.revision == 1_631_625_045
   end
 end

--- a/host_core/test/support/constants.exs
+++ b/host_core/test/support/constants.exs
@@ -5,6 +5,7 @@ defmodule HostCoreTest.Constants do
   @echo_ociref_updated "wasmcloud.azurecr.io/echo:0.3.1-liveupdate"
   @echo_path "test/fixtures/actors/echo.wasm"
   @kvcounter_key "MCFMFDWFHGKELOXPCNCDXKK5OFLHBVEWRAOXR5JSQUD2TOFRE3DFPM7E"
+  @kvcounter_ociref "wasmcloud.azurecr.io/kvcounter:0.3.0"
   @kvcounter_path "test/fixtures/actors/kvcounter.wasm"
   @kvcounter_unpriv_key "MBW3UGAIONCX3RIDDUGDCQIRGBQQOWS643CVICQ5EZ7SWNQPZLZTSQKU"
   @kvcounter_unpriv_path "test/fixtures/actors/kvcounter_unpriv_s.wasm"
@@ -31,6 +32,7 @@ defmodule HostCoreTest.Constants do
   def echo_ociref, do: @echo_ociref
   def echo_ociref_updated, do: @echo_ociref_updated
   def kvcounter_key, do: @kvcounter_key
+  def kvcounter_ociref, do: @kvcounter_ociref
   def kvcounter_path, do: @kvcounter_path
   def kvcounter_unpriv_key, do: @kvcounter_unpriv_key
   def kvcounter_unpriv_path, do: @kvcounter_unpriv_path


### PR DESCRIPTION
Fixes #208 

This PR implements replacing zero or None revision values with the `iat` field on the jwt.

Just a note, the `iat` is implemented as a `u64` integer, while the revision is currently an `i32`. This will cause all wasmCloud actors and providers with a `0` or `None` revision to be unable to load at exactly GMT: Tuesday, January 19, 2038 3:14:07 AM. This is not _that_ far into the future, and we should consider switching revision at least to an `i64`, though I wanted to get thoughts on this before making that change.

I also added some clippy things to reduce the warning output when we compile.

Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>