### PR TITLE
Ensured actors and providers accurately return errors

### DIFF
--- a/host_core/lib/host_core/actors/actor_supervisor.ex
+++ b/host_core/lib/host_core/actors/actor_supervisor.ex
@@ -53,7 +53,7 @@ defmodule HostCore.Actors.ActorSupervisor do
          ) do
       {:error, err} ->
         Logger.error("Failed to download OCI bytes for #{oci}")
-        {:stop, err}
+        {:error, err}
 
       {:ok, bytes} ->
         start_actor(bytes |> IO.iodata_to_binary(), oci)
@@ -182,9 +182,6 @@ defmodule HostCore.Actors.ActorSupervisor do
         case 1..abs(diff)
              |> Enum.reduce_while("", fn _, _ ->
                case start_actor_from_oci(ociref) do
-                 {:stop, err} ->
-                   {:halt, "Error: #{err}"}
-
                  {:error, err} ->
                    {:halt, "Error: #{err}"}
 

--- a/host_core/lib/host_core/providers/provider_supervisor.ex
+++ b/host_core/lib/host_core/providers/provider_supervisor.ex
@@ -70,8 +70,13 @@ defmodule HostCore.Providers.ProviderSupervisor do
          {:ok, path} <- extract_executable_to_tmp(par, link_name) do
       start_executable_provider(path, par.claims, link_name, par.contract_id, oci, config_json)
     else
-      {:error, err} -> Logger.error("Error starting provider from OCI: #{err}")
-      _err -> Logger.error("Error starting provider from OCI")
+      {:error, err} ->
+        Logger.error("Error starting provider from OCI: #{err}")
+        {:error, err}
+
+      _err ->
+        Logger.error("Error starting provider from OCI")
+        {:error, "Error starting provider from OCI"}
     end
   end
 
@@ -92,7 +97,7 @@ defmodule HostCore.Providers.ProviderSupervisor do
 
       err ->
         Logger.error("Error starting provider from file")
-        err
+        {:error, err}
     end
   end
 

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.51.3"
+  @app_vsn "0.51.4"
 
   def project do
     [

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://github.com/wasmCloud/wasmcloud.com-dev/raw/main/static/images/wasm
 
 type: application
 
-version: 0.2.2
+version: 0.2.3
 
 appVersion: "0.51.4"

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 
 version: 0.2.2
 
-appVersion: "0.51.3"
+appVersion: "0.51.4"

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.51.3"
+  @app_vsn "0.51.4"
 
   def project do
     [


### PR DESCRIPTION
Previously when starting an actor from the control interface, if the OCI bytes failed to download we would return `{:stop, err}`. This was inconsistent with other failure modes, so I changed that to `{:error, err}`.

Additionally, some failures for starting providers from the control interface would simply return the result of logging the error, which was `:ok`. I added an additional line to properly return `{:error, err}` here.

Also bump to `0.51.4` for these changes.