### PR TITLE
Ensured tests purge before running

### DIFF
--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -90,7 +90,7 @@ defmodule HostCore.Providers.ProviderModule do
       publish_provider_oci_map(claims.public_key, link_name, oci)
     end
 
-    Process.send(self(), :do_health, [:noconnect, :nosuspend])
+    Process.send_after(self(), :do_health, 5_000)
     :timer.send_interval(@thirty_seconds, self(), :do_health)
 
     {:ok,

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -10,6 +10,11 @@ defmodule HostCore.MixProject do
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+			rustler_crates: [
+				hostcore_wasmcloud_native: [
+					mode: (if Mix.env() == :dev, do: :debug, else: :release)
+				]
+			],
       dialyzer: [plt_add_deps: :apps_direct]
     ]
   end

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -10,11 +10,11 @@ defmodule HostCore.MixProject do
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-			rustler_crates: [
-				hostcore_wasmcloud_native: [
-					mode: (if Mix.env() == :dev, do: :debug, else: :release)
-				]
-			],
+      rustler_crates: [
+        hostcore_wasmcloud_native: [
+          mode: if(Mix.env() == :dev, do: :debug, else: :release)
+        ]
+      ],
       dialyzer: [plt_add_deps: :apps_direct]
     ]
   end

--- a/host_core/test/e2e/controlinterface_test.exs
+++ b/host_core/test/e2e/controlinterface_test.exs
@@ -1,6 +1,15 @@
 defmodule HostCore.E2E.ControlInterfaceTest do
   use ExUnit.Case, async: false
 
+  setup do
+    {:ok, evt_watcher} =
+      GenServer.start_link(HostCoreTest.EventWatcher, HostCore.Host.lattice_prefix())
+
+    [
+      evt_watcher: evt_watcher
+    ]
+  end
+
   @echo_key HostCoreTest.Constants.echo_key()
   @echo_path HostCoreTest.Constants.echo_path()
   @kvcounter_key HostCoreTest.Constants.kvcounter_key()
@@ -8,7 +17,7 @@ defmodule HostCore.E2E.ControlInterfaceTest do
   @redis_link HostCoreTest.Constants.default_link()
   @redis_contract HostCoreTest.Constants.keyvalue_contract()
 
