### PR TITLE
Add IPv6 support for NATS connections

### DIFF
--- a/host_core/lib/host_core/config_plan.ex
+++ b/host_core/lib/host_core/config_plan.ex
@@ -54,7 +54,8 @@ defmodule HostCore.ConfigPlan do
           {:config_service_enabled, "WASMCLOUD_CONFIG_SERVICE", required: false},
           {:enable_structured_logging, "WASMCLOUD_STRUCTURED_LOGGING_ENABLED", required: false},
           {:structured_log_level, "WASMCLOUD_STRUCTURED_LOG_LEVEL",
-           required: false, map: &string_to_loglevel/1}
+           required: false, map: &string_to_loglevel/1},
+          {:enable_ipv6, "WASMCLOUD_ENABLE_IPV6", required: false, map: &String.to_integer/1}
         ]
       }
     ]
@@ -88,7 +89,8 @@ defmodule HostCore.ConfigPlan do
       {:js_domain, "js_domain", required: false, default: nil},
       {:config_service_enabled, "config_service_enabled", required: false, default: ""},
       {:enable_structured_logging, "structured_logging_enabled", required: false, default: false},
-      {:structured_log_level, "structured_log_level", required: false, default: :info}
+      {:structured_log_level, "structured_log_level", required: false, default: :info},
+      {:enable_ipv6, "enable_ipv6", required: false, default: 0}
     ]
   end
 

--- a/host_core/lib/host_core/nats.ex
+++ b/host_core/lib/host_core/nats.ex
@@ -10,7 +10,12 @@ defmodule HostCore.Nats do
       backoff_period: 4_000,
       connection_settings: [
         Map.merge(
-          %{host: opts.rpc_host, port: opts.rpc_port, tls: opts.rpc_tls == 1},
+          %{
+            host: opts.rpc_host,
+            port: opts.rpc_port,
+            tls: opts.rpc_tls == 1,
+            tcp_opts: determine_ipv6(opts.enable_ipv6)
+          },
           determine_auth_method(opts.rpc_seed, opts.rpc_jwt, "lattice rpc")
         )
       ]
@@ -25,7 +30,12 @@ defmodule HostCore.Nats do
       backoff_period: 4_000,
       connection_settings: [
         Map.merge(
-          %{host: opts.ctl_host, port: opts.ctl_port, tls: opts.ctl_tls == 1},
+          %{
+            host: opts.ctl_host,
+            port: opts.ctl_port,
+            tls: opts.ctl_tls == 1,
+            tcp_opts: determine_ipv6(opts.enable_ipv6)
+          },
           determine_auth_method(opts.ctl_seed, opts.ctl_jwt, "control interface")
         )
       ]
@@ -52,6 +62,9 @@ defmodule HostCore.Nats do
         %{}
     end
   end
+
+  defp determine_ipv6(use_ipv6) when use_ipv6 == 1, do: [:binary, :inet6]
+  defp determine_ipv6(_), do: [:binary]
 
   def safe_pub(process_name, topic, msg) do
     if Process.whereis(process_name) != nil do


### PR DESCRIPTION
Add a new environment variable (`WASMCLOUD_ENABLE_IPV6`) that enables
IPv6 support for establishing NATS connections. Without this value, the
Gnat client cannot connect to IPv6-only endpoints.

In theory we could just always enable it, since the underlying `:inet6`
option is dual-stack, but wasmcloud hosts may end up running on systems
that do not support IPv6.

Signed-off-by: Dan Norris <protochron@users.noreply.github.com>