### PR TITLE
feat(chart): Adds Kubernetes applier support

### DIFF
--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://github.com/wasmCloud/wasmcloud.com-dev/raw/main/static/images/wasm
 
 type: application
 
-version: 0.2.3
+version: 0.2.4
 
 appVersion: "0.51.4"

--- a/wasmcloud_host/chart/README.md
+++ b/wasmcloud_host/chart/README.md
@@ -82,3 +82,16 @@ information.
 If you have deployed the host using one of the production options, it can be scaled as high as you'd
 like. The number of hosts can be scaled by setting `replicaCount` to the desired number or by using
 `kubectl scale`
+
+#### Kubernetes Applier Support
+
+This chart comes with built in support for the [Kubernetes Applier provider and
+actor](https://github.com/cosmonic/kubernetes-applier). To enable support so that any applier
+provider running on these nodes automatically gets the necessary credentials, set
+`wasmcloud.enableApplierSupport` to `true`. Note that this will force usage of a pod
+`ServiceAccount`.
+
+If using the architecture described in the [applier
+documentation](https://github.com/cosmonic/kubernetes-applier/tree/main/service-applier#requirements-for-hosts-running-in-kubernetes)
+that uses router nodes, you can use the `wasmcloud.customLabels` map to set the custom labels needed
+for those hosts (such as `wasmcloud.dev/route-to: "true"`)

--- a/wasmcloud_host/chart/templates/_helpers.tpl
+++ b/wasmcloud_host/chart/templates/_helpers.tpl
@@ -54,7 +54,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "wasmcloud_host.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if or .Values.serviceAccount.create .Values.wasmcloud.enableApplierSupport }}
 {{- default (include "wasmcloud_host.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}

--- a/wasmcloud_host/chart/templates/deployment.yaml
+++ b/wasmcloud_host/chart/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       {{- end }}
       labels:
         {{- include "wasmcloud_host.selectorLabels" . | nindent 8 }}
+        {{- if .Values.wasmcloud.customLabels }}
+        {{- toYaml .Values.wasmcloud.customLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/wasmcloud_host/chart/templates/role-binding.yaml
+++ b/wasmcloud_host/chart/templates/role-binding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.wasmcloud.enableApplierSupport -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "wasmcloud_host.name" . }}-service-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ include "wasmcloud_host.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "wasmcloud_host.name" . }}-service-manager
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/wasmcloud_host/chart/templates/role.yaml
+++ b/wasmcloud_host/chart/templates/role.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.wasmcloud.enableApplierSupport -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "wasmcloud_host.name" . }}-service-manager
+rules:
+- apiGroups: [""] 
+  resources: ["services"]
+  verbs: ["get", "create", "update", "delete", "patch"]
+{{- end }}

--- a/wasmcloud_host/chart/templates/serviceaccount.yaml
+++ b/wasmcloud_host/chart/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if or .Values.serviceAccount.create .Values.wasmcloud.enableApplierSupport -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/wasmcloud_host/chart/values.yaml
+++ b/wasmcloud_host/chart/values.yaml
@@ -33,6 +33,14 @@ wasmcloud:
     # names, so the `.` character is not allowed
     hostLabels:
       kubernetes: "true"
+  # Enables support for the Kubernetes Applier provider. Essentially, this generates a role and role
+  # binding for the pod service account that allows it to get, create, update, delete, and patch
+  # service resources if you start the kubernetes applier on one of these hosts. Enabling this
+  # option enables service account creation
+  enableApplierSupport: false
+  # Extra labels to attach to the pod template for each host. Meant for use with things like the
+  # Service Applier actor, which requires specific labels in order to route to those pods
+  customLabels: {}
   image:
     repository: wasmcloud/wasmcloud_host
     pullPolicy: IfNotPresent


### PR DESCRIPTION
As part of this effort, this also adds support for custom labels so that the
"router hosts" pattern can be used