### PR TITLE
Add support for compilation on Arm Mac

### DIFF
--- a/host_core/Makefile
+++ b/host_core/Makefile
@@ -9,6 +9,8 @@ ARCH ?= x86_64
 TARGET ?= unknown-linux-gnu
 ifeq ($(UNAME_ARCH), aarch64)
 ARCH = aarch64
+else ifeq ($(UNAME_ARCH), arm)
+ARCH = aarch64
 endif
 ifeq ($(UNAME), Darwin)
 TARGET = apple-darwin

--- a/host_core/native/hostcore_wasmcloud_native/.cargo/config
+++ b/host_core/native/hostcore_wasmcloud_native/.cargo/config
@@ -3,3 +3,9 @@ rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
These are fixes for some errors I ran into while trying to compile this
locally on an Arm Mac.

The change to the Makefile is because `uname -p` on an M1 Mac returns
`arm`, not `aarch64`. We still want this to set the `ARCH` variable to
`aarch64`.

The addition to the .cargo/config ensures that the same rustflags that
are being passed for x86_64 are also passed when compiling for the
aarch64 target. Without this there are linking errors in the `make
wasmcloud-nif` step that look like:

    error: linking with `cc` failed: exit status: 1
    .
    .
    .
    ld: symbol(s) not found for architecture arm64
    clang: error: linker command failed with exit code 1 (use -v to see invocation)

---

Hi wasmCloud! 

In attempting to compile wasmcloud-otp locally (following the steps in `.github/workflows/wasmcloud_host.yml:release_macos`) on an M1, I ran into some errors and managed to get past them using these fixes. I was wondering if any of you had attempted the same and got the same/different fixes?

Thanks!