### PR TITLE
Write configuration file regardless if it exists

### DIFF
--- a/host_core/lib/host_core.ex
+++ b/host_core/lib/host_core.ex
@@ -158,11 +158,9 @@ defmodule HostCore do
   end
 
   defp write_json(config, file) do
-    if !File.exists?(file) do
-      case File.write(file, Jason.encode!(remove_extras(config))) do
-        {:error, reason} -> Logger.error("Failed to write configuration file #{reason}")
-        :ok -> Logger.info("Wrote #{inspect(file)}")
-      end
+    case File.write(file, Jason.encode!(remove_extras(config))) do
+      {:error, reason} -> Logger.error("Failed to write configuration file #{reason}")
+      :ok -> Logger.info("Wrote #{inspect(file)}")
     end
   end
 


### PR DESCRIPTION
My reasoning for this is two-pronged:
1. If you are setting multiple environment variables to configure a host, it's likely that you'll want to persist those for the next time that you close your shell and start up another host. In the case that this is a production machine, and you want to avoid storing sensitive information in a file on disk, you'd have to ensure this file has been created _first_ and then set those variables according to the current logic.
2. With the presence of `host_config.json` and `~/.wash/host_config.json`, those two files should be identical to avoid confusion. If these files are only written when they don't exist, changes in the `host_config.json` relative to the host will not be reflected in `~/.wash/host_config.json` unless it's manually removed.

I sought out this solution initially because of the `wash ctx` feature, and my desire to use `~/.wash/host_config.json`'s configuration values for the default context. I think that this is a better approach regardless, and figured I'd go ahead and PR it and we can conversate here if necessary.