### PR TITLE
fix(host_core): Fixes key lookup

### DIFF
--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -212,7 +212,7 @@ defmodule HostCore.ControlInterface.Server do
       # hooks: https://github.com/botsquad/graceful_stop.
       {:ok, stop_host_command} ->
         Logger.info("Received stop request for host")
-        Process.send_after(HostCore.Host, {:do_stop, stop_host_command.timeout}, 100)
+        Process.send_after(HostCore.Host, {:do_stop, stop_host_command["timeout"]}, 100)
         {:reply, success_ack()}
 
       {:error, e} ->


### PR DESCRIPTION
Looking up with the atom was giving a `KeyError`. This changes things to
use a string map key