### PR TITLE
fix(host_core): Avoids crashing when passing a JS domain

### DIFF
--- a/host_core/lib/host_core.ex
+++ b/host_core/lib/host_core.ex
@@ -135,7 +135,7 @@ defmodule HostCore do
 
     chunk_config =
       if config.js_domain != nil do
-        Map.put(config, "js_domain", config.js_domain)
+        Map.put(chunk_config, "js_domain", config.js_domain)
       else
         chunk_config
       end

--- a/host_core/native/hostcore_wasmcloud_native/src/lib.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/lib.rs
@@ -133,7 +133,7 @@ fn set_chunking_connection_config(config: HashMap<String, String>) -> Result<Ato
     let lattice = config
         .get("lattice")
         .cloned()
-        .unwrap_or("default".to_string());
+        .unwrap_or_else(|| "default".to_string());
     let store = objstore::create_or_reuse_store(&js, &lattice).map_err(to_rustler_err)?;
 
     *CHUNKING_STORE.write().unwrap() = Some(store);
@@ -515,7 +515,7 @@ fn generate_invocation_bytes(
         msg.as_slice().to_vec(),
     );
     if msg.len() > CHONKY_THRESHOLD_BYTES {
-        inv.msg = vec![];        
+        inv.msg = vec![];
         objstore::chonk_to_object_store(&inv.id, &mut msg.as_slice())?;
     }
     Ok(inv::serialize(&inv).unwrap())


### PR DESCRIPTION
The new chunk config was unintentionally adding a value to the original `config`
object rather than adding to the chunk config