### PR TITLE
ScaleActor fix, added count to StartActor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ npm-debug.log
 
 host_config.json
 .vscode/
+.DS_STORE

--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -201,7 +201,14 @@ defmodule HostCore.ControlInterface.Server do
       if host_id == HostCore.Host.host_key() do
         actor_id = scale_request["actor_id"]
         actor_ref = scale_request["actor_ref"]
-        count = String.to_integer(scale_request["count"])
+
+        # Handle either integer or string count arg
+        count =
+          if is_integer(scale_request["count"]) do
+            scale_request["count"]
+          else
+            String.to_integer(scale_request["count"])
+          end
 
         case HostCore.Actors.ActorSupervisor.scale_actor(actor_id, count, actor_ref) do
           :ok ->

--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -7,7 +7,7 @@ defmodule HostCore.ControlInterface.Server do
   alias HostCore.CloudEvent
 
   import HostCore.Actors.ActorSupervisor,
-    only: [start_actor_from_bindle: 1, start_actor_from_oci: 1]
+    only: [start_actor_from_bindle: 2, start_actor_from_oci: 2]
 
   import HostCore.Providers.ProviderSupervisor,
     only: [start_provider_from_bindle: 3, start_provider_from_oci: 3]
@@ -137,18 +137,20 @@ defmodule HostCore.ControlInterface.Server do
   # a queue group
 
   # Launch Actor
