### PR TITLE
Wrapping all NATS calls in safe bubble-wrap

### DIFF
--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -229,7 +229,7 @@ defmodule HostCore.Actors.ActorModule do
            }, nil}
       end
 
-    Gnat.pub(:lattice_nats, reply_to, ir |> Msgpax.pack!() |> IO.iodata_to_binary())
+    HostCore.Nats.safe_pub(:lattice_nats, reply_to, ir |> Msgpax.pack!() |> IO.iodata_to_binary())
 
     Task.start(fn ->
       publish_invocation_result(inv, ir)
@@ -447,7 +447,7 @@ defmodule HostCore.Actors.ActorModule do
       |> CloudEvent.new(evt_type)
 
     topic = "wasmbus.evt.#{prefix}"
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
   def publish_actor_started(claims, api_version, instance_id, oci) do
@@ -475,7 +475,7 @@ defmodule HostCore.Actors.ActorModule do
 
     topic = "wasmbus.evt.#{prefix}"
 
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
   def publish_actor_updated(actor_pk, revision, instance_id) do
@@ -491,7 +491,7 @@ defmodule HostCore.Actors.ActorModule do
 
     topic = "wasmbus.evt.#{prefix}"
 
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
   def publish_actor_stopped(actor_pk, instance_id) do
@@ -506,7 +506,7 @@ defmodule HostCore.Actors.ActorModule do
 
     topic = "wasmbus.evt.#{prefix}"
 
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
   defp publish_check_passed(agent) do
@@ -522,7 +522,7 @@ defmodule HostCore.Actors.ActorModule do
       |> CloudEvent.new("health_check_passed")
 
     topic = "wasmbus.evt.#{prefix}"
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
 
     nil
   end
@@ -541,7 +541,7 @@ defmodule HostCore.Actors.ActorModule do
       |> CloudEvent.new("health_check_failed")
 
     topic = "wasmbus.evt.#{prefix}"
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
 
     nil
   end

--- a/host_core/lib/host_core/claims/manager.ex
+++ b/host_core/lib/host_core/claims/manager.ex
@@ -67,7 +67,7 @@ defmodule HostCore.Claims.Manager do
     prefix = HostCore.Host.lattice_prefix()
     topic = "lc.#{prefix}.claims.#{claims.sub}"
 
-    Gnat.pub(:control_nats, topic, Jason.encode!(claims))
+    HostCore.Nats.safe_pub(:control_nats, topic, Jason.encode!(claims))
   end
 
   def get_claims() do

--- a/host_core/lib/host_core/config_service_client.ex
+++ b/host_core/lib/host_core/config_service_client.ex
@@ -21,7 +21,7 @@ defmodule HostCore.ConfigServiceClient do
   end
 
   defp api_request(topic, payload, timeout \\ 2_000) do
-    Gnat.request(
+    HostCore.Nats.safe_req(
       :control_nats,
       topic,
       payload,

--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -415,7 +415,7 @@ defmodule HostCore.ControlInterface.Server do
 
     topic = "wasmbus.evt.#{prefix}"
 
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
   defp publish_provider_start_failed(command, msg) do
@@ -431,7 +431,7 @@ defmodule HostCore.ControlInterface.Server do
 
     topic = "wasmbus.evt.#{prefix}"
 
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
   defp success_ack() do

--- a/host_core/lib/host_core/heartbeat_emitter.ex
+++ b/host_core/lib/host_core/heartbeat_emitter.ex
@@ -42,7 +42,7 @@ defmodule HostCore.HeartbeatEmitter do
     Logger.debug("Publishing heartbeat")
     topic = "wasmbus.evt.#{state[:lattice_prefix]}"
     msg = generate_heartbeat(state)
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
   defp generate_heartbeat(state) do

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -272,7 +272,7 @@ defmodule HostCore.Host do
 
     topic = "wasmbus.evt.#{prefix}"
 
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
   defp publish_host_started(labels, friendly_name) do
@@ -287,7 +287,7 @@ defmodule HostCore.Host do
 
     topic = "wasmbus.evt.#{prefix}"
 
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
   defp configure_ets() do

--- a/host_core/lib/host_core/jetstream/client.ex
+++ b/host_core/lib/host_core/jetstream/client.ex
@@ -52,7 +52,7 @@ defmodule HostCore.Jetstream.Client do
       |> Jason.encode!()
 
     cont =
-      case Gnat.request(:control_nats, create_topic, payload_json) do
+      case HostCore.Nats.safe_req(:control_nats, create_topic, payload_json) do
         {:ok, %{body: body}} ->
           handle_stream_create_response(body |> Jason.decode!())
 
@@ -101,7 +101,7 @@ defmodule HostCore.Jetstream.Client do
       }
       |> Jason.encode!()
 
-    case Gnat.request(:control_nats, create_topic, payload_json) do
+    case HostCore.Nats.safe_req(:control_nats, create_topic, payload_json) do
       {:ok, %{body: body}} ->
         handle_consumer_create_response(body |> Jason.decode!())
 

--- a/host_core/lib/host_core/linkdefs/manager.ex
+++ b/host_core/lib/host_core/linkdefs/manager.ex
@@ -80,9 +80,9 @@ defmodule HostCore.Linkdefs.Manager do
       }
       |> CloudEvent.new("linkdef_set")
 
-    Gnat.pub(:control_nats, cache_topic, Jason.encode!(ld))
-    Gnat.pub(:lattice_nats, provider_topic, Msgpax.pack!(ld))
-    Gnat.pub(:control_nats, event_topic, evtmsg)
+    HostCore.Nats.safe_pub(:control_nats, cache_topic, Jason.encode!(ld))
+    HostCore.Nats.safe_pub(:lattice_nats, provider_topic, Msgpax.pack!(ld))
+    HostCore.Nats.safe_pub(:control_nats, event_topic, evtmsg)
   end
 
   # Publishes the removal of a link definition to the stream and tells the provider via RPC
@@ -107,10 +107,10 @@ defmodule HostCore.Linkdefs.Manager do
       }
       |> CloudEvent.new("linkdef_deleted")
 
