### PR TITLE
Changed workflow to run builds on our supported os'es

### DIFF
--- a/.github/workflows/host_core.yml
+++ b/.github/workflows/host_core.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-10.15]
         elixir: [1.13.3]
@@ -57,6 +58,7 @@ jobs:
           mix do deps.get, deps.compile
 
       - name: Check Formatting
+        if: ${{ !startswith(matrix.os, 'windows') }} # Windows gets angry about carriage returns
         working-directory: ${{env.working-directory}}
         run: mix format --check-formatted
 

--- a/.github/workflows/host_core.yml
+++ b/.github/workflows/host_core.yml
@@ -52,12 +52,16 @@ jobs:
             host_core/_build
           key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('host_core/mix.exs', 'host_core/mix.lock') }}
 
+      - name: Install Rebar and Hex
+        working-directory: ${{env.working-directory}}
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+
       - name: Install Mix Dependencies
         working-directory: ${{env.working-directory}}
         if: steps.mix-cache.outputs.cache-hit != 'true'
         run: |
-          mix local.rebar --force
-          mix local.hex --force
           mix do deps.get, deps.compile
 
       - name: Check Formatting

--- a/.github/workflows/host_core.yml
+++ b/.github/workflows/host_core.yml
@@ -75,10 +75,9 @@ jobs:
         working-directory: ${{env.working-directory}}
         env:
           EXTRA_TEST_ARGS: "--timeout 120000"
-        run: |
-          WASMCLOUD_LATTICE_PREFIX=${{ env.wasmcloud_lattice_prefix }} \
-          WASMCLOUD_RPC_TIMEOUT_MS=3000 \
-          make test
+          WASMCLOUD_LATTICE_PREFIX: ${{ env.wasmcloud_lattice_prefix }}
+          WASMCLOUD_RPC_TIMEOUT_MS: 3000
+        run: make test
 
       - name: Retrieve PLT Cache
         uses: actions/cache@v2

--- a/.github/workflows/host_core.yml
+++ b/.github/workflows/host_core.yml
@@ -67,12 +67,16 @@ jobs:
         continue-on-error: true # Don't fail entire action with refactoring opportunities for now
         run: mix credo --strict
 
+      - name: Determine lattice prefix
+        shell: bash
+        run: echo "wasmcloud_lattice_prefix=$(echo "${{ runner.os }}__${{ matrix.otp }}__${{ matrix.elixir }}__${{ env.working-directory }}" | sed 's/\./_/g')" > $GITHUB_ENV
+
       - name: Run Tests
         working-directory: ${{env.working-directory}}
         env:
           EXTRA_TEST_ARGS: "--timeout 120000"
         run: |
-          WASMCLOUD_LATTICE_PREFIX=$(echo "${{ runner.os }}__${{ matrix.otp }}__${{ matrix.elixir }}__${{ env.working-directory }}" | sed 's/\./_/g') \
+          WASMCLOUD_LATTICE_PREFIX=${{ env.wasmcloud_lattice_prefix }} \
           WASMCLOUD_RPC_TIMEOUT_MS=3000 \
           make test
 

--- a/.github/workflows/host_core.yml
+++ b/.github/workflows/host_core.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-10.15]
         elixir: [1.13.3]
-        otp: [23.0, 24.0]
+        otp: [23, 24]
 
     name: Build and test
     runs-on: ${{ matrix.os }}
@@ -33,8 +33,8 @@ jobs:
         if: ${{ startswith(matrix.os, 'ubuntu') || startswith(matrix.os, 'windows') }}
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "=24"
-          elixir-version: "1.13.3"
+          otp-version: "=${{ matrix.otp }}"
+          elixir-version: ${{ matrix.elixir }}
           install-hex: true
           install-rebar: true
       - name: Install erlang and elixir
@@ -77,7 +77,7 @@ jobs:
       - name: Determine lattice prefix
         if: ${{ startswith(matrix.os, 'ubuntu') }} # Run on Ubuntu only as a temporary workaround to dependencies that aren't present on windows/mac runners
         shell: bash
