### PR TITLE
fix(host_core): Makes sure the structured_logging_enabled is a bool

### DIFF
--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -423,10 +423,14 @@ defmodule HostCore.Host do
       cluster_issuers: cluster_issuers(),
       invocation_seed: cluster_seed(),
       # In case providers want to be aware of this for their own logging
-      structured_logging_enabled: structured_logging_enabled
+      structured_logging_enabled: to_bool(structured_logging_enabled)
     }
     |> Jason.encode!()
   end
+
+  defp to_bool(val) when is_binary(val), do: String.downcase(val) == "true"
+
+  defp to_bool(_), do: false
 
   defp normalize_prefix("bindle://" <> _str = s) do
     s


### PR DESCRIPTION
If you set the environment variable, the value would be serialized as
a string, which made Rust not very happy (and probably any other
strongly typed language). This is a small fix that ensures that it is
an actual bool before it is encoded into the config map