### PR TITLE
[fix] add inotify-tools to wasmcloud_host image

### DIFF
--- a/wasmcloud_host/Dockerfile
+++ b/wasmcloud_host/Dockerfile
@@ -131,6 +131,7 @@ RUN apt update && \
   curl \
   locales \
   libssl-dev \
+  inotify-tools \
   procps && \
   export LANG=en_US.UTF-8 && \
     echo $LANG UTF-8 > /etc/locale.gen && \


### PR DESCRIPTION
This PR adds inotify-tools to the installed packages in the release
image of wasmcloud_host. This is necessary for live reload of actors
to work successfully, particularly when used in the docker-compose file
as a bind mount between a remote host and wasmcloud_host. In this case,
the remote system having inotify is not germane to the 
wasmcloud_host application monitoring it's newly visible and watched
files in it's own os environment and package set, which needs inotify for
functioning live-reload.