### PR TITLE
[fix] Docker release use buildx

### DIFF
--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -102,13 +102,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        id: buildx-builder
-
       - name: Login to AzureCR
         uses: azure/docker-login@v1
         with:
@@ -121,6 +114,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_PUSH_USER }}
           password: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        id: buildx-builder
 
       - name: Determine version
         run: echo "wasmcloud_host_version=$(grep '@app_vsn "' ${{env.working-directory}}/mix.exs | cut -d '"' -f2)" > $GITHUB_ENV

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -132,7 +132,7 @@ jobs:
           builder: ${{ steps.buildx-builder.outputs.name }}
           push: false # TODO: remove after test 
           file: ${{env.working-directory}}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64 # TODO: Troubleshoot missing `git` executable, add this back ,linux/arm64
           build-args: |
             BUILDER_IMAGE=elixir:1.12.2-slim
             RELEASE_IMAGE=debian:buster-slim

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -90,7 +90,8 @@ jobs:
 
   release-docker:
     needs: build
-    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    # TODO: comment back in after test
+    #if: startswith(github.ref, 'refs/tags/') # Only run on tag push
 
     name: Release Linux Docker Image
     runs-on: ubuntu-18.04
@@ -106,6 +107,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        id: buildx-builder
 
       - name: Login to AzureCR
         uses: azure/docker-login@v1
@@ -127,7 +129,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
+          builder: ${{ steps.buildx-builder.outputs.name }}
+          push: false # TODO: remove after test 
           file: ${{env.working-directory}}/Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -90,8 +90,7 @@ jobs:
 
   release-docker:
     needs: build
-    # TODO: comment back in after test
-    #if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
 
     name: Release Linux Docker Image
     runs-on: ubuntu-18.04
@@ -130,7 +129,7 @@ jobs:
         with:
           context: .
           builder: ${{ steps.buildx-builder.outputs.name }}
-          push: false # TODO: remove after test 
+          push: true
           file: ${{env.working-directory}}/Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -132,7 +132,7 @@ jobs:
           builder: ${{ steps.buildx-builder.outputs.name }}
           push: false # TODO: remove after test 
           file: ${{env.working-directory}}/Dockerfile
-          platforms: linux/amd64 # TODO: Troubleshoot missing `git` executable, add this back ,linux/arm64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             BUILDER_IMAGE=elixir:1.12.2-slim
             RELEASE_IMAGE=debian:buster-slim

--- a/wasmcloud_host/Dockerfile
+++ b/wasmcloud_host/Dockerfile
@@ -19,6 +19,12 @@ WORKDIR /opt/app
 # This copies our app source code into the build container
 COPY ./host_core ./host_core
 COPY ./wasmcloud_host ./wasmcloud_host
+
+# Install necessary system dependencies
+RUN apt update && \
+  DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
+  git
+
 # This step installs all the build tools we'll need
 RUN mix local.rebar --force && \
   mix local.hex --force

--- a/wasmcloud_host/Dockerfile
+++ b/wasmcloud_host/Dockerfile
@@ -23,7 +23,9 @@ COPY ./wasmcloud_host ./wasmcloud_host
 # Install necessary system dependencies
 RUN apt update && \
   DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
-  git
+  git \
+  ca-certificates && \
+  update-ca-certificates
 
 # This step installs all the build tools we'll need
 RUN mix local.rebar --force && \


### PR DESCRIPTION
This PR fixes the release action issue where the Docker image would fail to build for 2 reasons:
1. The docker config location was overwritten by the `docker login` step which was not properly tested when I used my fork (since I disabled the login steps)
2. `git` and `ca-certificates` were not available in the deps-builder image, which failed since we use a git dependency for `vapor`