### PR TITLE
Published host started command after initialization

### DIFF
--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -64,6 +64,8 @@ defmodule HostCore.Host do
       Logger.warn(warning)
     end
 
+    publish_host_started()
+
     {:ok,
      %State{
        host_key: opts.host_key,
@@ -108,6 +110,18 @@ defmodule HostCore.Host do
     msg =
       %{}
       |> CloudEvent.new("host_stopped")
+
+    topic = "wasmbus.evt.#{prefix}"
+
+    Gnat.pub(:control_nats, topic, msg)
+  end
+
+  defp publish_host_started() do
+    prefix = HostCore.Host.lattice_prefix()
+
+    msg =
+      %{}
+      |> CloudEvent.new("host_started")
 
     topic = "wasmbus.evt.#{prefix}"
 


### PR DESCRIPTION
This PR publishes the `host_started` event after initialization of the host. It does not yet handle the `host_started` or `host_stopped` events in the dashboard, however, that process incurs some additional complexity with the relationship between those events and heartbeats. Keeping it simple to get the issue done.

Fixes #262 