### PR TITLE
Bumped chart to 0.55

### DIFF
--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://github.com/wasmCloud/wasmcloud.com-dev/raw/main/static/images/wasm
 
 type: application
 
-version: 0.5.1
+version: 0.6.0
 
-appVersion: "0.54.3"
+appVersion: "0.55.0"

--- a/wasmcloud_host/chart/templates/deployment.yaml
+++ b/wasmcloud_host/chart/templates/deployment.yaml
@@ -91,6 +91,10 @@ spec:
             - name: WASMCLOUD_JS_DOMAIN
               value: {{ .Values.wasmcloud.config.jetstreamDomain | quote }}
             {{- end }}
+            {{- if .Values.wasmcloud.config.registry.url }}
+            - name: OCI_REGISTRY
+              value: {{ .Values.wasmcloud.config.registry.url | quote }}
+            {{- end }}
             {{- if .Values.wasmcloud.config.registry.username }}
             - name: OCI_REGISTRY_USER
               value: {{ .Values.wasmcloud.config.registry.username | quote }}

--- a/wasmcloud_host/chart/templates/deployment.yaml
+++ b/wasmcloud_host/chart/templates/deployment.yaml
@@ -91,6 +91,14 @@ spec:
             - name: WASMCLOUD_JS_DOMAIN
               value: {{ .Values.wasmcloud.config.jetstreamDomain | quote }}
             {{- end }}
+            {{- if .Values.wasmcloud.config.otel.exporter }}
+            - name: OTEL_TRACES_EXPORTER
+              value: {{ .Values.wasmcloud.config.otel.exporter | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.otel.endpoint }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.wasmcloud.config.otel.endpoint | quote }}
+            {{- end }}
             {{- if .Values.wasmcloud.config.registry.url }}
             - name: OCI_REGISTRY
               value: {{ .Values.wasmcloud.config.registry.url | quote }}
@@ -98,6 +106,13 @@ spec:
             {{- if .Values.wasmcloud.config.registry.username }}
             - name: OCI_REGISTRY_USER
               value: {{ .Values.wasmcloud.config.registry.username | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.registry.password }}
+            - name: OCI_REGISTRY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wasmcloud_host.fullname" . }}
+                  key: registryPassword
             {{- end }}
             {{- if .Values.wasmcloud.config.hostSeed }}
             - name: WASMCLOUD_HOST_SEED
@@ -126,13 +141,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "wasmcloud_host.fullname" . }}
                   key: ctlSeed
-            {{- end }}
-            {{- if .Values.wasmcloud.config.registry.password }}
-            - name: OCI_REGISTRY_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "wasmcloud_host.fullname" . }}
-                  key: registryPassword
             {{- end }}
             {{- range $k, $v := .Values.wasmcloud.config.hostLabels }}
             - name: HOST_{{ $k }}

--- a/wasmcloud_host/chart/templates/deployment.yaml
+++ b/wasmcloud_host/chart/templates/deployment.yaml
@@ -91,6 +91,14 @@ spec:
             - name: WASMCLOUD_JS_DOMAIN
               value: {{ .Values.wasmcloud.config.jetstreamDomain | quote }}
             {{- end }}
+            {{- if .Values.wasmcloud.logging.structuredLoggingEnabled }}
+            - name: WASMCLOUD_STRUCTURED_LOGGING_ENABLED
+              value: {{ .Values.wasmcloud.config.logging.structuredLoggingEnabled | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.logging.logLevel }}
+            - name: WASMCLOUD_STRUCTURED_LOG_LEVEL
+              value: {{ .Values.wasmcloud.config.logging.logLevel | quote }}
+            {{- end }}
             {{- if .Values.wasmcloud.config.otel.exporter }}
             - name: OTEL_TRACES_EXPORTER
               value: {{ .Values.wasmcloud.config.otel.exporter | quote }}

--- a/wasmcloud_host/chart/values.yaml
+++ b/wasmcloud_host/chart/values.yaml
@@ -25,6 +25,9 @@ wasmcloud:
     providerRpcSeed: ""
     ctlSeed: ""
     jetstreamDomain: ""
+    logging:
+      structuredLoggingEnabled: false
+      logLevel: ""
     otel:
       exporter: ""
       endpoint: ""

--- a/wasmcloud_host/chart/values.yaml
+++ b/wasmcloud_host/chart/values.yaml
@@ -27,6 +27,7 @@ wasmcloud:
     jetstreamDomain: ""
     # Sets the username and password for use with a private registry
     registry:
+      url: ""
       username: ""
       password: ""
     # A map of key value pairs to use as wasmCloud Host labels. These map to environment variable

--- a/wasmcloud_host/chart/values.yaml
+++ b/wasmcloud_host/chart/values.yaml
@@ -25,6 +25,9 @@ wasmcloud:
     providerRpcSeed: ""
     ctlSeed: ""
     jetstreamDomain: ""
+    otel:
+      exporter: ""
+      endpoint: ""
     # Sets the username and password for use with a private registry
     registry:
       url: ""


### PR DESCRIPTION
Seeking an opinion from @thomastaylor312, do we want to include some of the things from the otel docker compose with this chart?

If not, this should be good to go once 0.55 is released