### PR TITLE
Adds support for per-instance annotaions on providers and actors

### DIFF
--- a/host_core/lib/host_core/actors/actor_supervisor.ex
+++ b/host_core/lib/host_core/actors/actor_supervisor.ex
@@ -14,9 +14,7 @@ defmodule HostCore.Actors.ActorSupervisor do
     DynamicSupervisor.init(strategy: :one_for_one)
   end
 
-  @spec start_actor(bytes :: binary(), oci :: String.t(), count :: Integer.t()) ::
-          {:error, any} | {:ok, [pid()]}
-  def start_actor(bytes, oci \\ "", count \\ 1) when is_binary(bytes) do
+  def start_actor(bytes, oci \\ "", count \\ 1, annotations \\ %{}) when is_binary(bytes) do
     Logger.debug("Start actor request received", oci_ref: oci)
 
     case HostCore.WasmCloud.Native.extract_claims(bytes) do
@@ -34,7 +32,7 @@ defmodule HostCore.Actors.ActorSupervisor do
                |> Enum.reduce_while([], fn _count, pids ->
                  case DynamicSupervisor.start_child(
                         __MODULE__,
-                        {HostCore.Actors.ActorModule, {claims, bytes, oci}}
+                        {HostCore.Actors.ActorModule, {claims, bytes, oci, annotations}}
                       ) do
                    {:error, err} ->
                      {:halt, {:error, "Error: #{err}"}}
@@ -64,7 +62,7 @@ defmodule HostCore.Actors.ActorSupervisor do
     |> length() > 0
   end
 
-  def start_actor_from_oci(oci, count \\ 1) do
+  def start_actor_from_oci(oci, count \\ 1, annotations \\ %{}) do
     creds = HostCore.Host.get_creds(oci)
 
     case HostCore.WasmCloud.Native.get_oci_bytes(
@@ -78,11 +76,11 @@ defmodule HostCore.Actors.ActorSupervisor do
         {:error, err}
 
       {:ok, bytes} ->
-        start_actor(bytes |> IO.iodata_to_binary(), oci, count)
+        start_actor(bytes |> IO.iodata_to_binary(), oci, count, annotations)
     end
   end
 
-  def start_actor_from_bindle(bindle_id, count \\ 1) do
+  def start_actor_from_bindle(bindle_id, count \\ 1, annotations \\ %{}) do
     creds = HostCore.Host.get_creds(bindle_id)
 
     case HostCore.WasmCloud.Native.get_actor_bindle(
@@ -98,7 +96,7 @@ defmodule HostCore.Actors.ActorSupervisor do
         {:error, err}
 
       {:ok, bytes} ->
-        start_actor(bytes |> IO.iodata_to_binary(), bindle_id, count)
+        start_actor(bytes |> IO.iodata_to_binary(), bindle_id, count, annotations)
     end
   end
 

--- a/host_core/lib/host_core/control_interface/acl.ex
+++ b/host_core/lib/host_core/control_interface/acl.ex
@@ -11,7 +11,7 @@ defmodule HostCore.ControlInterface.ACL do
         pids
         |> Enum.map(fn pid ->
           %{
-            annotations: %{},
+            annotations: HostCore.Actors.ActorModule.annotations(pid),
             instance_id: HostCore.Actors.ActorModule.instance_id(pid),
             revision: revision
           }
@@ -41,6 +41,7 @@ defmodule HostCore.ControlInterface.ACL do
         link_name: link,
         name: name,
         instance_id: instance_id,
+        annotations: HostCore.Providers.ProviderModule.annotations(pid),
         revision: revision
       }
     end)

--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -7,10 +7,10 @@ defmodule HostCore.ControlInterface.Server do
   alias HostCore.CloudEvent
 
   import HostCore.Actors.ActorSupervisor,
-    only: [start_actor_from_bindle: 2, start_actor_from_oci: 2]
+    only: [start_actor_from_bindle: 3, start_actor_from_oci: 3]
 
   import HostCore.Providers.ProviderSupervisor,
-    only: [start_provider_from_bindle: 3, start_provider_from_oci: 3]
+    only: [start_provider_from_bindle: 4, start_provider_from_oci: 4]
 
   def request(%{topic: topic, body: body, reply_to: reply_to}) do
     topic
@@ -145,12 +145,13 @@ defmodule HostCore.ControlInterface.Server do
            Map.has_key?(start_actor_command, "actor_ref") do
       Task.start(fn ->
         count = Map.get(start_actor_command, "count", 1)
+        annotations = Map.get(start_actor_command, "annotations", %{})
 
         res =
           if String.starts_with?(start_actor_command["actor_ref"], "bindle://") do
-            start_actor_from_bindle(start_actor_command["actor_ref"], count)
+            start_actor_from_bindle(start_actor_command["actor_ref"], count, annotations)
           else
-            start_actor_from_oci(start_actor_command["actor_ref"], count)
+            start_actor_from_oci(start_actor_command["actor_ref"], count, annotations)
           end
 
         case res do
@@ -237,18 +238,22 @@ defmodule HostCore.ControlInterface.Server do
            start_provider_command["link_name"]
          ) do
         Task.start(fn ->
+          annotations = Map.get(start_provider_command, "annotations", %{})
+
           res =
             if String.starts_with?(start_provider_command["provider_ref"], "bindle://") do
               start_provider_from_bindle(
                 start_provider_command["provider_ref"],
                 start_provider_command["link_name"],
-                Map.get(start_provider_command, "configuration", "")
+                Map.get(start_provider_command, "configuration", ""),
+                annotations
               )
             else
               start_provider_from_oci(
                 start_provider_command["provider_ref"],
                 start_provider_command["link_name"],
-                Map.get(start_provider_command, "configuration", "")
+                Map.get(start_provider_command, "configuration", ""),
+                annotations
               )
             end
 

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -17,6 +17,7 @@ defmodule HostCore.Providers.ProviderModule do
       :public_key,
       :lattice_prefix,
       :instance_id,
+      :annotations,
       :executable_path,
       :ociref,
       :healthy
@@ -38,6 +39,10 @@ defmodule HostCore.Providers.ProviderModule do
     GenServer.call(pid, :get_instance_id)
   end
 
+  def annotations(pid) do
+    GenServer.call(pid, :get_annotations)
+  end
+
   def ociref(pid) do
     GenServer.call(pid, :get_ociref)
   end
@@ -51,7 +56,7 @@ defmodule HostCore.Providers.ProviderModule do
   end
 
   @impl true
-  def init({:executable, path, claims, link_name, contract_id, oci, config_json}) do
+  def init({:executable, path, claims, link_name, contract_id, oci, config_json, annotations}) do
     Logger.info("Starting executable capability provider at  '#{path}'",
       provider_id: claims.public_key,
       link_name: link_name,
@@ -84,11 +89,11 @@ defmodule HostCore.Providers.ProviderModule do
     {:os_pid, pid} = Port.info(port, :os_pid)
 
     # Worth pointing out here that this process doesn't need to subscribe to
-    # the provider's NATS topic. The provider now subscribes to that directly
+    # the provider's NATS topic. The provider subscribes to that directly
     # when it starts.
 
     HostCore.Claims.Manager.put_claims(claims)
-    publish_provider_started(claims, link_name, contract_id, instance_id, oci)
+    publish_provider_started(claims, link_name, contract_id, instance_id, oci, annotations)
 
     if oci != nil && oci != "" do
       publish_provider_oci_map(claims.public_key, link_name, oci)
@@ -107,6 +112,7 @@ defmodule HostCore.Providers.ProviderModule do
        instance_id: instance_id,
        lattice_prefix: HostCore.Host.lattice_prefix(),
        executable_path: path,
+       annotations: annotations,
        # until we prove otherwise
        healthy: false,
        ociref: oci
@@ -140,6 +146,11 @@ defmodule HostCore.Providers.ProviderModule do
   @impl true
   def handle_call(:get_instance_id, _from, state) do
     {:reply, state.instance_id, state}
+  end
+
+  @impl true
+  def handle_call(:get_annotations, _from, state) do
+    {:reply, state.annotations, state}
   end
 
   @impl true
@@ -295,7 +306,7 @@ defmodule HostCore.Providers.ProviderModule do
     HostCore.Nats.safe_pub(:control_nats, topic, msg)
   end
 
-  defp publish_provider_started(claims, link_name, contract_id, instance_id, image_ref) do
+  defp publish_provider_started(claims, link_name, contract_id, instance_id, image_ref, annotations) do
     prefix = HostCore.Host.lattice_prefix()
 
     msg =
@@ -305,6 +316,7 @@ defmodule HostCore.Providers.ProviderModule do
         link_name: link_name,
         contract_id: contract_id,
         instance_id: instance_id,
+        annotations: annotations,
         claims: %{
           issuer: claims.issuer,
           tags: claims.tags,

--- a/host_core/lib/host_core/refmaps/manager.ex
+++ b/host_core/lib/host_core/refmaps/manager.ex
@@ -28,7 +28,7 @@ defmodule HostCore.Refmaps.Manager do
   end
 
   def publish_refmap(oci_url, public_key) do
-    Logger.debug("Publishing ref map")
+    Logger.debug("Publishing ref map for #{inspect(oci_url)}")
     prefix = HostCore.Host.lattice_prefix()
     topic = "lc.#{prefix}.refmap.#{HostCore.Nats.sanitize_for_topic(oci_url)}"
     event_topic = "wasmbus.evt.#{prefix}"

--- a/host_core/test/host_core/providers_test.exs
+++ b/host_core/test/host_core/providers_test.exs
@@ -23,7 +23,10 @@ defmodule HostCore.ProvidersTest do
     {:ok, _pid} =
       HostCore.Providers.ProviderSupervisor.start_provider_from_file(
         @httpserver_path,
-        @httpserver_link
+        @httpserver_link,
+        %{
+          "is_testing" => "youbetcha"
+        }
       )
 
     {:ok, par} = HostCore.WasmCloud.Native.par_from_path(@httpserver_path, @httpserver_link)
@@ -38,8 +41,13 @@ defmodule HostCore.ProvidersTest do
         httpserver_key
       )
 
-    assert elem(Enum.at(HostCore.Providers.ProviderSupervisor.all_providers(), 0), 1) ==
+    provs = HostCore.Providers.ProviderSupervisor.all_providers()
+
+    assert elem(Enum.at(provs, 0), 1) ==
              httpserver_key
+
+    annotations = elem(Enum.at(provs, 0), 0) |> HostCore.Providers.ProviderModule.annotations()
+    assert annotations == %{"is_testing" => "youbetcha"}
 
     HostCore.Providers.ProviderSupervisor.terminate_provider(httpserver_key, @httpserver_link)
 


### PR DESCRIPTION
While this supports generic key-value pairs for annotations in the start instructions received from the control interface, its initial use will be to allow [wadm](https://github.com/wasmCloud/wadm) to tag individual instances with the application deployment to which it belongs.