-    Gnat.pub(:lattice_nats, provider_topic, Msgpax.pack!(ld))
+    HostCore.Nats.safe_pub(:lattice_nats, provider_topic, Msgpax.pack!(ld))
     ld = Map.put(ld, :deleted, true)
-    Gnat.pub(:control_nats, cache_topic, Jason.encode!(ld))
-    Gnat.pub(:control_nats, event_topic, evtmsg)
+    HostCore.Nats.safe_pub(:control_nats, cache_topic, Jason.encode!(ld))
+    HostCore.Nats.safe_pub(:control_nats, event_topic, evtmsg)
   end
 
   def get_link_definitions() do

--- a/host_core/lib/host_core/nats.ex
+++ b/host_core/lib/host_core/nats.ex
@@ -52,4 +52,24 @@ defmodule HostCore.Nats do
         %{}
     end
   end
+
+  def safe_pub(process_name, topic, msg) do
+    if Process.whereis(process_name) != nil do
+      Gnat.pub(process_name, topic, msg)
+    else
+      Logger.warn("Publication on #{topic} aborted - connection #{process_name} is down")
+    end
+  end
+
+  def safe_req(process_name, topic, body, opts \\ []) do
+    if Process.whereis(process_name) != nil do
+      Gnat.request(process_name, topic, body, opts)
+    else
+      Logger.error(
+        "NATS request for #{topic} aborted, connection #{process_name} is down. Returning 'fast timeout'"
+      )
+
+      {:error, :timeout}
+    end
+  end
 end

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -190,7 +190,9 @@ defmodule HostCore.Providers.ProviderModule do
 
     res =
       try do
-        Gnat.request(:lattice_nats, topic, payload, receive_timeout: HostCore.Host.rpc_timeout())
+        HostCore.Nats.safe_req(:lattice_nats, topic, payload,
+          receive_timeout: HostCore.Host.rpc_timeout()
+        )
       rescue
         _e -> {:error, "Received no response on health check topic from provider"}
       end
