### PR TITLE
Initial implementation of support for supplemental config via service

### DIFF
--- a/host_core/README.md
+++ b/host_core/README.md
@@ -10,7 +10,7 @@ The use of the [Makefile](./Makefile) is preferred for building and running this
 
 - [Elixir installation](https://elixir-lang.org/install.html), minimum `v1.12.0`
 - [Erlang/OTP installation](https://elixir-lang.org/install.html#installing-erlang), minimum `OTP 22`
-- [NATS installation](https://docs.nats.io/nats-server/installation), minimum `v2.3.4`
+- [NATS installation](https://docs.nats.io/nats-server/installation), minimum `v2.7.2`
 
 ## Installation and Running
 
@@ -20,7 +20,7 @@ If instead you prefer to work from the production release, then consult our [ins
 
 ### NATS
 
-This OTP application requires the use of NATS with the JetStream server enabled (**v2.3.4** or later). Thankfully JetStream comes built-in to all NATS servers and you can simply launch your server with the `-js` or `--jetstream` flag.
+This OTP application requires the use of NATS with the JetStream server enabled (**v2.7.2** or later). Thankfully JetStream comes built-in to all NATS servers and you can simply launch your server with the `-js` or `--jetstream` flag.
 
 This OTP application will _fail to start_ without a running NATS server.
 

--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -288,7 +288,6 @@ defmodule HostCore.Actors.ActorModule do
     }
 
     Agent.update(agent, fn _content -> raw_state end)
-    Logger.debug("Agent state updated")
 
     # invoke __guest_call
     # if it fails, set guest_error, return 1

--- a/host_core/lib/host_core/actors/actor_supervisor.ex
+++ b/host_core/lib/host_core/actors/actor_supervisor.ex
@@ -65,7 +65,10 @@ defmodule HostCore.Actors.ActorSupervisor do
   end
 
   def start_actor_from_oci(oci, count \\ 1) do
+    creds = HostCore.Host.get_creds(oci)
+
     case HostCore.WasmCloud.Native.get_oci_bytes(
+           creds,
            oci,
            HostCore.Oci.allow_latest(),
            HostCore.Oci.allowed_insecure()
@@ -80,7 +83,12 @@ defmodule HostCore.Actors.ActorSupervisor do
   end
 
   def start_actor_from_bindle(bindle_id, count \\ 1) do
-    case HostCore.WasmCloud.Native.get_actor_bindle(String.trim_leading(bindle_id, "bindle://")) do
+    creds = HostCore.Host.get_creds(bindle_id)
+
+    case HostCore.WasmCloud.Native.get_actor_bindle(
+           creds,
+           String.trim_leading(bindle_id, "bindle://")
+         ) do
       {:error, err} ->
         Logger.error("Failed to download bytes from bindle server for #{bindle_id}")
         {:error, err}
@@ -91,8 +99,11 @@ defmodule HostCore.Actors.ActorSupervisor do
   end
 
   def live_update(oci) do
+    creds = HostCore.Host.get_creds(oci)
+
     with {:ok, bytes} <-
            HostCore.WasmCloud.Native.get_oci_bytes(
+             creds,
              oci,
              HostCore.Oci.allow_latest(),
              HostCore.Oci.allowed_insecure()

--- a/host_core/lib/host_core/config_plan.ex
+++ b/host_core/lib/host_core/config_plan.ex
@@ -49,7 +49,8 @@ defmodule HostCore.ConfigPlan do
           {:allow_latest, "WASMCLOUD_OCI_ALLOW_LATEST", required: false, map: &String.to_atom/1},
           {:allowed_insecure, "WASMCLOUD_OCI_ALLOWED_INSECURE",
            required: false, map: &String.split(&1, ",")},
-          {:js_domain, "WASMCLOUD_JS_DOMAIN", required: false}
+          {:js_domain, "WASMCLOUD_JS_DOMAIN", required: false},
+          {:config_service_enabled, "WASMCLOUD_CONFIG_SERVICE", required: false}
         ]
       }
     ]
@@ -80,7 +81,8 @@ defmodule HostCore.ConfigPlan do
       {:provider_delay, "provider_delay", required: false, default: 300},
       {:allow_latest, "allow_latest", required: false, default: false},
       {:allowed_insecure, "allowed_insecure", required: false, default: []},
-      {:js_domain, "js_domain", required: false, default: nil}
+      {:js_domain, "js_domain", required: false, default: nil},
+      {:config_service_enabled, "config_service_enabled", required: false, default: ""}
     ]
   end
 end

--- a/host_core/lib/host_core/config_service_client.ex
+++ b/host_core/lib/host_core/config_service_client.ex
@@ -1,0 +1,31 @@
+defmodule HostCore.ConfigServiceClient do
+  require Logger
+
+  def request_configuration(labels, topic)
+      when is_binary(topic) do
+    topic = "#{topic}.req"
+
+    payload =
+      %{
+        labels: labels
+      }
+      |> Jason.encode!()
+
+    with {:ok, message} <- api_request(topic, payload),
+         {:ok, decoded} <- Jason.decode(message.body) do
+      {:ok, decoded}
+    else
+      {:error, e} ->
+        {:error, "Failed to make config service request: #{inspect(e)}"}
+    end
+  end
+
+  defp api_request(topic, payload, timeout \\ 2_000) do
+    Gnat.request(
+      :control_nats,
+      topic,
+      payload,
+      receive_timeout: timeout
+    )
+  end
+end

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -144,7 +144,7 @@ defmodule HostCore.Host do
         if !Map.has_key?(prov, "imageReference") || !Map.has_key?(prov, "linkName") do
           Logger.error("Not enough information on auto-start provider configuration. Bypassing.")
         else
-          if String.starts_with?(prov["imageReference"], "bindle") do
+          if String.starts_with?(prov["imageReference"], "bindle://") do
             HostCore.Providers.ProviderSupervisor.start_provider_from_bindle(
               prov["imageReference"],
               prov["linkName"]
@@ -160,7 +160,7 @@ defmodule HostCore.Host do
 
       as
       |> Enum.each(fn actor ->
-        if String.starts_with?(actor, "bindle") do
+        if String.starts_with?(actor, "bindle://") do
           HostCore.Actors.ActorSupervisor.start_actor_from_bindle(actor)
         else
           HostCore.Actors.ActorSupervisor.start_actor_from_oci(actor)

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -131,15 +131,15 @@ defmodule HostCore.Host do
   # supp config's prestarts
   @impl true
   def handle_continue(:process_supp_config, %State{supplemental_config: sc} = state) do
-    aps = Map.get(sc, "autoStartProviders", [])
-    as = Map.get(sc, "autoStartActors", [])
+    autostart_providers = Map.get(sc, "autoStartProviders", [])
+    autostart_actors = Map.get(sc, "autoStartActors", [])
 
     Logger.info(
-      "Processing supplemental configuration: #{length(aps)} providers, #{length(as)} actors"
+      "Processing supplemental configuration: #{length(autostart_providers)} providers, #{length(autostart_actors)} actors"
     )
 
     Task.start(fn ->
-      aps
+      autostart_providers
       |> Enum.each(fn prov ->
         if !Map.has_key?(prov, "imageReference") || !Map.has_key?(prov, "linkName") do
           Logger.error("Not enough information on auto-start provider configuration. Bypassing.")
@@ -158,7 +158,7 @@ defmodule HostCore.Host do
         end
       end)
 
-      as
+      autostart_actors
       |> Enum.each(fn actor ->
         if String.starts_with?(actor, "bindle://") do
           HostCore.Actors.ActorSupervisor.start_actor_from_bindle(actor)

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -9,7 +9,7 @@ defmodule HostCore.Host do
 
   defmodule State do
     @moduledoc false
-    defstruct [:host_key, :lattice_prefix, :labels, :friendly_name]
+    defstruct [:host_key, :lattice_prefix, :labels, :friendly_name, :supplemental_config]
   end
 
   @doc """
@@ -73,13 +73,102 @@ defmodule HostCore.Host do
 
     publish_host_started(labels, friendly_name)
 
-    {:ok,
-     %State{
-       host_key: opts.host_key,
-       lattice_prefix: opts.lattice_prefix,
-       friendly_name: friendly_name,
-       labels: labels
-     }}
+    state = %State{
+      host_key: opts.host_key,
+      lattice_prefix: opts.lattice_prefix,
+      friendly_name: friendly_name,
+      labels: labels
+    }
+
+    if config_service_enabled?(opts) do
+      {:ok, state, {:continue, :load_supp_config}}
+    else
+      {:ok, state}
+    end
+  end
+
+  # truthy
+  defp config_service_enabled?(opts) do
+    String.upcase(opts.config_service_enabled) in [
+      "TRUE",
+      "YES",
+      "Y",
+      "YOU BETCHA",
+      "YUPPERS",
+      "TOTES",
+      "ENABLED"
+    ]
+  end
+
+  @impl true
+  def handle_continue(:load_supp_config, state) do
+    topic = "wasmbus.cfg.#{state.lattice_prefix}"
+    Logger.debug("Requesting supplemental host configuration via topic '#{topic}'")
+
+    state =
+      with {:ok, supp_config} <-
+             HostCore.ConfigServiceClient.request_configuration(
+               state.labels,
+               topic
+             ) do
+        %State{state | supplemental_config: supp_config}
+      else
+        {:error, e} ->
+          Logger.error("Failed to obtain supplemental configuration: #{inspect(e)}")
+          state
+      end
+
+    {:noreply, state, {:continue, :process_supp_config}}
+  end
+
+  @impl true
+  def handle_continue(:process_supp_config, %State{supplemental_config: nil} = state) do
+    {:noreply, state}
+  end
+
+  # NOTE - we do this work in a handle continue because we need the registry credentials
+  # to be a part of this process's state prior to attempting to start the components in the
+  # supp config's prestarts
+  @impl true
+  def handle_continue(:process_supp_config, %State{supplemental_config: sc} = state) do
+    aps = Map.get(sc, "autoStartProviders", [])
+    as = Map.get(sc, "autoStartActors", [])
+
+    Logger.info(
+      "Processing supplemental configuration: #{length(aps)} providers, #{length(as)} actors"
+    )
+
+    Task.start(fn ->
+      aps
+      |> Enum.each(fn prov ->
+        if !Map.has_key?(prov, "imageReference") || !Map.has_key?(prov, "linkName") do
+          Logger.error("Not enough information on auto-start provider configuration. Bypassing.")
+        else
+          if String.starts_with?(prov["imageReference"], "bindle") do
+            HostCore.Providers.ProviderSupervisor.start_provider_from_bindle(
+              prov["imageReference"],
+              prov["linkName"]
+            )
+          else
+            HostCore.Providers.ProviderSupervisor.start_provider_from_oci(
+              prov["imageReference"],
+              prov["linkName"]
+            )
+          end
+        end
+      end)
+
+      as
+      |> Enum.each(fn actor ->
+        if String.starts_with?(actor, "bindle") do
+          HostCore.Actors.ActorSupervisor.start_actor_from_bindle(actor)
+        else
+          HostCore.Actors.ActorSupervisor.start_actor_from_oci(actor)
+        end
+      end)
+    end)
+
+    {:noreply, state}
   end
 
   @impl true
@@ -96,6 +185,43 @@ defmodule HostCore.Host do
     Map.new(keys, fn k ->
       {String.slice(k, 5..999) |> String.downcase(), System.get_env(k, "")}
     end)
+  end
+
+  @impl true
+  def handle_call({:get_creds, ref}, _from, state) do
+    nref = ref |> normalize_prefix()
+
+    if state.supplemental_config == nil do
+      {:reply, nil, state}
+    else
+      res =
+        if String.contains?(nref, "@") do
+          # extract server from bindle://invoice@server, look for
+          # credentials in map equal to bindle://server
+          server = nref |> extract_bindle_server()
+
+          if server != nil do
+            Map.get(state.supplemental_config, "registryCredentials", %{})
+            |> Enum.find(fn {k, _v} ->
+              k == "bindle://#{server}"
+            end)
+          else
+            nil
+          end
+        else
+          Map.get(state.supplemental_config, "registryCredentials", %{})
+          |> Enum.find(fn {k, _v} ->
+            String.starts_with?(nref, k)
+          end)
+        end
+
+      {:reply,
+       if res != nil do
+         elem(res, 1)
+       else
+         nil
+       end, state}
+    end
   end
 
   @impl true
@@ -172,6 +298,10 @@ defmodule HostCore.Host do
       [config: config_map] -> config_map[:host_key]
       _ -> ""
     end
+  end
+
+  def get_creds(ref) do
+    GenServer.call(__MODULE__, {:get_creds, ref})
   end
 
   def friendly_name() do
@@ -259,4 +389,22 @@ defmodule HostCore.Host do
     }
     |> Jason.encode!()
   end
+
+  defp normalize_prefix("bindle://" <> _str = s) do
+    s
+  end
+
+  defp normalize_prefix("oci://" <> _str = s) do
+    s
+  end
+
+  defp normalize_prefix(str) do
+    "oci://#{str}"
+  end
+
+  defp extract_bindle_server("bindle://" <> trailing) do
+    trailing |> String.split("@", trim: true) |> Enum.at(-1)
+  end
+
+  defp extract_bindle_server(other), do: other
 end

--- a/host_core/lib/host_core/providers/provider_supervisor.ex
+++ b/host_core/lib/host_core/providers/provider_supervisor.ex
@@ -60,8 +60,11 @@ defmodule HostCore.Providers.ProviderSupervisor do
   end
 
   def start_provider_from_oci(oci, link_name, config_json \\ "") do
+    creds = HostCore.Host.get_creds(oci)
+
     with {:ok, bytes} <-
            HostCore.WasmCloud.Native.get_oci_bytes(
+             creds,
              oci,
              HostCore.Oci.allow_latest(),
              HostCore.Oci.allowed_insecure()
@@ -81,8 +84,11 @@ defmodule HostCore.Providers.ProviderSupervisor do
   end
 
   def start_provider_from_bindle(bindle_id, link_name, config_json \\ "") do
+    creds = HostCore.Host.get_creds(bindle_id)
+
     with {:ok, par} <-
            HostCore.WasmCloud.Native.get_provider_bindle(
+             creds,
              String.trim_leading(bindle_id, "bindle://")
            ),
          {:ok, path} <- extract_executable_to_tmp(par, link_name) do

--- a/host_core/lib/host_core/wasmcloud/native.ex
+++ b/host_core/lib/host_core/wasmcloud/native.ex
@@ -20,12 +20,12 @@ defmodule HostCore.WasmCloud.Native do
       ),
       do: error()
 
-  def get_oci_bytes(_oci_ref, _allow_latest, _allowed_insecure), do: error()
+  def get_oci_bytes(_creds, _oci_ref, _allow_latest, _allowed_insecure), do: error()
   def par_from_bytes(_bytes), do: error()
   def par_cache_path(_subject, _rev, _contract_id, _link_name), do: error()
   def detect_core_host_labels(), do: error()
-  def get_actor_bindle(_bindle_id), do: error()
-  def get_provider_bindle(_bindle_id), do: error()
+  def get_actor_bindle(_creds, _bindle_id), do: error()
+  def get_provider_bindle(_creds, _bindle_id), do: error()
 
   # When the NIF is loaded, it will override functions in this module.
   # Calling error is handles the case when the nif could not be loaded.

--- a/host_core/test/host_core/wasmcloud/native_test.exs
+++ b/host_core/test/host_core/wasmcloud/native_test.exs
@@ -15,7 +15,7 @@ defmodule HostCore.WasmCloud.NativeTest do
   use ExUnit.Case, async: false
 
   test "retrieves provider archive from OCI image" do
-    {:ok, bytes} = HostCore.WasmCloud.Native.get_oci_bytes(@httpserver_oci, false, [])
+    {:ok, bytes} = HostCore.WasmCloud.Native.get_oci_bytes(nil, @httpserver_oci, false, [])
     bytes = bytes |> IO.iodata_to_binary()
 
     {:ok, par} = HostCore.WasmCloud.Native.ProviderArchive.from_bytes(bytes)
@@ -107,7 +107,7 @@ defmodule HostCore.WasmCloud.NativeTest do
   end
 
   test "missing or zero revision is replaced with iat" do
-    {:ok, bytes} = HostCore.WasmCloud.Native.get_oci_bytes(@echo_oci, false, [])
+    {:ok, bytes} = HostCore.WasmCloud.Native.get_oci_bytes(nil, @echo_oci, false, [])
     bytes = bytes |> IO.iodata_to_binary()
     {:ok, claims} = HostCore.WasmCloud.Native.extract_claims(bytes)
     assert claims.public_key == @echo_key
@@ -115,7 +115,7 @@ defmodule HostCore.WasmCloud.NativeTest do
     assert claims.revision == 4
 
     {:ok, bytes} =
-      HostCore.WasmCloud.Native.get_oci_bytes(@httpserver_zero_revision_oci, false, [])
+      HostCore.WasmCloud.Native.get_oci_bytes(nil, @httpserver_zero_revision_oci, false, [])
 
     bytes = bytes |> IO.iodata_to_binary()
     {:ok, par} = HostCore.WasmCloud.Native.ProviderArchive.from_bytes(bytes)
@@ -124,7 +124,7 @@ defmodule HostCore.WasmCloud.NativeTest do
     assert par.claims.issuer == @official_issuer
     assert par.claims.revision == 1_631_292_694
 
-    {:ok, bytes} = HostCore.WasmCloud.Native.get_oci_bytes(@kvcounter_oci, false, [])
+    {:ok, bytes} = HostCore.WasmCloud.Native.get_oci_bytes(nil, @kvcounter_oci, false, [])
     bytes = bytes |> IO.iodata_to_binary()
     {:ok, claims} = HostCore.WasmCloud.Native.extract_claims(bytes)
     assert claims.public_key == @kvcounter_key


### PR DESCRIPTION
At startup, if the `WASMCLOUD_CONFIG_SERVICE` environment variable is truthy,  the wasmCloud host will attempt to pull supplemental configuration from `wasmbus.cfg.{latttice}`.

This configuration may contain a list of actors to auto-start, a list of providers to auto-start, and a map of registry credentials to be used for pulling from secure OCI/bindle registries.

Not included in this PR (to be added later): support for receiving _push_ updates from a config service as a notification that registry credentials have changed.