### PR TITLE
Updated dashboard heartbeat shape

### DIFF
--- a/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
@@ -257,17 +257,18 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
     actor_map =
       actors
       |> Enum.reduce(%{}, fn actor, actor_map ->
-        actor_id = Map.get(actor, "actor")
-        existing_actor = current_host |> Map.get(:actors, %{}) |> Map.get(actor_id)
+        actor_id = Map.get(actor, "public_key")
 
-        if existing_actor != nil && Map.get(existing_actor, :count) == Map.get(actor, "instances") do
-          Map.put(actor_map, actor_id, existing_actor)
-        else
-          Map.put(actor_map, actor_id, %{
-            count: Map.get(actor, "instances"),
-            status: "Awaiting"
-          })
-        end
+        actor_info = Map.get(actor_map, actor_id, %{})
+        count = Map.get(actor_info, :count, 0) + 1
+
+        status =
+          current_host
+          |> Map.get(:actors, %{})
+          |> Map.get(actor_id, %{})
+          |> Map.get(:status, "Awaiting")
+
+        Map.put(actor_map, actor_id, %{count: count, status: status})
       end)
 
     # TODO: Also ensure that providers don't exist in the dashboard that aren't in the health check

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.heex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.heex
@@ -62,7 +62,7 @@
                         <tbody>
                            <%= for {host_id, host_map} <- display_hosts do %>
                            <%= for {actor, info_map} <- Map.get(host_map, :actors, %{}) do %>
-                           <% actor_name = @claims |> Enum.find(fn {k, _v} -> k == actor end) |> elem(1) |> Map.get(:name) %>
+                           <% actor_name = @claims |> Enum.find({"", %{}}, fn {k, _v} -> k == actor end) |> elem(1) |> Map.get(:name, "N/A") %>
                            <% oci_ref = @ocirefs |> Enum.find({"", actor}, fn {_oci, id} -> id == actor end) |> elem(0) %>
                            <% count = Map.get(info_map, :count) %>
                            <% status = Map.get(info_map, :status) %>
@@ -257,6 +257,7 @@
                                  <%= Map.get(@hosts, host_id, %{})
                                     |> Map.get(:actors, %{})
                                     |> Enum.map(fn {_actor_id, info} -> Map.get(info, :count, 0) end)
+                                    |> Enum.filter(fn count -> count != nil end)
                                     |> Enum.reduce(0, fn count, acc -> count + acc end) %>
                               </td>
                               <td>


### PR DESCRIPTION
This PR updates the dashboard to use the new heartbeat format introduced in #309. 

This also fixes #304 and will not cause a dashboard crash in the case of missing claims (instead, the actor name will show as `N/A`)