-        run: echo "wasmcloud_lattice_prefix=$(echo "${{ runner.os }}__${{ matrix.otp }}__${{ matrix.elixir }}__${{ env.working-directory }}" | sed 's/\./_/g')" > $GITHUB_ENV
+        run: echo "wasmcloud_lattice_prefix=$(echo "${{ runner.os }}__${{ matrix.otp }}__${{ matrix.elixir }}__${{ env.working-directory }}" | sed 's/\./_/g')" >> $GITHUB_ENV
 
       - name: Run Tests
         if: ${{ startswith(matrix.os, 'ubuntu') }} # Run on Ubuntu only as a temporary workaround to dependencies that aren't present on windows/mac runners

--- a/.github/workflows/host_core.yml
+++ b/.github/workflows/host_core.yml
@@ -15,15 +15,30 @@ jobs:
     strategy:
       # fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-10.15]
+        os: [windows-2019]
         elixir: [1.13.3]
-        otp: [23.0, 24.0]
+        otp: [24.0]
+        # os: [ubuntu-20.04, windows-2022, macos-10.15]
+        # elixir: [1.13.3]
+        # otp: [23.0, 24.0]
 
     name: Build and test
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Connor test
+        run: vswhere -products * -latest -prerelease -property installationPath
+
+      - name: Set up Visual Studio C++ toolchain
+        uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ startswith(matrix.os, 'windows') }}
+
+      - id: run-nats
+        uses: wasmcloud/common-actions/run-nats@main
+      - id: run-redis
+        uses: wasmcloud/common-actions/run-redis@main
 
       # Install erlang/OTP and elixir
       - name: Install erlang and elixir
@@ -77,6 +92,7 @@ jobs:
           EXTRA_TEST_ARGS: "--timeout 120000"
           WASMCLOUD_LATTICE_PREFIX: ${{ env.wasmcloud_lattice_prefix }}
           WASMCLOUD_RPC_TIMEOUT_MS: 3000
+          MIX_ENV: test
         run: make test
 
       - name: Retrieve PLT Cache

--- a/.github/workflows/host_core.yml
+++ b/.github/workflows/host_core.yml
@@ -14,11 +14,12 @@ jobs:
   build:
     strategy:
       matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
         elixir: [1.13.3]
-        otp: [23.0, 23.3.4.1, 24.0]
+        otp: [23.0, 24.0]
 
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/host_core.yml
+++ b/.github/workflows/host_core.yml
@@ -13,32 +13,20 @@ env:
 jobs:
   build:
     strategy:
-      # fail-fast: false
+      fail-fast: false
       matrix:
-        os: [windows-2019]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
         elixir: [1.13.3]
-        otp: [24.0]
-        # os: [ubuntu-20.04, windows-2022, macos-10.15]
-        # elixir: [1.13.3]
-        # otp: [23.0, 24.0]
+        otp: [23.0, 24.0]
 
     name: Build and test
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Connor test
-        run: vswhere -products * -latest -prerelease -property installationPath
-
-      - name: Set up Visual Studio C++ toolchain
+      - name: Set up Visual Studio C++ toolchain for Windows
         uses: ilammy/msvc-dev-cmd@v1
         if: ${{ startswith(matrix.os, 'windows') }}
-
-      - id: run-nats
-        uses: wasmcloud/common-actions/run-nats@main
-      - id: run-redis
-        uses: wasmcloud/common-actions/run-redis@main
 
       # Install erlang/OTP and elixir
       - name: Install erlang and elixir
@@ -83,10 +71,12 @@ jobs:
         run: mix credo --strict
 
       - name: Determine lattice prefix
+        if: ${{ startswith(matrix.os, 'ubuntu') }} # Run on Ubuntu only as a temporary workaround to dependencies that aren't present on windows/mac runners
         shell: bash
         run: echo "wasmcloud_lattice_prefix=$(echo "${{ runner.os }}__${{ matrix.otp }}__${{ matrix.elixir }}__${{ env.working-directory }}" | sed 's/\./_/g')" > $GITHUB_ENV
 
       - name: Run Tests
