### PR TITLE
Add procps to wasmcloud Docker image

### DIFF
--- a/wasmcloud_host/Dockerfile
+++ b/wasmcloud_host/Dockerfile
@@ -130,7 +130,8 @@ RUN apt update && \
   ca-certificates \
   curl \
   locales \
-  libssl-dev && \
+  libssl-dev \
+  procps && \
   export LANG=en_US.UTF-8 && \
     echo $LANG UTF-8 > /etc/locale.gen && \
     locale-gen && \


### PR DESCRIPTION
Add procps to the Docker image so that it installs `kill` as a binary
instead of just a shell builtin.

Partial fix for #344.