@@ -239,7 +241,7 @@ defmodule HostCore.Providers.ProviderModule do
 
     topic = "wasmbus.evt.#{prefix}"
 
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
   defp publish_health_failed(state) do
@@ -254,7 +256,7 @@ defmodule HostCore.Providers.ProviderModule do
 
     topic = "wasmbus.evt.#{prefix}"
 
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
   @spec publish_provider_stopped(String.t(), String.t(), String.t(), String.t(), String.t()) ::
@@ -274,7 +276,7 @@ defmodule HostCore.Providers.ProviderModule do
 
     topic = "wasmbus.evt.#{prefix}"
 
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
   defp publish_provider_started(claims, link_name, contract_id, instance_id, image_ref) do
@@ -300,6 +302,6 @@ defmodule HostCore.Providers.ProviderModule do
 
     topic = "wasmbus.evt.#{prefix}"
 
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 end

--- a/host_core/lib/host_core/providers/provider_supervisor.ex
+++ b/host_core/lib/host_core/providers/provider_supervisor.ex
@@ -141,7 +141,7 @@ defmodule HostCore.Providers.ProviderSupervisor do
         prefix = HostCore.Host.lattice_prefix()
 
         # Allow provider 2 seconds to respond/acknowledge termination request (give time to clean up resources)
