### PR TITLE
Updated release image to bullseye

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             BUILDER_IMAGE=elixir:1.13.3-slim
-            RELEASE_IMAGE=debian:buster-slim
+            RELEASE_IMAGE=debian:bullseye-slim
             APP_NAME=wasmcloud_host
             APP_VSN=${{ env.wasmcloud_host_version }}
             SECRET_KEY_BASE=${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}

--- a/wasmcloud_host/Makefile
+++ b/wasmcloud_host/Makefile
@@ -21,7 +21,7 @@ build-image: build esbuild ## Build docker image for running, testing, or distri
 	cd ../ && \
 	docker build $(BASE_ARGS) \
 		--build-arg BUILDER_IMAGE=elixir:1.13.3-slim \
-		--build-arg RELEASE_IMAGE=debian:buster-slim  \
+		--build-arg RELEASE_IMAGE=debian:bullseye-slim  \
 		$(BASE_TAGS) \
 		-f $(DOCKERFILE) \
 		.
@@ -30,7 +30,7 @@ build-arm-image: build esbuild ## Build arm64 docker image for running, testing,
 	cd ../ && \
 	docker buildx build $(BASE_ARGS) \
 		--build-arg BUILDER_IMAGE=elixir:1.13.3-slim \
-		--build-arg RELEASE_IMAGE=debian:buster-slim \
+		--build-arg RELEASE_IMAGE=debian:bullseye-slim \
 		-t wasmcloud_host:arm64 \
 		--platform linux/arm64 \
 		--load \


### PR DESCRIPTION
The previously released `0.54.5` or `latest` version of the wasmCloud host docker image fails due to an unusable erlang runtime system. This is due to the wasmCloud binary being built on `bullseye` (newer version of debian) but the release image layer is `buster` (older version)

This fix will be released with #392 