+        if: ${{ startswith(matrix.os, 'ubuntu') }} # Run on Ubuntu only as a temporary workaround to dependencies that aren't present on windows/mac runners
         working-directory: ${{env.working-directory}}
         env:
           EXTRA_TEST_ARGS: "--timeout 120000"

--- a/.github/workflows/host_core.yml
+++ b/.github/workflows/host_core.yml
@@ -24,12 +24,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup elixir
-        uses: actions/setup-elixir@v1.5
+      # Install erlang/OTP and elixir
+      - name: Install erlang and elixir
+        if: ${{ startswith(matrix.os, 'ubuntu') || startswith(matrix.os, 'windows') }}
+        uses: erlef/setup-beam@v1
         with:
-          elixir-version: ${{ matrix.elixir }} # Define the elixir version [required]
-          otp-version: ${{ matrix.otp }} # Define the OTP version [required]
-          experimental-otp: true # experimental flag required for ubuntu 20.04
+          otp-version: "=24"
+          elixir-version: "1.13.3"
+          install-hex: true
+          install-rebar: true
+      - name: Install erlang and elixir
+        if: ${{ startswith(matrix.os, 'macos') }}
+        run: |
+          brew install erlang
+          brew install elixir
 
       - name: Retrieve Mix Dependencies Cache
         uses: actions/cache@v2

--- a/.github/workflows/host_core.yml
+++ b/.github/workflows/host_core.yml
@@ -13,9 +13,9 @@ env:
 jobs:
   build:
     strategy:
-      fail-fast: false
+      # fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2022, macos-10.15]
         elixir: [1.13.3]
         otp: [23.0, 24.0]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,14 +93,14 @@ jobs:
     name: Build application release tarballs
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
         working-directory: [wasmcloud_host, host_core]
         include:
           - os: ubuntu-20.04
             rust-target: x86_64-unknown-linux-gnu
             tarball-filename: x86_64-linux
             working-directory: wasmcloud_host
-          - os: windows-2022
+          - os: windows-2019
             rust-target: x86_64-pc-windows-msvc
             tarball-filename: x86_64-windows
             working-directory: wasmcloud_host
@@ -112,7 +112,7 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
             tarball-filename: x86_64-core-linux
             working-directory: host_core
-          - os: windows-2022
+          - os: windows-2019
             rust-target: x86_64-pc-windows-msvc
             tarball-filename: x86_64-core-windows
             working-directory: host_core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,14 +93,14 @@ jobs:
     name: Build application release tarballs
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2022, macos-10.15]
         working-directory: [wasmcloud_host, host_core]
         include:
           - os: ubuntu-20.04
             rust-target: x86_64-unknown-linux-gnu
             tarball-filename: x86_64-linux
             working-directory: wasmcloud_host
-          - os: windows-2019
+          - os: windows-2022
             rust-target: x86_64-pc-windows-msvc
             tarball-filename: x86_64-windows
             working-directory: wasmcloud_host
@@ -112,7 +112,7 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
             tarball-filename: x86_64-core-linux
             working-directory: host_core
-          - os: windows-2019
+          - os: windows-2022
             rust-target: x86_64-pc-windows-msvc
             tarball-filename: x86_64-core-windows
             working-directory: host_core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: WasmCloud Host Release
 
 on:
   push:
-    tags: "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+    tags: ["v*"] # Push events to matching v*, i.e. v1.0, v20.15.10
   workflow_dispatch: # Allow manual creation of artifacts without a release
 
 jobs:
@@ -131,6 +131,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Visual Studio C++ toolchain for Windows
+        uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ startswith(matrix.os, 'windows') }}
 
       # Setup Rust for NIF dependencies
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -13,28 +13,32 @@ jobs:
   build:
     strategy:
       matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
         elixir: [1.13.3]
-        otp: [23.0, 23.3.4.1, 24.0]
-    services:
-      nats:
-        image: nats:2
-        ports:
-          - 4222:4222
+        otp: [23.0, 24.0]
 
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     env:
       MIX_ENV: test
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup elixir
-        uses: actions/setup-elixir@v1.5
+      # Install erlang/OTP and elixir
+      - name: Install erlang and elixir
+        if: ${{ startswith(matrix.os, 'ubuntu') || startswith(matrix.os, 'windows') }}
+        uses: erlef/setup-beam@v1
         with:
