### PR TITLE
Propagating selected env vars to providers

### DIFF
--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -82,7 +82,7 @@ defmodule HostCore.Providers.ProviderModule do
       |> Base.encode64()
       |> to_charlist()
 
-    port = Port.open({:spawn, "#{path}"}, [:binary])
+    port = Port.open({:spawn, "#{path}"}, [:binary, {:env, extract_env_vars()}])
     Port.monitor(port)
     Port.command(port, "#{host_info}\n")
 
@@ -117,6 +117,15 @@ defmodule HostCore.Providers.ProviderModule do
        healthy: false,
        ociref: oci
      }}
+  end
+
+  @propagated_env_vars ["OTEL_TRACES_EXPORTER", "OTEL_EXPORTER_OTLP_ENDPOINT"]
+
+  defp extract_env_vars() do
+    @propagated_env_vars
+    |> Enum.map(fn e -> {e |> to_charlist(), System.get_env(e) |> to_charlist()} end)
+    |> Enum.filter(fn {_k, v} -> length(v) > 0 end)
+    |> Enum.into([])
   end
 
   @impl true


### PR DESCRIPTION
Rather than add the environment variables to the `env_values` field on the host info struct, I decided to propagate the environment variables as actual env vars. This means that capability providers need to do no work in order to handle the environment variables and there won't be any race conditions where a provider might query an env var before it extracts the host info struct.

Initially this is to enable open telemetry in the capability providers but we can also add select variables to the propagation list later