### PR TITLE
Emit invocation success and failure events

### DIFF
--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -367,7 +367,7 @@ defmodule HostCore.Actors.ActorModule do
           link_name: Map.get(target, "link_name")
         },
         operation: inv["operation"],
-        bytes: byte_size(inv["msg"])
+        bytes: byte_size(Map.get(inv, "msg", ""))
       }
       |> CloudEvent.new(evt_type)
 

--- a/host_core/lib/host_core/web_assembly/imports.ex
+++ b/host_core/lib/host_core/web_assembly/imports.ex
@@ -2,6 +2,7 @@ defmodule HostCore.WebAssembly.Imports do
   @moduledoc false
   require Logger
   alias HostCore.Actors.ActorModule.State
+  alias HostCore.CloudEvent
 
   @wasmcloud_logging "wasmcloud:builtin:logging"
   @wasmcloud_numbergen "wasmcloud:builtin:numbergen"
@@ -299,15 +300,83 @@ defmodule HostCore.WebAssembly.Imports do
       )
       |> perform_rpc_invoke(target_subject)
 
-    case unpack_invocation_response(invocation_res) do
-      {1, :host_response, msg} ->
-        Agent.update(agent, fn state -> %State{state | host_response: msg} end)
-        1
+    unpacked = unpack_invocation_response(invocation_res)
 
-      {0, :host_error, error} ->
-        Agent.update(agent, fn state -> %State{state | host_error: error} end)
-        0
-    end
+    res =
+      case unpacked do
+        {1, :host_response, msg} ->
+          Agent.update(agent, fn state -> %State{state | host_response: msg} end)
+          1
+
+        {0, :host_error, error} ->
+          Agent.update(agent, fn state -> %State{state | host_error: error} end)
+          0
+      end
+
+    Task.start(fn ->
+      publish_invocation_result(
+        actor,
+        namespace,
+        binding,
+        operation,
+        byte_size(payload),
+        target_type,
+        target_key,
+        res
+      )
+    end)
+
+    res
+  end
+
+  defp publish_invocation_result(
+         actor,
+         namespace,
+         binding,
+         operation,
+         payload_bytes,
+         target_type,
+         target_key,
+         res
+       ) do
+    evt_type =
+      if res == 1 do
+        "invocation_succeeded"
+      else
+        "invocation_failed"
+      end
+
+    prefix = HostCore.Host.lattice_prefix()
+
+    msg =
+      %{
+        source: %{
+          public_key: actor,
+          contract_id: nil,
+          link_name: nil
+        },
+        dest: %{
+          public_key: target_key,
+          contract_id:
+            if target_type == :provider do
+              namespace
+            else
+              nil
+            end,
+          link_name:
+            if target_type == :provider do
+              binding
+            else
+              nil
+            end
+        },
+        operation: operation,
+        bytes: payload_bytes
+      }
+      |> CloudEvent.new(evt_type)
+
+    topic = "wasmbus.evt.#{prefix}"
+    Gnat.pub(:control_nats, topic, msg)
   end
 
   defp lookup_call_alias(call_alias) do

--- a/host_core/lib/host_core/web_assembly/imports.ex
+++ b/host_core/lib/host_core/web_assembly/imports.ex
@@ -300,10 +300,8 @@ defmodule HostCore.WebAssembly.Imports do
       )
       |> perform_rpc_invoke(target_subject)
 
-    unpacked = unpack_invocation_response(invocation_res)
-
     res =
-      case unpacked do
+      case unpack_invocation_response(invocation_res) do
         {1, :host_response, msg} ->
           Agent.update(agent, fn state -> %State{state | host_response: msg} end)
           1


### PR DESCRIPTION
This PR adds support for publishing invocation success and failure events. These events are directional and so preserve the source and destination of the invocation. This will emit events for comms between actors and providers as well as actor<->actor comms.

Sample events:
```
{
    "data": {
        "bytes": 51,
        "dest": {
            "contract_id": "wasmcloud:httpserver",
            "link_name": "default",
            "public_key": "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M"
        },
        "operation": "HttpServer.HandleRequest",
        "source": {
            "contract_id": "",
            "link_name": "",
            "public_key": "system"
        }
    },
    "datacontenttype": "application/json",
    "id": "b2284728-d463-445d-ac7f-70174255b795",
    "source": "NDJ3Z7CBLV3UCPCENHQY34LG3XB7J766DBVG6MM6R34SGN2QDYEYN27K",
    "specversion": "1.0",
    "time": "2021-12-20T20:38:47.755590Z",
    "type": "com.wasmcloud.lattice.invocation_succeeded"
}

{
    "data": {
        "bytes": 8,
        "dest": {
            "contract_id": null,
            "link_name": null,
            "public_key": "MBMOM2EZZICFYM4KATRMH2JUO5QWE3YWCHGFZVRQQ2SQI4I5BKWIGMBS"
        },
        "operation": "Ping",
        "source": {
            "contract_id": null,
            "link_name": null,
            "public_key": "MDCX6E7RPUXSX5TJUD34CALXJJKV46MWJ2BUJQGWDDR3IYRJIWNUQ5PN"
        }
    },
    "datacontenttype": "application/json",
    "id": "21900ada-daec-41bc-a289-951b8dab6b89",
    "source": "NDJ3Z7CBLV3UCPCENHQY34LG3XB7J766DBVG6MM6R34SGN2QDYEYN27K",
    "specversion": "1.0",
    "time": "2021-12-20T20:38:49.941137Z",
    "type": "com.wasmcloud.lattice.invocation_succeeded"
}
```