### PR TITLE
Added OCI_REGISTRY environment variable and docs

### DIFF
--- a/host_core/native/hostcore_wasmcloud_native/README.md
+++ b/host_core/native/hostcore_wasmcloud_native/README.md
@@ -1,22 +1,10 @@
 # NIF for Elixir.HostCore.WasmCloud.Native
+This Native Implemented Function ([NIF](https://www.erlang.org/doc/tutorial/nif.html)) serves two purposes for wasmCloud:
+1. Implement functionality that is better suited for the memory safety or static typing of Rust
+2. Reuse common functionality in the various crates published in the Rust ecosystem.
 
 ## To build the NIF module:
 
 - Make sure your projects `mix.exs` has the `:rustler` compiler listed in the `project` function: `compilers: [:rustler] ++ Mix.compilers()` If there already is a `:compilers` list, you should append `:rustler` to it.
 - Add your crate to the `rustler_crates` attribute in the `project function. [See here](https://hexdocs.pm/rustler/basics.html#crate-configuration).
 - Your NIF will now build along with your project.
-
-## To load the NIF:
-
-```elixir
-defmodule HostCore.WasmCloud.Native do
-    use Rustler, otp_app: <otp-app>, crate: "hostcore_wasmcloud_native"
-
-    # When your NIF is loaded, it will override this function.
-    def add(_a, _b), do: :erlang.nif_error(:nif_not_loaded)
-end
-```
-
-## Examples
-
-[This](https://github.com/hansihe/NifIo) is a complete example of a NIF written in Rust.


### PR DESCRIPTION
This PR adds the `OCI_REGISTRY` environment variable which ensures that a specified set of OCI credentials is only used for that specific registry. Without all of these variables specified, anonymous authentication will be used.

An example configuration would be
`OCI_REGISTRY`: `mycustom.azurecr.io`
`OCI_REGISTRY_USER`: `brooksmtownsend`
`OCI_REGISTRY_PASSWORD`: `sup3rs3cur3!`

The motivation for this is both that some OCI registries will try to authenticate you anyways if you supply creds, even if it's a public registry (looking at you ghcr.io) and that it's a mild security risk to send your OCI creds along with each pull request.

Documentation that goes with this PR: https://github.com/wasmCloud/wasmcloud-dev-site/pull/135