### PR TITLE
Host pings now trigger heartbeats, health status only emitted when it changes

### DIFF
--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -63,7 +63,7 @@ defmodule HostCore.Actors.ActorModule do
   end
 
   def halt(pid) do
-    GenServer.call(pid, :halt_and_cleanup)
+    if Process.alive?(pid), do: GenServer.call(pid, :halt_and_cleanup)
   end
 
   def health_check(pid) do

--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -25,7 +25,8 @@ defmodule HostCore.Actors.ActorModule do
       :invocation,
       :claims,
       :subscription,
-      :ociref
+      :ociref,
+      :healthy
     ]
   end
 
@@ -231,7 +232,8 @@ defmodule HostCore.Actors.ActorModule do
     Registry.register(Registry.ActorRegistry, claims.public_key, claims)
     HostCore.Claims.Manager.put_claims(claims)
 
-    {:ok, agent} = Agent.start_link(fn -> %State{claims: claims, instance_id: UUID.uuid4()} end)
+    {:ok, agent} =
+      Agent.start_link(fn -> %State{claims: claims, instance_id: UUID.uuid4(), healthy: false} end)
 
     prefix = HostCore.Host.lattice_prefix()
     topic = "wasmbus.rpc.#{prefix}.#{claims.public_key}"
@@ -302,8 +304,17 @@ defmodule HostCore.Actors.ActorModule do
       end
 
     case res do
-      {:ok, _payload} -> publish_check_passed(agent)
-      {:error, reason} -> publish_check_failed(agent, reason)
+      {:ok, _payload} ->
+        if !Agent.get(agent, fn contents -> contents.healthy end) do
+          publish_check_passed(agent)
+          Agent.update(agent, fn contents -> %State{contents | healthy: true} end)
+        end
+
+      {:error, reason} ->
+        if Agent.get(agent, fn contents -> contents.healthy end) do
+          publish_check_failed(agent, reason)
+          Agent.update(agent, fn contents -> %State{contents | healthy: false} end)
+        end
     end
 
     res

--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -36,6 +36,8 @@ defmodule HostCore.ControlInterface.Server do
       uptime_seconds: div(total, 1000)
     }
 
+    HostCore.HeartbeatEmitter.emit_heartbeat()
+
     {:reply, Jason.encode!(res)}
   end
 

--- a/host_core/lib/host_core/heartbeat_emitter.ex
+++ b/host_core/lib/host_core/heartbeat_emitter.ex
@@ -28,7 +28,17 @@ defmodule HostCore.HeartbeatEmitter do
     {:noreply, state}
   end
 
-  def publish_heartbeat(state) do
+  @impl true
+  def handle_cast(:publish_heartbeat, state) do
+    publish_heartbeat(state)
+    {:noreply, state}
+  end
+
+  def emit_heartbeat() do
+    GenServer.cast(__MODULE__, :publish_heartbeat)
+  end
+
+  defp publish_heartbeat(state) do
     Logger.debug("Publishing heartbeat")
     topic = "wasmbus.evt.#{state[:lattice_prefix]}"
     msg = generate_heartbeat(state)

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -38,6 +38,7 @@ defmodule HostCore.Host do
   """
   @impl true
   def init(opts) do
+    Process.flag(:trap_exit, true)
     configure_ets()
 
     :ets.insert(:config_table, {:config, opts})
@@ -79,6 +80,13 @@ defmodule HostCore.Host do
        friendly_name: friendly_name,
        labels: labels
      }}
+  end
+
+  @impl true
+  def terminate(reason, state) do
+    Logger.debug("Host termination requested: #{inspect(reason)}")
+    publish_host_stopped(state.labels)
+    :timer.sleep(300)
   end
 
   defp get_env_host_labels() do

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -190,13 +190,12 @@ defmodule HostCore.Providers.ProviderModule do
     # Only publish health check pass/fail when state changes
     state =
       case res do
+        {:ok, _body} when not state.healthy ->
+          publish_health_passed(state)
+          %State{state | healthy: true}
+
         {:ok, _body} ->
-          if !state.healthy do
-            publish_health_passed(state)
-            %State{state | healthy: true}
-          else
-            state
-          end
+          state
 
         {:error, _} ->
           if state.healthy do

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -47,7 +47,7 @@ defmodule HostCore.Providers.ProviderModule do
   end
 
   def halt(pid) do
-    GenServer.call(pid, :halt_cleanup)
+    if Process.alive?(pid), do: GenServer.call(pid, :halt_cleanup)
   end
 
   @impl true

--- a/host_core/lib/host_core/web_assembly/imports.ex
+++ b/host_core/lib/host_core/web_assembly/imports.ex
@@ -448,7 +448,6 @@ defmodule HostCore.WebAssembly.Imports do
 
   # Load the guest response indicated by the location and length into the :guest_response state field.
   defp guest_response(_api_type, context, agent, ptr, len) do
-    Logger.debug("Guest response")
     memory = context.memory
     gr = Wasmex.Memory.read_binary(memory, ptr, len)
     Agent.update(agent, fn content -> %State{content | guest_response: gr} end)
@@ -458,7 +457,6 @@ defmodule HostCore.WebAssembly.Imports do
 
   # Load the guest error indicated by the location and length into the :guest_error field
   defp guest_error(_api_type, context, agent, ptr, len) do
-    Logger.debug("Guest error")
     memory = context.memory
 
     ge = Wasmex.Memory.read_binary(memory, ptr, len)
@@ -468,12 +466,10 @@ defmodule HostCore.WebAssembly.Imports do
   end
 
   defp guest_request(_api_type, context, agent, op_ptr, ptr) do
-    Logger.debug("Guest request")
     memory = context.memory
     # inv = HostCore.WebAssembly.ActorModule.current_invocation(actor_pid)
     inv = Agent.get(agent, fn content -> content.invocation end)
 
-    Logger.debug("Got current invocation")
     Wasmex.Memory.write_binary(memory, ptr, inv.payload)
     Wasmex.Memory.write_binary(memory, op_ptr, inv.operation)
 


### PR DESCRIPTION
This PR accomplishes the following:
* Host pings now function like proper radar and will emit a heartbeat as soon as they receive a ping
* Health checks are now only emitted when the state changes, which keeps the event log from being spammed by endless healthy status events when running at large-scale steady state.