### PR TITLE
Refactor to consumer supervisors for RPC subscriptions

### DIFF
--- a/host_core/config/config.exs
+++ b/host_core/config/config.exs
@@ -21,6 +21,14 @@ config :opentelemetry,
   span_processor: :batch,
   traces_exporter: :none
 
+# Subscription retention is a test-enabling tool. When enabled, a subscriber for
+# an actor _will not unsubscribe_ after all instances of that actor have been
+# removed from a host. This helps in testing because the constant churning of
+# stopping, unsubscribing, starting, and re-subscribing in the middle of a test
+# suite causes failure and race conditions on a large scale.
+#
+# tl;dr - leave subscription retention off at all times unless you're running
+# tests.
 config :host_core,
   retain_rpc_subscriptions: false
 

--- a/host_core/config/config.exs
+++ b/host_core/config/config.exs
@@ -21,4 +21,7 @@ config :opentelemetry,
   span_processor: :batch,
   traces_exporter: :none
 
+config :host_core,
+  retain_rpc_subscriptions: false
+
 import_config "#{config_env()}.exs"

--- a/host_core/config/test.exs
+++ b/host_core/config/test.exs
@@ -10,6 +10,9 @@ config :logger, :console,
   level: :debug,
   metadata: [:span_id, :trace_id]
 
+config :host_core,
+  retain_rpc_subscriptions: true
+
 # config :opentelemetry, :processors,
 #   otel_batch_processor: %{
 #     exporter: {:otel_exporter_stdout, []}

