### PR TITLE
updated provider RPC host default to 127.0.0.1

### DIFF
--- a/host_core/lib/host_core/config_plan.ex
+++ b/host_core/lib/host_core/config_plan.ex
@@ -28,7 +28,7 @@ defmodule HostCore.ConfigPlan do
           {:rpc_timeout, "WASMCLOUD_RPC_TIMEOUT_MS", default: 2000, map: &String.to_integer/1},
           {:rpc_jwt, "WASMCLOUD_RPC_JWT", default: ""},
           {:rpc_tls, "WASMCLOUD_RPC_TLS", default: 0, map: &String.to_integer/1},
-          {:prov_rpc_host, "WASMCLOUD_PROV_RPC_HOST", default: "0.0.0.0"},
+          {:prov_rpc_host, "WASMCLOUD_PROV_RPC_HOST", default: "127.0.0.1"},
           {:prov_rpc_port, "WASMCLOUD_PROV_RPC_PORT", default: 4222, map: &String.to_integer/1},
           {:prov_rpc_seed, "WASMCLOUD_PROV_RPC_SEED", default: ""},
           {:prov_rpc_tls, "WASMCLOUD_PROV_RPC_TLS", default: 0, map: &String.to_integer/1},


### PR DESCRIPTION
In a previous PR we updated the RPC and CTL defaults to `127.0.0.1` to properly resolve localhost, this simply does the same thing to `WASMCLOUD_PROV_RPC_HOST`