### PR TITLE
Fix/hotreload events

### DIFF
--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.50.4"
+  @app_vsn "0.51.0"
 
   def project do
     [

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.50.3"
+  @app_vsn "0.50.4"
 
   def project do
     [

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 
 version: 0.1.2
 
-appVersion: "0.50.3"
+appVersion: "0.50.4"

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 
 version: 0.1.2
 
-appVersion: "0.50.4"
+appVersion: "0.51.0"

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://github.com/wasmCloud/wasmcloud.com-dev/raw/main/static/images/wasm
 
 type: application
 
-version: 0.1.2
+version: 0.2.0
 
 appVersion: "0.51.0"

--- a/wasmcloud_host/lib/wasmcloud_host/actor_watcher.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/actor_watcher.ex
@@ -27,7 +27,6 @@ defmodule WasmcloudHost.ActorWatcher do
   def handle_info({:file_event, _watcher_pid, {path, events}}, state) do
     # Modified is emitted on Mac, Windows, and Linux when a file is changed
     if :modified in events do
-      {:ok, _bytes} = File.read(path)
       actor_map = Map.get(state, path, %{})
       actor_id = Map.get(actor_map, :actor_id, "")
       is_reloading = Map.get(actor_map, :is_reloading, false)

--- a/wasmcloud_host/lib/wasmcloud_host/actor_watcher.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/actor_watcher.ex
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.ActorWatcher do
   use GenServer
 
-  @reload_delay 1_000
+  @reload_delay_ms 1_000
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: :actor_watcher)
@@ -48,7 +48,7 @@ defmodule WasmcloudHost.ActorWatcher do
 
         true ->
           # Sending after a delay enables ignoring rapid-fire filesystem events
-          Process.send_after(self(), {:reload_actor, path}, @reload_delay)
+          Process.send_after(self(), {:reload_actor, path}, @reload_delay_ms)
           new_actor = Map.put(actor_map, :is_reloading, true)
           {:noreply, Map.put(state, path, new_actor)}
       end
@@ -73,6 +73,7 @@ defmodule WasmcloudHost.ActorWatcher do
       actor_id,
       replicas
     )
+
     start_actor(bytes, replicas)
 
     new_actor = %{actor_id: actor_id, is_reloading: false}

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.50.4"
+  @app_vsn "0.51.0"
 
   def project do
     [

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.50.3"
+  @app_vsn "0.50.4"
 
   def project do
     [


### PR DESCRIPTION
This PR fixes 2 bugs in hot reloading:

Different operating systems have different filesystem events, so my logic wasn't entirely correct. For example, on Linux there is an event for `:modified` AND an event that combines `:modified` and `:closed`, which was how I based my "done editing actor" logic before. Now, we reload whenever an actor is `:modified`

Not all OSes emit the `:closed` event, and often one run of `make` to update an actor will result in multiple modified events. With my testing on the M1 mac, I would get 5 rapid-fire events of modified for one change. The new logic to handle this requests a reload of an actor after a specified delay and sets a value in state to indicate that the actor is pending a reload so we don't reload each instance 5 times.