### PR TITLE
Return an error to the host if it fails to read a par file

### DIFF
--- a/host_core/native/hostcore_wasmcloud_native/src/lib.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/lib.rs
@@ -347,7 +347,7 @@ fn par_from_path(
                     },
                 ))
             }
-            Err(_) => Err(Error::BadArg),
+            Err(e) => Err(Error::Term(Box::new(format!("{}", e)))),
         }
     })
 }


### PR DESCRIPTION
`par_from_file` in the Rust NIF returns a generic argument error if it
fails to load. It can fail for a number of reasons, so instead of
returning a generic error, return the error message generated from the
underlying provider library.