### PR TITLE
0.53.0

### DIFF
--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.52.5"
+  @app_vsn "0.53.0"
 
   def project do
     [

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://github.com/wasmCloud/wasmcloud.com-dev/raw/main/static/images/wasm
 
 type: application
 
-version: 0.3.5
+version: 0.4.0
 
-appVersion: "0.52.5"
+appVersion: "0.53.0"

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.52.5"
+  @app_vsn "0.53.0"
 
   def project do
     [


### PR DESCRIPTION
With this release we get:
1. Invocation chunking support
2. Terminating providers when the linked binary exits (gracefully or due to panic)
3. safe NATS calls that don't crash genservers when network briefly fails
4. better clarified errors for timeouts
5. actors safely terminate if wasmex fails to start