-  # %{"actor_ref" => "wasmcloud.azurecr.io/echo:0.12.0", "host_id" => "Nxxxx"}
-  # %{"actor_ref" => "bindle://example.com/echo/0.12.0", "host_id" => "Nxxxx"}
+  # %{"actor_ref" => "wasmcloud.azurecr.io/echo:0.12.0", "host_id" => "Nxxxx", "count" => 3}
+  # %{"actor_ref" => "bindle://example.com/echo/0.12.0", "host_id" => "Nxxxx", "count" => 4}
   defp handle_request({"cmd", _host_id, "la"}, body, _reply_to) do
     with {:ok, start_actor_command} <- Jason.decode(body),
          true <-
            Map.has_key?(start_actor_command, "actor_ref") do
       Task.start(fn ->
+        count = Map.get(start_actor_command, "count", 1)
+
         res =
           if String.starts_with?(start_actor_command["actor_ref"], "bindle://") do
-            start_actor_from_bindle(start_actor_command["actor_ref"])
+            start_actor_from_bindle(start_actor_command["actor_ref"], count)
           else
-            start_actor_from_oci(start_actor_command["actor_ref"])
+            start_actor_from_oci(start_actor_command["actor_ref"], count)
           end
 
         case res do
@@ -201,8 +203,12 @@ defmodule HostCore.ControlInterface.Server do
         actor_ref = scale_request["actor_ref"]
         count = String.to_integer(scale_request["count"])
 
-        case HostCore.Actors.ActorSupervisor.scale_actor(actor_id, count, actor_ref) do
+        case HostCore.Actors.ActorSupervisor.scale_actor(actor_id, count, actor_ref)
+             |> IO.inspect() do
           :ok ->
+            {:reply, success_ack()}
+
+          {:ok, _pids} ->
             {:reply, success_ack()}
 
           {:error, err} ->

--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -190,18 +190,18 @@ defmodule HostCore.ControlInterface.Server do
   end
 
   # Scale Actor
-  # input: #{"actor_id" => "...", "actor_ref" => "...", "replicas" => "..."}
+  # input: #{"actor_id" => "...", "actor_ref" => "...", "count" => "..."}
   defp handle_request({"cmd", host_id, "scale"}, body, _reply_to) do
     with {:ok, scale_request} <- Jason.decode(body),
          true <-
-           ["actor_id", "actor_ref", "replicas"]
+           ["actor_id", "actor_ref", "count"]
            |> Enum.all?(&Map.has_key?(scale_request, &1)) do
       if host_id == HostCore.Host.host_key() do
         actor_id = scale_request["actor_id"]
         actor_ref = scale_request["actor_ref"]
-        replicas = String.to_integer(scale_request["replicas"])
+        count = String.to_integer(scale_request["count"])
 
-        case HostCore.Actors.ActorSupervisor.scale_actor(actor_id, replicas, actor_ref) do
+        case HostCore.Actors.ActorSupervisor.scale_actor(actor_id, count, actor_ref) do
           :ok ->
             {:reply, success_ack()}
 

--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -203,8 +203,7 @@ defmodule HostCore.ControlInterface.Server do
         actor_ref = scale_request["actor_ref"]
         count = String.to_integer(scale_request["count"])
 
-        case HostCore.Actors.ActorSupervisor.scale_actor(actor_id, count, actor_ref)
-             |> IO.inspect() do
+        case HostCore.Actors.ActorSupervisor.scale_actor(actor_id, count, actor_ref) do
           :ok ->
             {:reply, success_ack()}
 

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.52.0"
+  @app_vsn "0.52.1"
 
   def project do
     [

--- a/host_core/test/host_core/actors_test.exs
+++ b/host_core/test/host_core/actors_test.exs
@@ -92,11 +92,7 @@ defmodule HostCore.ActorsTest do
   test "can load actors", %{:evt_watcher => evt_watcher} do
     on_exit(fn -> HostCore.Host.purge() end)
     {:ok, bytes} = File.read(@kvcounter_path)
-    {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
-    {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
-    {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
-    {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
-    {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
+    {:ok, _pids} = HostCore.Actors.ActorSupervisor.start_actor(bytes, "", 5)
 
     :ok =
       HostCoreTest.EventWatcher.wait_for_event(
@@ -182,8 +178,8 @@ defmodule HostCore.ActorsTest do
     on_exit(fn -> HostCore.Host.purge() end)
     :ets.delete(:refmap_table, @echo_oci_reference)
     :ets.delete(:refmap_table, @echo_old_oci_reference)
-    {:ok, pid} = HostCore.Actors.ActorSupervisor.start_actor_from_oci(@echo_oci_reference)
-    assert Process.alive?(pid)
+    {:ok, pid} = HostCore.Actors.ActorSupervisor.start_actor_from_oci(@echo_oci_reference, 1)
+    assert Process.alive?(pid |> List.first())
 
     actor_count =
       Map.get(HostCore.Actors.ActorSupervisor.all_actors(), @echo_key)
@@ -301,8 +297,8 @@ defmodule HostCore.ActorsTest do
     :ets.delete(:refmap_table, @echo_oci_reference)
     :ets.delete(:refmap_table, @echo_old_oci_reference)
 
-    {:ok, pid} = HostCore.Actors.ActorSupervisor.start_actor_from_oci(@echo_oci_reference)
-    assert Process.alive?(pid)
+    {:ok, pid} = HostCore.Actors.ActorSupervisor.start_actor_from_oci(@echo_oci_reference, 1)
+    assert Process.alive?(pid |> List.first())
 
     res = HostCore.Actors.ActorSupervisor.start_actor_from_oci("wasmcloud.azurecr.io/echo:0.3.0")
 
@@ -314,11 +310,7 @@ defmodule HostCore.ActorsTest do
   test "stop with zero count terminates all", %{:evt_watcher => evt_watcher} do
     on_exit(fn -> HostCore.Host.purge() end)
     {:ok, bytes} = File.read(@kvcounter_path)
-    {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
-    {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
-    {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
-    {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
-    {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
+    {:ok, _pids} = HostCore.Actors.ActorSupervisor.start_actor(bytes, "", 5)
 
     :ok =
       HostCoreTest.EventWatcher.wait_for_event(

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://github.com/wasmCloud/wasmcloud.com-dev/raw/main/static/images/wasm
 
 type: application
 
-version: 0.3.0
+version: 0.3.1
 
-appVersion: "0.52.0"
+appVersion: "0.52.1"

--- a/wasmcloud_host/lib/wasmcloud_host/actor_watcher.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/actor_watcher.ex
@@ -119,18 +119,9 @@ defmodule WasmcloudHost.ActorWatcher do
   end
 
   def start_actor(bytes, replicas) do
-    case 1..replicas
-         |> Enum.reduce_while("", fn _, _ ->
-           case HostCore.Actors.ActorSupervisor.start_actor(bytes) do
-             {:stop, err} ->
-               {:halt, "Error: #{err}"}
-
-             _any ->
-               {:cont, ""}
-           end
-         end) do
-      "" -> :ok
-      msg -> {:error, msg}
+    case HostCore.Actors.ActorSupervisor.start_actor(bytes, "", replicas) do
+      {:ok, _pids} -> :ok
+      {:error, e} -> {:error, e}
     end
   end
 end

--- a/wasmcloud_host/lib/wasmcloud_host/lattice/control_interface.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/lattice/control_interface.ex
@@ -1,14 +1,14 @@
 defmodule WasmcloudHost.Lattice.ControlInterface do
   @wasmbus_prefix "wasmbus.ctl."
 
-  def scale_actor(actor_id, actor_ref, desired_replicas, host_id) do
+  def scale_actor(actor_id, actor_ref, desired_count, host_id) do
     topic = "#{@wasmbus_prefix}#{HostCore.Host.lattice_prefix()}.cmd.#{host_id}.scale"
 
     payload =
       Jason.encode!(%{
         "actor_id" => actor_id,
         "actor_ref" => actor_ref,
-        "replicas" => desired_replicas
+        "count" => desired_count
       })
 
     case ctl_request(topic, payload, 2_000) do

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/actor_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/actor_row_component.ex
@@ -50,7 +50,7 @@ defmodule ActorRowComponent do
         <button id="scale_actor_button_<%= @actor %>_<%= @host_id %>" class="btn btn-sm btn-warning" data-toggle="tooltip"
           data-placement="top" title data-original-title="Scale Actor" phx-click="show_modal"
           phx-value-title='Scale "<%= @name %>"' phx-value-component="ScaleActorComponent" phx-value-id="scale_actor_modal"
-          phx-value-actor="<%= @actor %>" phx-value-host="<%= @host_id %>" phx-value-replicas="<%= @count %>"
+          phx-value-actor="<%= @actor %>" phx-value-host="<%= @host_id %>" phx-value-count="<%= @count %>"
           phx-value-oci="<%= @oci_ref %>">
           <svg class="c-icon" style="color: white">
             <use xlink:href="/coreui/free.svg#cil-equalizer"></use>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
@@ -24,7 +24,7 @@ defmodule ScaleActorComponent do
     case WasmcloudHost.Lattice.ControlInterface.scale_actor(
            actor_id,
            actor_ref,
-           count,
+           String.to_integer(count),
            host_id
          ) do
       :ok ->

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
@@ -14,7 +14,7 @@ defmodule ScaleActorComponent do
   def handle_event(
         "scale_actor",
         %{
-          "desired_replicas" => replicas,
+          "desired_count" => count,
           "actor_id" => actor_id,
           "actor_ociref" => actor_ref,
           "host_id" => host_id
@@ -24,7 +24,7 @@ defmodule ScaleActorComponent do
     case WasmcloudHost.Lattice.ControlInterface.scale_actor(
            actor_id,
            actor_ref,
-           replicas,
+           count,
            host_id
          ) do
       :ok ->
@@ -46,8 +46,8 @@ defmodule ScaleActorComponent do
       <div class="form-group row">
         <label class="col-md-3 col-form-label" for="text-input">Replicas</label>
         <div class="col-md-9">
-          <input class="form-control" id="number-input" type="number" name="desired_replicas"
-            value='<%= Map.get(@modal, "replicas") %>' min="0">
+          <input class="form-control" id="number-input" type="number" name="desired_count"
+            value='<%= Map.get(@modal, "count") %>' min="0">
           <span class="help-block">Enter how many instances of this actor you want</span>
         </div>
       </div>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_actor_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_actor_component.ex
@@ -33,7 +33,7 @@ defmodule StartActorComponent do
 
   def handle_event(
         "start_actor_file",
-        evt = %{"count" => count},
+        %{"count" => count},
         socket
       ) do
     error_msg =
@@ -112,7 +112,7 @@ defmodule StartActorComponent do
     case WasmcloudHost.Lattice.ControlInterface.scale_actor(
            actor_id,
            actor_ociref,
-           count,
+           String.to_integer(count),
            host_id
          ) do
       :ok ->

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.52.0"
+  @app_vsn "0.52.1"
 
   def project do
     [


### PR DESCRIPTION
fixes #332 

This PR makes the start actor accept a `count` field to start multiple instances, and does so in a way that doesn't involve downloading bytes or copying bytes multiple times. Appropriate changes were made in the dashboard to accommodate these changes.

As all of these changes are internal, this is appropriate as a patch bump. The fact that the host did not use the `count` on the start actor payload was a bug.