-  test "can get claims" do
+  test "can get claims", %{:evt_watcher => evt_watcher} do
     on_exit(fn -> HostCore.Host.purge() end)
     {:ok, bytes} = File.read(@echo_path)
     {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
@@ -27,7 +36,7 @@ defmodule HostCore.E2E.ControlInterfaceTest do
     assert Map.get(echo_claims, "sub") == @echo_key
   end
 
-  test "can get linkdefs" do
+  test "can get linkdefs", %{:evt_watcher => evt_watcher} do
     :ok =
       HostCore.Linkdefs.Manager.put_link_definition(
         @kvcounter_key,

--- a/host_core/test/e2e/echo_test.exs
+++ b/host_core/test/e2e/echo_test.exs
@@ -97,7 +97,7 @@ defmodule HostCore.E2E.EchoTest do
              httpserver_contract,
              @httpserver_link,
              httpserver_key,
-             %{PORT: "8083"}
+             %{PORT: "8084"}
            ) == :ok
 
     {:ok, _pid} =

--- a/host_core/test/e2e/echo_test.exs
+++ b/host_core/test/e2e/echo_test.exs
@@ -93,7 +93,7 @@ defmodule HostCore.E2E.EchoTest do
 
     # OK to put link definition with no claims information
     assert HostCore.Linkdefs.Manager.put_link_definition(
-             @echo_key,
+             @echo_unpriv_key,
              httpserver_contract,
              @httpserver_link,
              httpserver_key,

--- a/host_core/test/host_core/actors_test.exs
+++ b/host_core/test/host_core/actors_test.exs
@@ -28,7 +28,7 @@ defmodule HostCore.ActorsTest do
 
   @pinger_key HostCoreTest.Constants.pinger_key()
 
-  test "live update same revision fails" do
+  test "live update same revision fails", %{:evt_watcher => evt_watcher} do
     on_exit(fn -> HostCore.Host.purge() end)
     :ets.delete(:refmap_table, @echo_oci_reference)
     :ets.delete(:refmap_table, @echo_old_oci_reference)
@@ -37,7 +37,7 @@ defmodule HostCore.ActorsTest do
     assert {:error, :error} == HostCore.Actors.ActorSupervisor.live_update(@echo_oci_reference)
   end
 
-  test "live update with new revision succeeds" do
+  test "live update with new revision succeeds", %{:evt_watcher => evt_watcher} do
     on_exit(fn -> HostCore.Host.purge() end)
     :ets.delete(:refmap_table, @echo_oci_reference)
     :ets.delete(:refmap_table, @echo_old_oci_reference)
@@ -122,7 +122,7 @@ defmodule HostCore.ActorsTest do
     assert Map.get(HostCore.Actors.ActorSupervisor.all_actors(), @kvcounter_key) == nil
   end
 
-  test "can invoke the echo actor" do
+  test "can invoke the echo actor", %{:evt_watcher => evt_watcher} do
     on_exit(fn -> HostCore.Host.purge() end)
     :ets.delete(:refmap_table, @echo_oci_reference)
     :ets.delete(:refmap_table, @echo_old_oci_reference)
@@ -176,7 +176,7 @@ defmodule HostCore.ActorsTest do
              "{\"body\":[104,101,108,108,111],\"method\":\"GET\",\"path\":\"/\",\"query_string\":\"\"}"
   end
 
-  test "can invoke echo via OCI reference" do
+  test "can invoke echo via OCI reference", %{:evt_watcher => evt_watcher} do
     on_exit(fn -> HostCore.Host.purge() end)
     :ets.delete(:refmap_table, @echo_oci_reference)
     :ets.delete(:refmap_table, @echo_old_oci_reference)
@@ -236,7 +236,7 @@ defmodule HostCore.ActorsTest do
              "{\"body\":[104,101,108,108,111],\"method\":\"GET\",\"path\":\"/\",\"query_string\":\"\"}"
   end
 
-  test "can invoke via call alias" do
+  test "can invoke via call alias", %{:evt_watcher => evt_watcher} do
     on_exit(fn -> HostCore.Host.purge() end)
     {:ok, bytes} = File.read("test/fixtures/actors/ponger_s.wasm")
     {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
@@ -289,7 +289,9 @@ defmodule HostCore.ActorsTest do
              "{\"value\":53}"
   end
 
-  test "Prevents an attempt to start an actor with a conflicting OCI reference" do
+  test "Prevents an attempt to start an actor with a conflicting OCI reference", %{
+    :evt_watcher => evt_watcher
+  } do
     on_exit(fn -> HostCore.Host.purge() end)
     # NOTE the reason we block this is because the only supported path to change
     # an actor's OCI reference should be through the live update process, which includes

--- a/host_core/test/support/event_watcher.exs
+++ b/host_core/test/support/event_watcher.exs
@@ -29,6 +29,12 @@ defmodule HostCoreTest.EventWatcher do
         Logger.error("Failed to purge NATS stream for events watcher")
     end
 
+    # Purge all resources from ETS to avoid leftover information
+    :ets.delete_all_objects(:linkdef_table)
+    :ets.delete_all_objects(:claims_table)
+    :ets.delete_all_objects(:refmap_table)
+    :ets.delete_all_objects(:callalias_table)
+
     Registry.register(Registry.EventMonitorRegistry, "cache_loader_events", [])
 
     # Subscribe to lattice events stream

--- a/host_core/test/support/event_watcher.exs
+++ b/host_core/test/support/event_watcher.exs
@@ -20,7 +20,6 @@ defmodule HostCoreTest.EventWatcher do
   @impl true
   def init(prefix) do
     purge_topic = "$JS.API.STREAM.PURGE.LATTICECACHE_#{prefix}"
-    _stream_topic = "lc.#{prefix}.>"
 
     case Gnat.request(:control_nats, purge_topic, []) do
       {:ok, %{body: _body}} ->


### PR DESCRIPTION
Tests that depend on or establish linkdefs, claims, or OCI references need to purge the stream before they run their test. The event watcher is a means-to-an-end here, e.g. it isn't strictly necessary for these tests but the initialization function is useful. Happy to split this out into another piece of logic if needed.