### PR TITLE
fix(jetstream): Handle error when using a stream with multiple replicas

### DIFF
--- a/host_core/lib/host_core/jetstream/client.ex
+++ b/host_core/lib/host_core/jetstream/client.ex
@@ -153,6 +153,19 @@ defmodule HostCore.Jetstream.Client do
     true
   end
 
+  # This is almost identical to above, but for some reason when the stream has multiple replicas,
+  # this returns a 400 error code rather than 500
+  def handle_stream_create_response(%{
+        "type" => "io.nats.jetstream.api.v1.stream_create_response",
+        "error" => %{
+          "code" => 400,
+          "description" => "stream name already in use"
+        }
+      }) do
+    Logger.info("Lattice cache stream name already in use, assuming previously-configured stream")
+    true
+  end
+
   def handle_stream_create_response(%{
         "error" => %{
           "code" => 500,


### PR DESCRIPTION
While setting up a more production ready nats cluster with a replicated
lattice cache stream, I noticed that an error was occurring when it tried
to create the stream. For some reason (that I haven't figured out), the
error code returned from NATS if the stream already existed was `400`
instead of `500` when the stream was replicated across multiple nodes.
Because of this error, the lattice cache consumer was never created, leading
to each individual host maintaining its own in memory cache of the claims.

This PR introduces an additional function for checking the streaming
response that takes into account this error code difference. I tested
this against a NATS cluster with a replicated lattice stream and all
the claims appear properly