--- a/host_core/lib/host_core.ex
+++ b/host_core/lib/host_core.ex
@@ -38,6 +38,7 @@ defmodule HostCore do
     [
       {Registry, keys: :unique, name: Registry.ProviderRegistry},
       {Registry, keys: :duplicate, name: Registry.ActorRegistry},
+      {Registry, keys: :unique, name: Registry.ActorRpcSubscribers},
       {Registry,
        keys: :duplicate,
        name: Registry.EventMonitorRegistry,
@@ -50,6 +51,7 @@ defmodule HostCore do
         {Gnat.ConnectionSupervisor, HostCore.Nats.rpc_connection_settings(config)},
         id: :rpc_connection_supervisor
       ),
+      {HostCore.Actors.ActorRpcSupervisor, strategy: :one_for_one},
       {HostCore.Providers.ProviderSupervisor, strategy: :one_for_one, name: ProviderRoot},
       {HostCore.Actors.ActorSupervisor,
        strategy: :one_for_one,

--- a/host_core/lib/host_core/actors/actor_rpc_server.ex
+++ b/host_core/lib/host_core/actors/actor_rpc_server.ex
@@ -11,9 +11,8 @@ defmodule HostCore.Actors.ActorRpcServer do
       ) do
     pk = topic |> String.split(".") |> Enum.at(-1)
 
-    # Randomly choose a running instance to handle this request.
-    # optimization for later - in the future, we might be able to detect an instance that isn't currently
-    # handling a request (isn't busy) to optimize this
+    # Choose the least busy (smallest message queue length) actor in the registry
+    # as the target for the inbound RPC
     #
     # NOTE - dispatch doesn't invoke the handler if no registry entries exist for the given key
     Registry.dispatch(Registry.ActorRegistry, pk, fn entries ->

--- a/host_core/lib/host_core/actors/actor_rpc_server.ex
+++ b/host_core/lib/host_core/actors/actor_rpc_server.ex
@@ -1,0 +1,44 @@
+defmodule HostCore.Actors.ActorRpcServer do
+  require Logger
+  use Gnat.Server
+
+  def request(
+        %{
+          body: _body,
+          reply_to: _reply_to,
+          topic: topic
+        } = msg
+      ) do
+    pk = topic |> String.split(".") |> Enum.at(-1)
+
+    # Randomly choose a running instance to handle this request.
+    # optimization for later - in the future, we might be able to detect an instance that isn't currently
+    # handling a request (isn't busy) to optimize this
+    #
+    # NOTE - dispatch doesn't invoke the handler if no registry entries exist for the given key
+    Registry.dispatch(Registry.ActorRegistry, pk, fn entries ->
+      {pid, _value} = entries |> Enum.random()
+      GenServer.cast(pid, {:handle_incoming_rpc, msg})
+    end)
+  end
+
+  def error(
+        %{gnat: gnat, reply_to: reply_to},
+        error
+      ) do
+    Logger.error("Actor RPC handler failure: #{inspect(error)}")
+
+    ir = %{
+      msg: nil,
+      invocation_id: "",
+      error: "Failed to handle actor RPC: #{inspect(error)}",
+      instance_id: ""
+    }
+
+    HostCore.Nats.safe_pub(
+      gnat,
+      reply_to,
+      ir |> Msgpax.pack!() |> IO.iodata_to_binary()
+    )
+  end
+end

--- a/host_core/lib/host_core/actors/actor_rpc_supervisor.ex
+++ b/host_core/lib/host_core/actors/actor_rpc_supervisor.ex
@@ -1,0 +1,62 @@
+defmodule HostCore.Actors.ActorRpcSupervisor do
+  require Logger
+  use Supervisor
+
+  def start_link(state) do
+    Supervisor.start_link(__MODULE__, state, name: __MODULE__)
+  end
+
+  def init(_opts) do
+    Process.flag(:trap_exit, true)
+    Supervisor.init([], strategy: :one_for_one)
+  end
+
+  defp via_tuple(pk) do
+    {:via, Registry, {Registry.ActorRpcSubscribers, pk, []}}
+  end
+
+  def stop_rpc_subscriber(public_key) do
+    if !Application.get_env(:host_core, :retain_rpc_subscriptions, false) do
+      Logger.debug("Terminating RPC subscriber for actor #{public_key}")
+      Supervisor.terminate_child(__MODULE__, via_tuple(public_key))
+    end
+  end
+
+  def start_or_reuse_consumer_supervisor(claims) do
+    prefix = HostCore.Host.lattice_prefix()
+    topic = "wasmbus.rpc.#{prefix}.#{claims.public_key}"
+
+    cs_settings = %{
+      connection_name: :lattice_nats,
+      module: HostCore.Actors.ActorRpcServer,
+      subscription_topics: [
+        %{topic: topic, queue_group: topic}
+      ]
+    }
+
+    spec =
+      Supervisor.child_spec(
+        {Gnat.ConsumerSupervisor, cs_settings},
+        id: via_tuple(claims.public_key)
+      )
+
+    case Supervisor.start_child(
+           __MODULE__,
+           spec
+         ) do
+      {:ok, _v} ->
+        Logger.debug("Starting consumer supervisor for actor RPC #{claims.public_key}")
+
+      {:error, {:already_started, _pid}} ->
+        Logger.debug("Reusing existing consumer supervisor for actor RPC #{claims.public_key}")
+
+      {:error, :already_present} ->
+        Logger.debug("Reusing existing consumer supervisor for actor RPC #{claims.public_key}")
+
+      {:error, e} ->
+        Logger.error(
+          "Failed to start consumer supervisor for actor RPC #{claims.public_key}: #{inspect(e)}"
+        )
+    end
+  end
+end

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -67,6 +67,12 @@ defmodule HostCore.Host do
       Logger.warn(warning)
     end
 
+    if Application.get_env(:host_core, :retain_rpc_subscriptions, false) do
+      Logger.warn(
+        "RPC Subscription Retention Enabled. This host instance is NOT stable in production!"
+      )
+    end
+
     labels =
       get_env_host_labels()
       |> Map.merge(HostCore.WasmCloud.Native.detect_core_host_labels())

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -36,19 +36,35 @@ defmodule HostCore.Providers.ProviderModule do
   end
 
   def instance_id(pid) do
-    GenServer.call(pid, :get_instance_id)
+    if Process.alive?(pid) do
+      GenServer.call(pid, :get_instance_id)
+    else
+      "n/a"
+    end
   end
 
   def annotations(pid) do
-    GenServer.call(pid, :get_annotations)
+    if Process.alive?(pid) do
+      GenServer.call(pid, :get_annotations)
+    else
+      %{}
+    end
   end
 
   def ociref(pid) do
-    GenServer.call(pid, :get_ociref)
+    if Process.alive?(pid) do
+      GenServer.call(pid, :get_ociref)
+    else
+      "n/a"
+    end
   end
 
   def path(pid) do
-    GenServer.call(pid, :get_path)
+    if Process.alive?(pid) do
+      GenServer.call(pid, :get_path)
+    else
+      "n/a"
+    end
   end
 
   def halt(pid) do

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.54.6"
+  @app_vsn "0.55.0"
 
   def project do
     [

--- a/wasmcloud_host/config/config.exs
+++ b/wasmcloud_host/config/config.exs
@@ -24,7 +24,6 @@ config :wasmcloud_host, WasmcloudHostWeb.Endpoint,
 config :host_core,
   retain_rpc_subscriptions: false
 
-
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/wasmcloud_host/config/config.exs
+++ b/wasmcloud_host/config/config.exs
@@ -21,6 +21,14 @@ config :wasmcloud_host, WasmcloudHostWeb.Endpoint,
   pubsub_server: WasmcloudHost.PubSub,
   live_view: [signing_salt: "Jr0Bi5x0"]
 
+# Subscription retention is a test-enabling tool. When enabled, a subscriber for
+# an actor _will not unsubscribe_ after all instances of that actor have been
+# removed from a host. This helps in testing because the constant churning of
+# stopping, unsubscribing, starting, and re-subscribing in the middle of a test
+# suite causes failure and race conditions on a large scale.
+#
+# tl;dr - leave subscription retention off at all times unless you're running
+# tests.
 config :host_core,
   retain_rpc_subscriptions: false
 

--- a/wasmcloud_host/config/config.exs
+++ b/wasmcloud_host/config/config.exs
@@ -21,6 +21,10 @@ config :wasmcloud_host, WasmcloudHostWeb.Endpoint,
   pubsub_server: WasmcloudHost.PubSub,
   live_view: [signing_salt: "Jr0Bi5x0"]
 
+config :host_core,
+  retain_rpc_subscriptions: false
+
+
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/wasmcloud_host/config/test.exs
+++ b/wasmcloud_host/config/test.exs
@@ -8,3 +8,6 @@ config :wasmcloud_host, WasmcloudHostWeb.Endpoint,
 
 # Print only warnings and errors during test
 config :logger, level: :warn
+
+config :host_core,
+  retain_rpc_subscriptions: true

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.54.6"
+  @app_vsn "0.55.0"
 
   def project do
     [


### PR DESCRIPTION
Included in this PR:
* Refactor of manual RPC subscriptions for actors into consumer supervisors
  * Subscriptions are now reused per actor and not per instance 
* Misc error handling and edge case enhancements
* Health checks for actors are no longer performed (corresponding events no longer emitted)