### PR TITLE
Adds a JetStream domain configuration parameter.

### DIFF
--- a/host_core/lib/host_core.ex
+++ b/host_core/lib/host_core.ex
@@ -167,6 +167,14 @@ defmodule HostCore do
 
   defp write_config(config) do
     write_json(config, "./host_config.json")
+
+    case System.user_home() do
+      nil ->
+        Logger.warn("Can't check for ~/.wash host config - no user home available")
+
+      h ->
+        write_json(config, Path.join([h, "/.wash/", "host_config.json"]))
+    end
   end
 
   defp write_json(config, file) do

--- a/host_core/lib/host_core.ex
+++ b/host_core/lib/host_core.ex
@@ -81,7 +81,22 @@ defmodule HostCore do
   end
 
   defp post_process_config(config) do
-    {host_key, host_seed} = HostCore.WasmCloud.Native.generate_key(:server)
+    {host_key, host_seed} =
+      if config.host_seed == nil do
+        HostCore.WasmCloud.Native.generate_key(:server)
+      else
+        case HostCore.WasmCloud.Native.pk_from_seed(config.host_seed) do
+          {:ok, pk} ->
+            {pk, config.host_seed}
+
+          {:error, _err} ->
+            Logger.error(
+              "Failed to obtain host public key from seed: #{config.host_seed}. Using new host key."
+            )
+
+            HostCore.WasmCloud.Native.generate_key(:server)
+        end
+      end
 
     config =
       config
@@ -98,6 +113,11 @@ defmodule HostCore do
 
     hid = Hashids.encode(s, Enum.random(1..4_294_967_295))
     config = Map.put(config, :cache_deliver_inbox, "_INBOX.#{hid}")
+
+    if config.js_domain != nil && String.valid?(config.js_domain) &&
+         String.length(config.js_domain) > 1 do
+      Logger.info("Using JetStream domain: #{config.js_domain}")
+    end
 
     {def_cluster_key, def_cluster_seed} = HostCore.WasmCloud.Native.generate_key(:cluster)
     # we're generating the key, so we know this is going to work
@@ -147,14 +167,6 @@ defmodule HostCore do
 
   defp write_config(config) do
     write_json(config, "./host_config.json")
-
-    case System.user_home() do
-      nil ->
-        Logger.warn("Can't check for ~/.wash host config - no user home available")
-
-      h ->
-        write_json(config, Path.join([h, "/.wash/", "host_config.json"]))
-    end
   end
 
   defp write_json(config, file) do

--- a/host_core/lib/host_core/config_plan.ex
+++ b/host_core/lib/host_core/config_plan.ex
@@ -12,12 +12,10 @@ defmodule HostCore.ConfigPlan do
 
   @impl Vapor.Plan
   def config_plan do
-    wash_config = Path.join(System.user_home(), "/.wash/host_config.json")
-
     [
       %Dotenv{},
       %FilesConfigProvider{
-        paths: [wash_config, "host_config.json"],
+        paths: ["host_config.json"],
         bindings: json_bindings()
       },
       # Default values will be in the merged accumulator at this point,
@@ -25,6 +23,7 @@ defmodule HostCore.ConfigPlan do
       %Env{
         bindings: [
           {:lattice_prefix, @prefix_var, required: false},
+          {:host_seed, "WASMCLOUD_HOST_SEED", required: false},
           {:rpc_host, "WASMCLOUD_RPC_HOST", required: false},
           {:rpc_port, "WASMCLOUD_RPC_PORT", required: false, map: &String.to_integer/1},
           {:rpc_seed, "WASMCLOUD_RPC_SEED", required: false},
@@ -49,7 +48,8 @@ defmodule HostCore.ConfigPlan do
            required: false, map: &String.to_integer/1},
           {:allow_latest, "WASMCLOUD_OCI_ALLOW_LATEST", required: false, map: &String.to_atom/1},
           {:allowed_insecure, "WASMCLOUD_OCI_ALLOWED_INSECURE",
-           required: false, map: &String.split(&1, ",")}
+           required: false, map: &String.split(&1, ",")},
+          {:js_domain, "WASMCLOUD_JS_DOMAIN", required: false}
         ]
       }
     ]
@@ -58,6 +58,7 @@ defmodule HostCore.ConfigPlan do
   defp json_bindings() do
     [
       {:lattice_prefix, "lattice_prefix", required: false, default: @default_prefix},
+      {:host_seed, "host_seed", required: false, default: nil},
       {:rpc_host, "rpc_host", required: false, default: "127.0.0.1"},
       {:rpc_port, "rpc_port", required: false, default: 4222},
       {:rpc_seed, "rpc_seed", required: false, default: ""},
@@ -78,7 +79,8 @@ defmodule HostCore.ConfigPlan do
       {:cluster_issuers, "cluster_issuers", required: false, default: []},
       {:provider_delay, "provider_delay", required: false, default: 300},
       {:allow_latest, "allow_latest", required: false, default: false},
-      {:allowed_insecure, "allowed_insecure", required: false, default: []}
+      {:allowed_insecure, "allowed_insecure", required: false, default: []},
+      {:js_domain, "js_domain", required: false, default: nil}
     ]
   end
 end


### PR DESCRIPTION
This closes #273. This PR includes the following:

* Re-enable the ability for a host's identity to be supplied via environment variable (`WASMCLOUD_HOST_SEED`)
* Add a new configuration value `js_domain` in the JSON config and `WASMCLOUD_JS_DOMAIN` env var
* No longer writes host configuration to `~/.wash/host_config.json` per discussions
* We now display the current consumer count on the JS stream the host is using. This can be super helpful in troubleshooting domain/leaf node issues (each active wasmCloud host represents an active ephemeral consumer)