### PR TITLE
Disambiguate error message for denied invocation

### DIFF
--- a/host_core/lib/host_core/web_assembly/imports.ex
+++ b/host_core/lib/host_core/web_assembly/imports.ex
@@ -253,9 +253,34 @@ defmodule HostCore.WebAssembly.Imports do
     %{token | authorized: true}
   end
 
+  # Deny invocation due to missing link definition for a contract ID and link name
+  defp invoke(
+         _token = %{
+           verified: false,
+           authorized: false,
+           agent: agent,
+           namespace: namespace,
+           prefix: prefix
+         }
+       ) do
+    Agent.update(agent, fn state ->
+      %State{
+        state
+        | host_error:
+            "Invocation not authorized: missing link definition for #{namespace} on #{prefix}"
+      }
+    end)
+
+    0
+  end
+
+  # Deny invocation due to missing capability claim
   defp invoke(_token = %{authorized: false, agent: agent, namespace: namespace}) do
     Agent.update(agent, fn state ->
-      %State{state | host_error: "Invocation not authorized: missing claim for #{namespace}"}
+      %State{
+        state
+        | host_error: "Invocation not authorized: missing capability claim for #{namespace}"
+      }
     end)
 
     0

--- a/host_core/lib/host_core/web_assembly/imports.ex
+++ b/host_core/lib/host_core/web_assembly/imports.ex
@@ -257,7 +257,6 @@ defmodule HostCore.WebAssembly.Imports do
   defp invoke(
          _token = %{
            verified: false,
-           authorized: false,
            agent: agent,
            namespace: namespace,
            prefix: prefix

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.54.5"
+  @app_vsn "0.54.6"
 
   def project do
     [

--- a/host_core/test/e2e/kvcounter_test.exs
+++ b/host_core/test/e2e/kvcounter_test.exs
@@ -206,7 +206,7 @@ defmodule HostCore.E2E.KVCounterTest do
     {:ok, resp} = request_http("http://localhost:8082/foobar", 10)
 
     assert resp.body ==
-             "{\"error\":\"Host send error Invocation not authorized: missing claim for wasmcloud:keyvalue\"}"
+             "{\"error\":\"Host send error Invocation not authorized: missing capability claim for wasmcloud:keyvalue\"}"
 
     assert resp.status_code == 500
   end

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.54.5"
+  @app_vsn "0.54.6"
 
   def project do
     [


### PR DESCRIPTION
Fixes #364 

This PR disambiguates a previous confusing error message for a denied invocation into 2 parts
1. A missing link definition for a contract ID / link name pair (link not configured)
2. A missing capability claim (Actor not allowed to invoke that capability)

Using the kvcounter example, here's what the response error messages look like now. For a successful invocation:
```
> curl localhost:8080/sup
{"counter":1}%  
```

For a kvcounter actor that is missing the `wasmcloud:keyvalue` claim:
```
> curl localhost:8080/sup
{"error":"Host send error Invocation not authorized: missing capability claim for wasmcloud:keyvalue"}%
```

For a kvcounter actor that is either missing a link definition for the `wasmcloud:keyvalue` contract, or does not have a configured link definition for the `wasmcloud:keyvalue` contract on the `default` link name (these are similar, but different)
```
> curl localhost:8080/sup
{"error":"Host send error Invocation not authorized: missing link definition for wasmcloud:keyvalue on default"}%  
```