### PR TITLE
Fix/api version passthrough

### DIFF
--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -187,7 +187,7 @@ defmodule HostCore.Actors.ActorModule do
             }
 
           _ ->
-            api_version = Map.get(inv, "api_version", 0)
+            api_version = Map.get(inv, :api_version, 0)
 
             case perform_invocation(agent, inv["operation"], inv["msg"], api_version) do
               {:ok, response} ->

--- a/host_core/lib/host_core/providers/builtin/logging.ex
+++ b/host_core/lib/host_core/providers/builtin/logging.ex
@@ -2,7 +2,7 @@ defmodule HostCore.Providers.Builtin.Logging do
   @moduledoc false
   require Logger
 
-  def invoke(actor, "Logging.WriteLog", payload) do
+  def invoke(actor, "Logging.WriteLog", payload, _api_version) do
     msg = Msgpax.unpack!(payload)
     text = "[#{actor}] #{msg["text"]}"
 

--- a/host_core/lib/host_core/providers/builtin/numbergen.ex
+++ b/host_core/lib/host_core/providers/builtin/numbergen.ex
@@ -1,9 +1,9 @@
 defmodule HostCore.Providers.Builtin.Numbergen do
-  def invoke("NumberGen.GenerateGuid", _payload) do
+  def invoke("NumberGen.GenerateGuid", _payload, _api_version) do
     IO.iodata_to_binary(Msgpax.pack!(UUID.uuid4()))
   end
 
-  def invoke("NumberGen.RandomInRange", payload) do
+  def invoke("NumberGen.RandomInRange", payload, _api_version) do
     params = Msgpax.unpack!(payload)
 
     min = max(params["min"], 0)
@@ -11,7 +11,7 @@ defmodule HostCore.Providers.Builtin.Numbergen do
     IO.iodata_to_binary(Msgpax.pack!(Enum.random(min..max)))
   end
 
-  def invoke("NumberGen.Random32", _payload) do
+  def invoke("NumberGen.Random32", _payload, _api_version) do
     IO.iodata_to_binary(Msgpax.pack!(Enum.random(0..4_294_967_295)))
   end
 end

--- a/host_core/lib/host_core/wasmcloud/native.ex
+++ b/host_core/lib/host_core/wasmcloud/native.ex
@@ -16,7 +16,8 @@ defmodule HostCore.WasmCloud.Native do
         _target_contract_id,
         _target_link_name,
         _op,
-        _msg
+        _msg,
+        _api_version
       ),
       do: error()
 

--- a/host_core/lib/host_core/web_assembly/imports.ex
+++ b/host_core/lib/host_core/web_assembly/imports.ex
@@ -247,10 +247,11 @@ defmodule HostCore.WebAssembly.Imports do
            namespace: @wasmcloud_logging,
            operation: operation,
            payload: payload,
+           state: state,
            source_actor: actor
          }
        ) do
-    HostCore.Providers.Builtin.Logging.invoke(actor, operation, payload)
+    HostCore.Providers.Builtin.Logging.invoke(actor, operation, payload, state.api_version)
     1
   end
 
@@ -259,10 +260,11 @@ defmodule HostCore.WebAssembly.Imports do
            namespace: @wasmcloud_numbergen,
            operation: operation,
            payload: payload,
+           state: state,
            agent: agent
          }
        ) do
-    res = HostCore.Providers.Builtin.Numbergen.invoke(operation, payload)
+    res = HostCore.Providers.Builtin.Numbergen.invoke(operation, payload, state.api_version)
     Agent.update(agent, fn state -> %State{state | host_response: res} end)
     1
   end
@@ -283,9 +285,12 @@ defmodule HostCore.WebAssembly.Imports do
            binding: binding,
            operation: operation,
            payload: payload,
+           state: state,
            target: {target_type, target_key, target_subject}
          }
        ) do
+    api_version = state.api_version
+    # Logger.debug("Invoking op #{operation} src-api #{api_version}")
     invocation_res =
       HostCore.WasmCloud.Native.generate_invocation_bytes(
         seed,
@@ -295,7 +300,8 @@ defmodule HostCore.WebAssembly.Imports do
         namespace,
         binding,
         operation,
-        payload
+        payload,
+        api_version
       )
       |> perform_rpc_invoke(target_subject)
 

