### PR TITLE
Bumped to 0.52.3 for docker re-release

### DIFF
--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.52.2"
+  @app_vsn "0.52.3"
 
   def project do
     [

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://github.com/wasmCloud/wasmcloud.com-dev/raw/main/static/images/wasm
 
 type: application
 
-version: 0.3.2
+version: 0.3.3
 
-appVersion: "0.52.2"
+appVersion: "0.52.3"

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.52.2"
+  @app_vsn "0.52.3"
 
   def project do
     [


### PR DESCRIPTION
After #339 merged, wanted to bump patch versions to re-release the aarch64 docker container