### PR TITLE
README badges, add prerequisites sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
+![wasmCloud logo](https://raw.githubusercontent.com/wasmCloud/branding/main/02.Horizontal%20Version/Pixel/PNG/Wasmcloud.Logo-Hrztl_Color.png)
+
+[![wasmcloud_host build status](https://img.shields.io/github/workflow/status/wasmcloud/wasmcloud-otp/WasmcloudHost%20Elixir%20CI)](https://github.com/wasmCloud/wasmcloud-otp/actions/workflows/wasmcloud_host.yml)
+[![latest release](https://img.shields.io/github/v/release/wasmcloud/wasmcloud-otp?include_prereleases)](https://github.com/wasmCloud/wasmcloud-otp/releases)
+[![homepage](https://img.shields.io/website?label=homepage&url=https%3A%2F%2Fwasmcloud.com)](https://wasmcloud.com)
+[![documentation site](https://img.shields.io/website?label=documentation&url=https%3A%2F%2Fwasmcloud.dev)](https://wasmcloud.dev)
+
 # wasmCloud Host Runtime (OTP)
+
 The wasmCloud Host Runtime is a server process that securely hosts and provides dispatch for [actors](https://wasmcloud.dev/reference/host-runtime/actors/) and [capability providers](https://wasmcloud.dev/reference/host-runtime/capabilities/). This runtime is designed to take advantage of WebAssembly's small footprint, secure sandbox, speed, and portability to allow developers to write boilerplate-free code that embraces the [actor model](https://en.wikipedia.org/wiki/Actor_model) and abstracts away dependencies on [non-functional requirements](https://www.scaledagileframework.com/nonfunctional-requirements/) via well-defined [interfaces](https://github.com/wasmCloud/interfaces/).
 
 This host runtime is written in Elixir and extensively leverages the decades of work, testing, and improvements that have gone into the **OTP** framework. There are a number of excellent Elixir and OTP references online, but we highly recommend starting with the [Pragmatic Programmers](https://pragprog.com/categories/elixir-phoenix-and-otp/) Elixir and OTP library of books.
@@ -7,18 +15,21 @@ To get started with installation and exploration, check out the [getting started
 
 The wasmCloud Host Runtime is made up of two pieces:
 
-* The Host Core
-* Dashboard Web UI
+- The Host Core
+- Dashboard Web UI
 
 ## Host Core
+
 The **host core** consists of all of the "headless" (no UI) functional components of the system. This OTP application and its contained supervision tree represent the _core_ of the wasmCloud OTP host runtime.
 
 You can find the [host core](./host_core/README.md) in this github repository.
 
 ## Dashboard Web UI
+
 The dashboard web UI (often colloquially referred to as the _washboard_) is a **Phoenix** application that fits snugly atop the host core, providing real-time web access to a variety of information, telemetry, and insight while also exposing a graphical interface to controlling the host and portions of the lattice.
 
 You can find the [dashboard UI](./wasmcloud_host/README.md) in this github repository.
 
 ### NATS
-All of wasmCloud's _lattice_ functionality requires the use of [NATS](https://nats.io).
+
+All of wasmCloud's _lattice_ functionality requires the use of [NATS](https://nats.io). To learn more, check out the [lattice](https://wasmcloud.dev/reference/lattice/) section of our documentation.

--- a/host_core/README.md
+++ b/host_core/README.md
@@ -1,7 +1,16 @@
+[![host_core build status](https://img.shields.io/github/workflow/status/wasmcloud/wasmcloud-otp/HostCore%20Elixir%20CI)](https://github.com/wasmCloud/wasmcloud-otp/actions/workflows/host_core.yml)
+
 # wasmCloud Host Core
+
 This is the Elixir OTP core or _functional engine_ of the server process.
 
 The use of the [Makefile](./Makefile) is preferred for building and running this project due to its NIF dependencies. Use the respective `make build` and `make run` options to build and run `host_core`.
+
+## Prerequisites
+
+- [Elixir installation](https://elixir-lang.org/install.html), minimum `v1.12.0`
+- [Erlang/OTP installation](https://elixir-lang.org/install.html#installing-erlang), minimum `OTP 22`
+- [NATS installation](https://docs.nats.io/nats-server/installation), minimum `v2.3.4`
 
 ## Installation and Running
 
@@ -11,7 +20,7 @@ If instead you prefer to work from the production release, then consult our [ins
 
 ### NATS
 
-This OTP application requires the use of NATS with the JetStream server enabled (**v2.3.4** or later). Thankfully JetStream comes built-in to all NATS servers and you can simply launch your server with the `-js` or `--jetstream` flag. 
+This OTP application requires the use of NATS with the JetStream server enabled (**v2.3.4** or later). Thankfully JetStream comes built-in to all NATS servers and you can simply launch your server with the `-js` or `--jetstream` flag.
 
 This OTP application will _fail to start_ without a running NATS server.
 

--- a/wasmcloud_host/Makefile
+++ b/wasmcloud_host/Makefile
@@ -46,6 +46,7 @@ wasmex-nif: ## Build wasmex native NIF
 
 build: deps ## Build wasmcloud_host for development
 	mix compile
+	npm --prefix ./assets install ./assets
 
 run: build ## Run development wasmcloud_host
 	mix phx.server

--- a/wasmcloud_host/README.md
+++ b/wasmcloud_host/README.md
@@ -1,20 +1,37 @@
+[![wasmcloud_host build status](https://img.shields.io/github/workflow/status/wasmcloud/wasmcloud-otp/WasmcloudHost%20Elixir%20CI)](https://github.com/wasmCloud/wasmcloud-otp/actions/workflows/wasmcloud_host.yml)
+
 # wasmCloud Host - Web UI Dashboard
+
 This is the web UI dashboard that provides for a basic way to interact with a host and its associated lattice. This web application automatically starts the [host_core](../host_core/README.md) application as a dependency.
+
+## Prerequisites
+
+- [Elixir installation](https://elixir-lang.org/install.html), minimum `v1.12.0`
+- [Erlang/OTP installation](https://elixir-lang.org/install.html#installing-erlang), minimum `OTP 22`
+- [NATS installation](https://docs.nats.io/nats-server/installation), minimum `v2.3.4`
+- [Node/NPM installation](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), recommended node `14`
 
 ## Starting the Host and Web UI Dashboard
 
 To start the wasmCloud host and web ui, cd to this folder (wasmcloud_host), and type or paste these commands:
+
 ```
+# start NATS in the background
+nats-server -js &
+
 # install dependencies
 mix deps.get
-cd assets; npm install
-# return to this folder and start the host
-cd ..
+npm --prefix ./assets install ./assets
+
+# start the host
 mix phx.server
 ```
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser. If you want to use a different HTTP port for the dashboard, set the environment variable PORT, for example, 
 
-```PORT=8000 mix phx.server```
+Alternatively, you can simply start NATS as shown above and run `make run` to perform the above steps and run the dashboard.
+
+Now you can visit [`localhost:4000`](http://localhost:4000) from your browser. If you want to use a different HTTP port for the dashboard, set the environment variable PORT, for example,
+
+`PORT=8000 mix phx.server`
 
 If you later update the source from github, you'll need to re-run the set of commands above.
 


### PR DESCRIPTION
Fixes #247 
Fixes #209 

Our READMEs needed a bit of spicing up, I added our logo, some README badges, and prerequisites required to run `host_core` and `wasmcloud_host`. 

Happy to add more badges for anything that's useful at this point, or if there's not enough information in them ATM we can wait until we can add code coverage analysis, contributor information, etc.