### PR TITLE
Generate secret key base for user when building docker image

### DIFF
--- a/wasmcloud_host/Makefile
+++ b/wasmcloud_host/Makefile
@@ -6,6 +6,7 @@ BUILD ?= `git rev-parse --short HEAD`
 DOCKERFILE ?= ./wasmcloud_host/Dockerfile
 SKIP_PHOENIX ?= false
 TAG ?= latest
+SECRET_KEY_BASE ?= $(shell mix phx.gen.secret)
 
 RUST_ARCH ?= x86_64
 RUST_TARGET ?= unknown-linux-gnu
@@ -16,7 +17,7 @@ BASE_TAGS ?= -t $(NAME):$(VERSION)-$(BUILD) -t $(NAME):$(TAG)
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_\-.*]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-build-image: ## Build docker image for running, testing, or distribution
+build-image: build ## Build docker image for running, testing, or distribution
 	cd ../ && \
 	docker build $(BASE_ARGS) \
 		--build-arg BUILDER_IMAGE=elixir:1.12.2-slim \


### PR DESCRIPTION
This is a small fix for the Makefile, but when users currently do `make build-image` to build a docker image it will autofill with an empty `SECRET_KEY_BASE`, which unfortunately will cause failures in the web dashboard all the way at runtime. This will use `mix` to generate a secret if it's not supplied.

I also considered just running `mix phx.gen.secret` and committing the dummy value on my own, though it felt a little wrong. Happy to do this if we are OK with committing a dummy secret in exchange for not requiring an elixir toolchain to build an image.