--- a/host_core/native/hostcore_wasmcloud_native/src/lib.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/lib.rs
@@ -218,6 +218,7 @@ fn generate_invocation_bytes<'a>(
     target_link_name: String,
     operation: String,
     msg: Binary,
+    api_version: u32,
 ) -> Result<Vec<u8>, Error> {
     let inv = inv::Invocation::new(
         &KeyPair::from_seed(&host_seed).unwrap(),
@@ -229,6 +230,7 @@ fn generate_invocation_bytes<'a>(
         },
         &operation,
         msg.as_slice().to_vec(),
+        api_version,
     );
     Ok(inv::serialize(&inv).unwrap())
 }

--- a/host_core/native/hostcore_wasmcloud_native/src/oci.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/oci.rs
@@ -1,7 +1,9 @@
-use std::env::temp_dir;
-use std::io::{Read, Write};
-use std::path::PathBuf;
-use std::str::FromStr;
+use std::{
+    env::temp_dir,
+    io::{Read, Write},
+    path::PathBuf,
+    str::FromStr,
+};
 
 pub(crate) const OCI_VAR_USER: &str = "OCI_REGISTRY_USER";
 pub(crate) const OCI_VAR_PASSWORD: &str = "OCI_REGISTRY_PASSWORD";

--- a/host_core/native/hostcore_wasmcloud_native/src/par.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/par.rs
@@ -3,8 +3,10 @@ use chrono::NaiveDateTime;
 
 use provider_archive::ProviderArchive;
 use rustler::{Env, Error};
-use std::env::temp_dir;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{
+    env::temp_dir,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 pub fn on_load(env: Env) -> bool {
     rustler::resource!(ProviderArchiveResource, env);

--- a/host_core/test/host_core/actors_test.exs
+++ b/host_core/test/host_core/actors_test.exs
@@ -65,7 +65,8 @@ defmodule HostCore.ActorsTest do
         @httpserver_contract,
         @httpserver_link,
         "HttpServer.HandleRequest",
-        req
+        req,
+        0
       )
 
     topic = "wasmbus.rpc.#{HostCore.Host.lattice_prefix()}.#{@echo_key}"
@@ -153,7 +154,8 @@ defmodule HostCore.ActorsTest do
         @httpserver_contract,
         @httpserver_link,
         "HttpServer.HandleRequest",
-        req
+        req,
+        0
       )
 
     topic = "wasmbus.rpc.#{HostCore.Host.lattice_prefix()}.#{@echo_key}"
@@ -213,7 +215,8 @@ defmodule HostCore.ActorsTest do
         @httpserver_contract,
         @httpserver_link,
         "HttpServer.HandleRequest",
-        req
+        req,
+        0
       )
 
     topic = "wasmbus.rpc.#{HostCore.Host.lattice_prefix()}.#{@echo_key}"
@@ -266,7 +269,8 @@ defmodule HostCore.ActorsTest do
         @httpserver_contract,
         @httpserver_link,
         "HandleRequest",
-        req
+        req,
+        0
       )
 
     pinger_key = "MDCX6E7RPUXSX5TJUD34CALXJJKV46MWJ2BUJQGWDDR3IYRJIWNUQ5PN"

--- a/host_core/test/host_core/wasmcloud/native_test.exs
+++ b/host_core/test/host_core/wasmcloud/native_test.exs
@@ -58,7 +58,8 @@ defmodule HostCore.WasmCloud.NativeTest do
         @httpserver_contract,
         @httpserver_link,
         "HandleRequest",
-        req
+        req,
+        0
       )
 
     res = HostCore.WasmCloud.Native.validate_antiforgery(inv |> IO.iodata_to_binary(), [pub])
@@ -94,7 +95,8 @@ defmodule HostCore.WasmCloud.NativeTest do
         @httpserver_contract,
         @httpserver_link,
         "HandleRequest",
-        req
+        req,
+        0
       )
 
     res =


### PR DESCRIPTION
api_version is recorded by wasmcloud-otp host when actors are loaded, but it isn't passed to message receivers who could use it for handling messages created with a different version.

This is intended to help us avoid breaking changes in the future if we decide to change wasmbus protocol. There are corresponding changes to wasmbus-rpc that need to be implemented, but this change and the wasmbus-rpc change are not inter-dependent and can be applied in either order.

This change should be non-breaking.