### PR TITLE
Adding support for friendly host names. Fixing bug with writing config file

### DIFF
--- a/host_core/lib/host_core.ex
+++ b/host_core/lib/host_core.ex
@@ -181,9 +181,14 @@ defmodule HostCore do
   end
 
   defp write_json(config, file) do
-    case File.write(file, Jason.encode!(remove_extras(config))) do
-      {:error, reason} -> Logger.error("Failed to write configuration file #{reason}")
-      :ok -> Logger.info("Wrote #{inspect(file)}")
+    with :ok <- File.mkdir_p(Path.dirname(file)) do
+      case File.write(file, Jason.encode!(remove_extras(config))) do
+        {:error, reason} -> Logger.error("Failed to write configuration file #{file}: #{reason}")
+        :ok -> Logger.info("Wrote #{inspect(file)}")
+      end
+    else
+      {:error, posix} ->
+        Logger.error("Failed to create path to config file #{file}: #{posix}")
     end
   end
 

--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -26,6 +26,7 @@ defmodule HostCore.ControlInterface.Server do
 
     res = %{
       id: HostCore.Host.host_key(),
+      friendly_name: HostCore.Host.friendly_name(),
       uptime_seconds: div(total, 1000)
     }
 
@@ -63,6 +64,7 @@ defmodule HostCore.ControlInterface.Server do
       res = %{
         host_id: HostCore.Host.host_key(),
         labels: HostCore.Host.host_labels(),
+        friendly_name: HostCore.Host.friendly_name(),
         actors: ACL.all_actors(),
         providers: ACL.all_providers()
       }

--- a/host_core/lib/host_core/heartbeat_emitter.ex
+++ b/host_core/lib/host_core/heartbeat_emitter.ex
@@ -49,7 +49,8 @@ defmodule HostCore.HeartbeatEmitter do
     %{
       actors: actors,
       providers: providers,
-      labels: HostCore.Host.host_labels()
+      labels: HostCore.Host.host_labels(),
+      friendly_name: HostCore.Host.friendly_name()
     }
     |> CloudEvent.new("host_heartbeat", state[:host_key])
   end

--- a/host_core/lib/host_core/namegen.ex
+++ b/host_core/lib/host_core/namegen.ex
@@ -1,0 +1,32 @@
+defmodule HostCore.Namegen do
+  @adjectives ~w(
+    autumn hidden bitter misty silent empty dry dark summer
+    icy delicate quiet white cool spring winter patient
+    twilight dawn crimson wispy weathered blue billowing
+    broken cold damp falling frosty green long late lingering
+    bold little morning muddy old red rough still small
+    sparkling bouncing shy wandering withered wild black
+    young holy solitary fragrant aged snowy proud floral
+    restless divine polished ancient purple lively nameless
+    gray orange mauve
+  )
+
+  @nouns ~w(
+    waterfall river breeze moon rain wind sea morning
+    snow lake sunset pine shadow leaf dawn glitter forest
+    hill cloud meadow sun glade bird brook butterfly
+    bush dew dust field fire flower firefly ladybug feather grass
+    haze mountain night pond darkness snowflake silence
+    sound sky shape stapler surf thunder violet water wildflower
+    wave water resonance sun wood dream cherry tree fog autocorrect
+    frost voice paper frog smoke star hamster ocean emoji robot
+  )
+
+  def generate(max_id \\ 9999) do
+    adjective = @adjectives |> Enum.random()
+    noun = @nouns |> Enum.random()
+    id = :rand.uniform(max_id)
+
+    [adjective, noun, id] |> Enum.join("-")
+  end
+end


### PR DESCRIPTION
This PR adds support for randomly generated friendly host names. These are not guaranteed to be globally unique, but it's a pretty good chance they'll be unique within a lattice (and there are no real consequences if there's a .001% chance duplicate).

Additionally, while I was in here I fixed a bug that came from assuming that the `~/.wash` directory exists prior to host launch.

```
15:24:22.149 [info]  Host NBLVEPX5AF35DKQVC6MBHGWN4WXIVWCAZX6MHOF6T6OAXH4AEWUXZPTL (misty-ocean-3359) started.

```