### PR TITLE
Add support for pushed registry credentials on control interface

### DIFF
--- a/host_core/lib/host_core.ex
+++ b/host_core/lib/host_core.ex
@@ -48,6 +48,7 @@ defmodule HostCore do
            connection_name: :control_nats,
            module: HostCore.ControlInterface.Server,
            subscription_topics: [
+             %{topic: "wasmbus.ctl.#{config.lattice_prefix}.registries.put"},
              %{topic: "wasmbus.ctl.#{config.lattice_prefix}.cmd.#{config.host_key}.*"},
              %{topic: "wasmbus.ctl.#{config.lattice_prefix}.ping.hosts"},
              %{

--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -319,6 +319,22 @@ defmodule HostCore.ControlInterface.Server do
     end
   end
 
+  ### REGISTRY CREDENTIALS (via Config Service)
+  defp handle_request({"registries", "put"}, body, _reply_to) do
+    with {:ok, credsmap} <- Jason.decode(body) do
+      HostCore.Host.set_credsmap(credsmap)
+
+      Logger.debug(
+        "Replaced registry credential map, new registry count: #{length(Map.keys(credsmap))}"
+      )
+    else
+      _ ->
+        Logger.error("failed to update registry credential map")
+    end
+
+    :ok
+  end
+
   ### AUCTIONS
   # All auctions are sent to every host within the lattice
   # so no queue subscription is used.

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -188,6 +188,19 @@ defmodule HostCore.Host do
   end
 
   @impl true
+  def handle_cast({:put_credsmap, credsmap}, state) do
+    # sanitize the incoming map
+    credsmap =
+      credsmap
+      |> Enum.filter(fn {_k, v} ->
+        Map.has_key?(v, "userName") || Map.has_key?(v, "password") || Map.has_key?(v, "token")
+      end)
+      |> Enum.into(%{})
+
+    {:noreply, Map.put(state, "registryCredentials", credsmap)}
+  end
+
+  @impl true
   def handle_call({:get_creds, ref}, _from, state) do
     nref = ref |> normalize_prefix()
 
@@ -284,6 +297,10 @@ defmodule HostCore.Host do
     :ets.new(:refmap_table, [:named_table, :set, :public])
     :ets.new(:callalias_table, [:named_table, :set, :public])
     :ets.new(:config_table, [:named_table, :set, :public])
+  end
+
+  def set_credsmap(credsmap) do
+    GenServer.cast(__MODULE__, {:put_credsmap, credsmap})
   end
 
   def lattice_prefix() do


### PR DESCRIPTION
Control interface server now supports the broadcast message on `registries.put`.