-          elixir-version: ${{ matrix.elixir }} # Define the elixir version [required]
-          otp-version: ${{ matrix.otp }} # Define the OTP version [required]
-          experimental-otp: true # experimental flag required for ubuntu 20.04
+          otp-version: "=24"
+          elixir-version: "1.13.3"
+          install-hex: true
+          install-rebar: true
+      - name: Install erlang and elixir
+        if: ${{ startswith(matrix.os, 'macos') }}
+        run: |
+          brew install erlang
+          brew install elixir
 
       - name: Retrieve Mix Dependencies Cache
         uses: actions/cache@v2
@@ -66,6 +70,7 @@ jobs:
         continue-on-error: true # Don't fail entire action with refactoring opportunities for now
         run: mix credo --strict
 
+      # Currently we do not have tests for the UI part of the wasmCloud dashboard
       # - name: Run Tests
       #   working-directory: ${{env.working-directory}}
       #   run: |

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-10.15]
         elixir: [1.13.3]
-        otp: [23.0, 24.0]
+        otp: [23, 24]
 
     name: Build and test
     runs-on: ${{ matrix.os }}
@@ -34,8 +34,8 @@ jobs:
         if: ${{ startswith(matrix.os, 'ubuntu') || startswith(matrix.os, 'windows') }}
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "=24"
-          elixir-version: "1.13.3"
+          otp-version: "=${{ matrix.otp }}"
+          elixir-version: ${{ matrix.elixir }}
           install-hex: true
           install-rebar: true
       - name: Install erlang and elixir

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -12,14 +12,11 @@ env:
 jobs:
   build:
     strategy:
-      # fail-fast: false
+      fail-fast: false
       matrix:
-        os: [windows-2022]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
         elixir: [1.13.3]
-        otp: [24.0]
-        # os: [ubuntu-20.04, windows-2022, macos-10.15]
-        # elixir: [1.13.3]
-        # otp: [23.0, 24.0]
+        otp: [23.0, 24.0]
 
     name: Build and test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -25,6 +25,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Visual Studio C++ toolchain for Windows
+        uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ startswith(matrix.os, 'windows') }}
 
       # Install erlang/OTP and elixir
       - name: Install erlang and elixir
@@ -50,12 +53,16 @@ jobs:
             wasmcloud_host/_build
           key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('wasmcloud_host/mix.exs', 'wasmcloud_host/mix.lock') }}
 
+      - name: Install Rebar and Hex
+        working-directory: ${{env.working-directory}}
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+
       - name: Install Mix Dependencies
         working-directory: ${{env.working-directory}}
         if: steps.mix-cache.outputs.cache-hit != 'true'
         run: |
-          mix local.rebar --force
-          mix local.hex --force
           mix do deps.get, deps.compile
 
       - name: Check Formatting

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-2019, macos-10.15]
         elixir: [1.13.3]
@@ -58,6 +59,7 @@ jobs:
           mix do deps.get, deps.compile
 
       - name: Check Formatting
+        if: ${{ !startswith(matrix.os, 'windows') }} # Windows gets angry about carriage returns
         working-directory: ${{env.working-directory}}
         run: mix format --check-formatted
 

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -14,9 +14,12 @@ jobs:
     strategy:
       # fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-10.15]
+        os: [windows-2022]
         elixir: [1.13.3]
-        otp: [23.0, 24.0]
+        otp: [24.0]
+        # os: [ubuntu-20.04, windows-2022, macos-10.15]
+        # elixir: [1.13.3]
+        # otp: [23.0, 24.0]
 
     name: Build and test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -12,9 +12,9 @@ env:
 jobs:
   build:
     strategy:
-      fail-fast: false
+      # fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2022, macos-10.15]
         elixir: [1.13.3]
         otp: [23.0, 24.0]
 


### PR DESCRIPTION
Updated the host_core and wasmcloud_host actions to build on windows and mac to ensure we don't introduce OS specific issues with updates.

Currently not running tests on those OS'es due to platform-specific dependencies that are not present on mac/windows github-hosted runners