### PR TITLE
[feat] Delete link definitions in Washboard UI

### DIFF
--- a/wasmcloud_host/lib/wasmcloud_host/lattice/control_interface.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/lattice/control_interface.ex
@@ -125,6 +125,39 @@ defmodule WasmcloudHost.Lattice.ControlInterface do
     end
   end
 
+  def put_linkdef(
+        actor_id,
+        contract_id,
+        link_name,
+        provider_id,
+        values
+      ) do
+    topic = "#{@wasmbus_prefix}#{HostCore.Host.lattice_prefix()}.linkdefs.put"
+
+    payload =
+      Jason.encode!(%{
+        "actor_id" => actor_id,
+        "contract_id" => contract_id,
+        "link_name" => link_name,
+        "provider_id" => provider_id,
+        "values" => values
+      })
+
+    case ctl_request(topic, payload, 2_000) do
+      {:ok, %{body: body}} ->
+        resp = Jason.decode!(body)
+
+        if Map.get(resp, "accepted", false) do
+          :ok
+        else
+          {:error, Map.get(resp, "error", "")}
+        end
+
+      {:error, :timeout} ->
+        {:error, "Request to stop provider timed out"}
+    end
+  end
+
   def delete_linkdef(actor_id, contract_id, link_name) do
     topic = "#{@wasmbus_prefix}#{HostCore.Host.lattice_prefix()}.linkdefs.del"
 

--- a/wasmcloud_host/lib/wasmcloud_host/lattice/control_interface.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/lattice/control_interface.ex
@@ -125,6 +125,31 @@ defmodule WasmcloudHost.Lattice.ControlInterface do
     end
   end
 
+  def delete_linkdef(actor_id, contract_id, link_name) do
+    topic = "#{@wasmbus_prefix}#{HostCore.Host.lattice_prefix()}.linkdefs.del"
+
+    payload =
+      Jason.encode!(%{
+        "actor_id" => actor_id,
+        "contract_id" => contract_id,
+        "link_name" => link_name
+      })
+
+    case ctl_request(topic, payload, 2_000) do
+      {:ok, %{body: body}} ->
+        resp = Jason.decode!(body)
+
+        if Map.get(resp, "accepted", false) do
+          :ok
+        else
+          {:error, Map.get(resp, "error", "")}
+        end
+
+      {:error, :timeout} ->
+        {:error, "Request to stop provider timed out"}
+    end
+  end
+
   defp ctl_request(topic, payload, timeout) do
     Gnat.request(:control_nats, topic, payload, request_timeout: timeout)
   end

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/define_link_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/define_link_component.ex
@@ -47,7 +47,7 @@ defmodule DefineLinkComponent do
           "Please select a Provider ID to link"
 
         true ->
-          case HostCore.Linkdefs.Manager.put_link_definition(
+          case WasmcloudHost.Lattice.ControlInterface.put_linkdef(
                  actor_id,
                  contract_id,
                  link_name,

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/link_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/link_row_component.ex
@@ -1,6 +1,15 @@
 defmodule LinkRowComponent do
   use Phoenix.LiveComponent
 
+  def handle_event(
+        "delete_linkdef",
+        %{"actor_id" => actor_id, "contract_id" => contract_id, "link_name" => link_name},
+        socket
+      ) do
+    WasmcloudHost.Lattice.ControlInterface.delete_linkdef(actor_id, contract_id, link_name)
+    {:noreply, socket}
+  end
+
   def mount(socket) do
     {:ok, socket}
   end
@@ -25,6 +34,17 @@ defmodule LinkRowComponent do
           <%= String.slice(@provider_key, 0..4) %>...
           <svg class="c-icon">
             <use xlink:href="/coreui/free.svg#cil-copy"></use>
+          </svg>
+        </button>
+      </td>
+      <td>
+
+    <button class="btn btn-sm btn-danger" id="delete_linkdef_<%= @actor_id %>_<%= @link_name %>_<%= @contract_id %>"
+    data-toggle="tooltip" data-placement="top" title data-original-title="Delete Linkdef" phx-target="<%= @myself %>"
+    phx-click="delete_linkdef" phx-value-contract_id="<%= @contract_id %>" phx-value-link_name="<%= @link_name %>"
+    phx-value-actor_id="<%= @actor_id %>">
+          <svg class="c-icon" style="color: white">
+            <use xlink:href="/coreui/free.svg#cil-trash"></use>
           </svg>
         </button>
       </td>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/link_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/link_row_component.ex
@@ -38,11 +38,10 @@ defmodule LinkRowComponent do
         </button>
       </td>
       <td>
-
-    <button class="btn btn-sm btn-danger" id="delete_linkdef_<%= @actor_id %>_<%= @link_name %>_<%= @contract_id %>"
-    data-toggle="tooltip" data-placement="top" title data-original-title="Delete Linkdef" phx-target="<%= @myself %>"
-    phx-click="delete_linkdef" phx-value-contract_id="<%= @contract_id %>" phx-value-link_name="<%= @link_name %>"
-    phx-value-actor_id="<%= @actor_id %>">
+        <button class="btn btn-sm btn-danger" id="delete_linkdef_<%= @actor_id %>_<%= @link_name %>_<%= @contract_id %>"
+          data-toggle="tooltip" data-placement="top" title data-original-title="Delete Linkdef" phx-target="<%= @myself %>"
+          phx-click="delete_linkdef" phx-value-contract_id="<%= @contract_id %>" phx-value-link_name="<%= @link_name %>"
+          phx-value-actor_id="<%= @actor_id %>">
           <svg class="c-icon" style="color: white">
             <use xlink:href="/coreui/free.svg#cil-trash"></use>
           </svg>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.heex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.heex
@@ -172,11 +172,12 @@
                               <th>Contract ID</th>
                               <th>Actor ID</th>
                               <th>Provider ID</th>
+                              <th>Actions</th>
                            </tr>
                         </thead>
                         <tbody>
                            <%= for { {actor_id, contract_id, link_name},v} <- @linkdefs do %>
-                           <%= live_component LinkRowComponent, link_name: link_name, contract_id: contract_id, actor_id: actor_id, provider_key: v.provider_key %>
+                           <%= live_component LinkRowComponent, id: "#{actor_id} (#{link_name}) (#{contract_id})", link_name: link_name, contract_id: contract_id, actor_id: actor_id, provider_key: v.provider_key %>
                            <% end %>
                         </tbody>
                      </table>


### PR DESCRIPTION
Partially addresses #195 

This allows the user to delete a link definition using the washboard, with a nice handy trashcan button.