### PR TITLE
Adding instance IDs to actor list on heartbeats

### DIFF
--- a/host_core/lib/host_core/actors/actor_supervisor.ex
+++ b/host_core/lib/host_core/actors/actor_supervisor.ex
@@ -116,6 +116,20 @@ defmodule HostCore.Actors.ActorSupervisor do
   end
 
   @doc """
+  A slightly different version of the all actors list, formatted for
+  suitability on emitted heartbeats
+  """
+  def all_actors_for_hb() do
+    Supervisor.which_children(HostCore.Actors.ActorSupervisor)
+    |> Enum.map(fn {_id, pid, _type, _modules} ->
+      {
+        HostCore.Actors.ActorModule.claims(pid).public_key,
+        HostCore.Actors.ActorModule.instance_id(pid)
+      }
+    end)
+  end
+
+  @doc """
   Produces a list of tuples containing the pid of the child actor, its public key, and its
   OCI reference.
   """

--- a/host_core/lib/host_core/heartbeat_emitter.ex
+++ b/host_core/lib/host_core/heartbeat_emitter.ex
@@ -37,8 +37,8 @@ defmodule HostCore.HeartbeatEmitter do
 
   defp generate_heartbeat(state) do
     actors =
-      HostCore.Actors.ActorSupervisor.all_actors()
-      |> Enum.map(fn {k, v} -> %{actor: k, instances: length(v)} end)
+      HostCore.Actors.ActorSupervisor.all_actors_for_hb()
+      |> Enum.map(fn {k, iid} -> %{public_key: k, instance_id: iid} end)
 
     providers =
       HostCore.Providers.ProviderSupervisor.all_providers()


### PR DESCRIPTION
This is ultimately required to give the lattice observer the ability to fill in partial data on actors and providers when monitoring heartbeats.