### PR TITLE
[BUG] Dashboard values cannot handle base64 '=' padding characters

### DIFF
--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/define_link_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/define_link_component.ex
@@ -32,7 +32,7 @@ defmodule DefineLinkComponent do
         value_list ->
           value_list
           |> String.split(",")
-          |> Enum.flat_map(fn s -> String.split(s, "=") end)
+          |> Enum.flat_map(fn s -> String.split(s, "=", parts: 2) end)
           |> Enum.chunk_every(2)
           |> Enum.map(fn [a, b] -> {a, b} end)
           |> Map.new()


### PR DESCRIPTION
Addresses #369

Utilize the parts option to only split once to ensure correct key=value decoding behavior.

See [Hex docs](https://hexdocs.pm/elixir/String.html#split/3-options)

Matches what wash does. [See wash](https://github.com/wasmCloud/wash/blob/4e9ccc406b7ca996fb1e6153aa93732d62047186/src/util.rs#L133)
