### PR TITLE
Emits claims for provider and actor start events

### DIFF
--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -320,7 +320,7 @@ defmodule HostCore.Actors.ActorModule do
       %State{content | api_version: api_version, instance: instance}
     end)
 
-    publish_actor_started(claims.public_key, api_version, instance_id)
+    publish_actor_started(claims, api_version, instance_id)
     {:ok, agent}
   end
 
@@ -336,14 +336,22 @@ defmodule HostCore.Actors.ActorModule do
     HostCore.Refmaps.Manager.put_refmap(oci, pk)
   end
 
-  def publish_actor_started(actor_pk, api_version, instance_id) do
+  def publish_actor_started(claims, api_version, instance_id) do
     prefix = HostCore.Host.lattice_prefix()
 
     msg =
       %{
-        public_key: actor_pk,
+        public_key: claims.public_key,
         api_version: api_version,
-        instance_id: instance_id
+        instance_id: instance_id,
+        claims: %{
+          call_alias: claims.call_alias,
+          caps: claims.caps,
+          issuer: claims.issuer,
+          tags: claims.tags,
+          name: claims.name,
+          version: claims.version
+        }
       }
       |> CloudEvent.new("actor_started")
 

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -83,7 +83,7 @@ defmodule HostCore.Providers.ProviderModule do
     # when it starts.
 
     HostCore.Claims.Manager.put_claims(claims)
-    publish_provider_started(claims.public_key, link_name, contract_id, instance_id)
+    publish_provider_started(claims, link_name, contract_id, instance_id)
 
     if oci != nil && oci != "" do
       publish_provider_oci_map(claims.public_key, link_name, oci)
@@ -235,15 +235,21 @@ defmodule HostCore.Providers.ProviderModule do
     Gnat.pub(:control_nats, topic, msg)
   end
 
-  defp publish_provider_started(pk, link_name, contract_id, instance_id) do
+  defp publish_provider_started(claims, link_name, contract_id, instance_id) do
     prefix = HostCore.Host.lattice_prefix()
 
     msg =
       %{
-        public_key: pk,
+        public_key: claims.public_key,
         link_name: link_name,
         contract_id: contract_id,
-        instance_id: instance_id
+        instance_id: instance_id,
+        claims: %{
+          issuer: claims.issuer,
+          tags: claims.tags,
+          name: claims.name,
+          version: claims.version
+        }
       }
       |> CloudEvent.new("provider_started")
 


### PR DESCRIPTION
This will allow the lattice observer to store and retrieve the additional metadata about providers and actors.