### PR TITLE
Perform first health checks/heartbeat immediately

### DIFF
--- a/host_core/lib/host_core.ex
+++ b/host_core/lib/host_core.ex
@@ -36,7 +36,6 @@ defmodule HostCore do
         {Gnat.ConnectionSupervisor, HostCore.Nats.rpc_connection_settings(config)},
         id: :rpc_connection_supervisor
       ),
-      {HostCore.HeartbeatEmitter, config},
       {HostCore.Providers.ProviderSupervisor, strategy: :one_for_one, name: ProviderRoot},
       {HostCore.Actors.ActorSupervisor,
        strategy: :one_for_one,
@@ -79,6 +78,7 @@ defmodule HostCore do
         id: :cacheloader_consumer_supervisor
       ),
       {HostCore.Host, config},
+      {HostCore.HeartbeatEmitter, config},
       {HostCore.Jetstream.Client, config}
     ]
   end

--- a/host_core/lib/host_core/heartbeat_emitter.ex
+++ b/host_core/lib/host_core/heartbeat_emitter.ex
@@ -16,7 +16,8 @@ defmodule HostCore.HeartbeatEmitter do
 
   @impl true
   def init(opts) do
-    Process.send_after(self(), :publish_heartbeat, @thirty_seconds)
+    :timer.send_interval(@thirty_seconds, self(), :publish_heartbeat)
+    Process.send(self(), :publish_heartbeat, [:noconnect, :nosuspend])
 
     {:ok, opts}
   end
@@ -24,7 +25,6 @@ defmodule HostCore.HeartbeatEmitter do
   @impl true
   def handle_info(:publish_heartbeat, state) do
     publish_heartbeat(state)
-    Process.send_after(self(), :publish_heartbeat, @thirty_seconds)
     {:noreply, state}
   end
 

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -89,7 +89,8 @@ defmodule HostCore.Providers.ProviderModule do
       publish_provider_oci_map(claims.public_key, link_name, oci)
     end
 
-    Process.send_after(self(), :do_health, @thirty_seconds)
+    Process.send(self(), :do_health, [:noconnect, :nosuspend])
+    :timer.send_interval(@thirty_seconds, self(), :do_health)
 
     {:ok,
      %State{
@@ -188,7 +189,6 @@ defmodule HostCore.Providers.ProviderModule do
       {:error, _} -> publish_health_failed(state)
     end
 
-    Process.send_after(self(), :do_health, @thirty_seconds)
     {:noreply, state}
   end
 


### PR DESCRIPTION
This PR performs the first actor and provider health checks immediately, and sends a host heartbeat as soon as it is initialized.

I've refactored the `Process.send_after` "recursive" calls to be `:timer.send_interval` in the `init` function to make it less error-prone. 