### PR TITLE
Fix control interface inventory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,12 +197,12 @@ jobs:
       - name: Download Release Tarballs
         uses: actions/download-artifact@v2
         with:
-          path: ${{ env.working-directory }}/release
+          path: release
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{ env.working-directory }}/release/**/*.tar.gz
+          files: release/**/*.tar.gz
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: false
           draft: false

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -193,7 +193,7 @@ defmodule HostCore.Providers.ProviderModule do
   end
 
   def handle_info({_ref, msg}, state) do
-    Logger.info(msg)
+    Logger.debug(msg)
 
     {:noreply, state}
   end

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.51.0"
+  @app_vsn "0.51.1"
 
   def project do
     [

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://github.com/wasmCloud/wasmcloud.com-dev/raw/main/static/images/wasm
 
 type: application
 
-version: 0.2.0
+version: 0.2.1
 
-appVersion: "0.51.0"
+appVersion: "0.51.1"

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.51.0"
+  @app_vsn "0.51.1"
 
   def project do
     [


### PR DESCRIPTION
This PR introduces a few fixes:
1. Modified the shape of the actor list in the `host inventory` query to match the control interface structure [here](https://docs.rs/wasmcloud-interface-lattice-control/0.2.2/wasmcloud_interface_lattice_control/struct.ActorInstance.html)
2. removed the unused `${{ env.working-directory }}` from the release action that was causing the GH release to fail
3. Added the `name` and `revision` information to the Actor and Provider inventory queries
4. Bumped to `0.51.1` as this PR fixes a bug, no breaking change