-        case Gnat.request(
+        case HostCore.Nats.safe_req(
                :lattice_nats,
                "wasmbus.rpc.#{prefix}.#{public_key}.#{link_name}.shutdown",
                "",

--- a/host_core/lib/host_core/refmaps/manager.ex
+++ b/host_core/lib/host_core/refmaps/manager.ex
@@ -40,7 +40,12 @@ defmodule HostCore.Refmaps.Manager do
       }
       |> CloudEvent.new("refmap_set")
 
-    Gnat.pub(:control_nats, topic, Jason.encode!(%{oci_url: oci_url, public_key: public_key}))
-    Gnat.pub(:control_nats, event_topic, evtmsg)
+    HostCore.Nats.safe_pub(
+      :control_nats,
+      topic,
+      Jason.encode!(%{oci_url: oci_url, public_key: public_key})
+    )
+
+    HostCore.Nats.safe_pub(:control_nats, event_topic, evtmsg)
   end
 end

--- a/host_core/lib/host_core/web_assembly/imports.ex
+++ b/host_core/lib/host_core/web_assembly/imports.ex
@@ -391,7 +391,7 @@ defmodule HostCore.WebAssembly.Imports do
       |> CloudEvent.new(evt_type)
 
     topic = "wasmbus.evt.#{prefix}"
-    Gnat.pub(:control_nats, topic, msg)
+    HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
   defp lookup_call_alias(call_alias) do
@@ -406,7 +406,7 @@ defmodule HostCore.WebAssembly.Imports do
 
   defp perform_rpc_invoke(inv_bytes, target_subject, timeout) do
     # Perform RPC invocation over lattice
-    case Gnat.request(:lattice_nats, target_subject, inv_bytes, receive_timeout: timeout) do
+    case HostCore.Nats.safe_req(:lattice_nats, target_subject, inv_bytes, receive_timeout: timeout) do
       {:ok, %{body: body}} -> body
       {:error, :timeout} -> :fail
     end

--- a/host_core/test/e2e/controlinterface_test.exs
+++ b/host_core/test/e2e/controlinterface_test.exs
@@ -25,7 +25,8 @@ defmodule HostCore.E2E.ControlInterfaceTest do
     prefix = HostCore.Host.lattice_prefix()
     topic = "wasmbus.ctl.#{prefix}.get.claims"
 
-    {:ok, %{body: body}} = Gnat.request(:control_nats, topic, [], receive_timeout: 2_000)
+    {:ok, %{body: body}} =
+      HostCore.Nats.safe_req(:control_nats, topic, [], receive_timeout: 2_000)
 
     echo_claims =
       body
@@ -49,7 +50,8 @@ defmodule HostCore.E2E.ControlInterfaceTest do
     prefix = HostCore.Host.lattice_prefix()
     topic = "wasmbus.ctl.#{prefix}.get.links"
 
-    {:ok, %{body: body}} = Gnat.request(:control_nats, topic, [], receive_timeout: 2_000)
+    {:ok, %{body: body}} =
+      HostCore.Nats.safe_req(:control_nats, topic, [], receive_timeout: 2_000)
 
     kvcounter_redis_link =
       body

--- a/host_core/test/host_core/actors_test.exs
+++ b/host_core/test/host_core/actors_test.exs
@@ -73,7 +73,7 @@ defmodule HostCore.ActorsTest do
     topic = "wasmbus.rpc.#{HostCore.Host.lattice_prefix()}.#{@echo_key}"
 
     res =
-      case Gnat.request(:lattice_nats, topic, inv, receive_timeout: 2_000) do
+      case HostCore.Nats.safe_req(:lattice_nats, topic, inv, receive_timeout: 2_000) do
         {:ok, %{body: body}} -> body
         {:error, :timeout} -> :fail
       end
@@ -160,7 +160,7 @@ defmodule HostCore.ActorsTest do
     topic = "wasmbus.rpc.#{HostCore.Host.lattice_prefix()}.#{@echo_key}"
 
     res =
-      case Gnat.request(:lattice_nats, topic, inv, receive_timeout: 12_000) do
+      case HostCore.Nats.safe_req(:lattice_nats, topic, inv, receive_timeout: 12_000) do
         {:ok, %{body: body}} -> body
         {:error, :timeout} -> :fail
       end
@@ -212,7 +212,7 @@ defmodule HostCore.ActorsTest do
     topic = "wasmbus.rpc.#{HostCore.Host.lattice_prefix()}.#{@echo_key}"
 
     res =
-      case Gnat.request(:lattice_nats, topic, inv, receive_timeout: 2_000) do
+      case HostCore.Nats.safe_req(:lattice_nats, topic, inv, receive_timeout: 2_000) do
         {:ok, %{body: body}} -> body
         {:error, :timeout} -> :fail
       end
@@ -272,7 +272,7 @@ defmodule HostCore.ActorsTest do
     topic = "wasmbus.rpc.#{HostCore.Host.lattice_prefix()}.#{@echo_key}"
 
     res =
-      case Gnat.request(:lattice_nats, topic, inv, receive_timeout: 2_000) do
+      case HostCore.Nats.safe_req(:lattice_nats, topic, inv, receive_timeout: 2_000) do
         {:ok, %{body: body}} -> body
         {:error, :timeout} -> :fail
       end
@@ -325,7 +325,7 @@ defmodule HostCore.ActorsTest do
     topic = "wasmbus.rpc.#{HostCore.Host.lattice_prefix()}.#{@pinger_key}"
 
     res =
-      case Gnat.request(:lattice_nats, topic, inv, receive_timeout: 2_000) do
+      case HostCore.Nats.safe_req(:lattice_nats, topic, inv, receive_timeout: 2_000) do
         {:ok, %{body: body}} -> body
         {:error, :timeout} -> :fail
       end

--- a/host_core/test/support/event_watcher.exs
+++ b/host_core/test/support/event_watcher.exs
@@ -21,7 +21,7 @@ defmodule HostCoreTest.EventWatcher do
   def init(prefix) do
     purge_topic = "$JS.API.STREAM.PURGE.LATTICECACHE_#{prefix}"
 
-    case Gnat.request(:control_nats, purge_topic, []) do
+    case HostCore.Nats.safe_req(:control_nats, purge_topic, []) do
       {:ok, %{body: _body}} ->
         Logger.debug("Purged NATS stream for events watcher")
 


### PR DESCRIPTION
Host no longer crashes during a network partition event that disconnects it from its NATS server. We will now see warnings and errors published to the standard logger and the host will automatically recover when connectivity is restored.

While it's a small change, it should contribute greatly to the resiliency of a host in cloud environments.