### PR TITLE
feat(tests): Use the same testing in the pipeline and makefile

### DIFF
--- a/.github/workflows/host_core.yml
+++ b/.github/workflows/host_core.yml
@@ -16,22 +16,12 @@ jobs:
       matrix:
         elixir: [1.12.1]
         otp: [22.0, 23.0, 23.3.4.1, 24.0]
-    services:
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
 
     name: Build and test
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions/checkout@v2      
-      
-      - id: run-nats
-        uses: wasmcloud/common-actions/run-nats@main
-        with:
-          options: '-js'
+      - uses: actions/checkout@v2
 
       - name: Setup elixir
         uses: actions/setup-elixir@v1
@@ -67,9 +57,11 @@ jobs:
 
       - name: Run Tests
         working-directory: ${{env.working-directory}}
+        env:
+          EXTRA_TEST_ARGS: "--timeout 120000"
         run: |
           WASMCLOUD_LATTICE_PREFIX=$(echo "${{ runner.os }}__${{ matrix.otp }}__${{ matrix.elixir }}__${{ env.working-directory }}" | sed 's/\./_/g') \
-          mix test --timeout 120000
+          make test
 
       - name: Retrieve PLT Cache
         uses: actions/cache@v2

--- a/host_core/Makefile
+++ b/host_core/Makefile
@@ -19,6 +19,8 @@ ifeq ($(UNAME), Windows_NT)
 TARGET = pc-windows-gnu
 endif
 
+EXTRA_TEST_ARGS ?=
+
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_\-.*]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
@@ -37,7 +39,7 @@ run-interactive: build ## Run host_core with an iex session
 
 test: build ## Run test suite, launch NATS with docker-compose
 	docker-compose -f ./test/docker-compose.yml up --detach
-	MIX_ENV=test mix test
+	MIX_ENV=test mix test $(EXTRA_TEST_ARGS)
 	docker-compose -f ./test/docker-compose.yml down
 
 wasmcloud-nif: ## Build wasmcloud native NIF

--- a/host_core/test/docker-compose.yml
+++ b/host_core/test/docker-compose.yml
@@ -1,9 +1,13 @@
 version: "3"
 services:
   nats:
-    image: nats:2.3.4
+    image: nats:2
     command: "-js"
     ports:
       - "4222:4222"
       - "6222:6222"
       - "8222:8222"
+  redis:
+    image: redis:6.2.4
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
Before this change, we were setting up a redis server only as part of the pipeline
while simultaneously using a docker compose file to get NATS. It is much
easier if the developer and the pipeline use the same targets. So this moves
redis to the docker compose file used for the test and removes it from the pipeline