### PR TITLE
Actor termination candidates now filtered by optional annotations

### DIFF
--- a/host_core/lib/host_core/actors/actor_supervisor.ex
+++ b/host_core/lib/host_core/actors/actor_supervisor.ex
@@ -285,6 +285,7 @@ defmodule HostCore.Actors.ActorSupervisor do
       Registry.lookup(Registry.ActorRegistry, public_key)
       |> Enum.filter(fn {pid, _v} ->
         existing = HostCore.Actors.ActorModule.annotations(pid)
+        # Property of maps - map a is contained within b if b.merge(a) == b
         Map.merge(existing, annotations) == existing
       end)
 
@@ -307,6 +308,7 @@ defmodule HostCore.Actors.ActorSupervisor do
     Registry.lookup(Registry.ActorRegistry, public_key)
     |> Enum.filter(fn {pid, _v} ->
       existing = HostCore.Actors.ActorModule.annotations(pid)
+      # Property of maps - map a is contained within b if b.merge(a) == b
       Map.merge(existing, annotations) == existing
     end)
     |> Enum.map(fn {pid, _v} -> pid end)

--- a/host_core/lib/host_core/actors/actor_supervisor.ex
+++ b/host_core/lib/host_core/actors/actor_supervisor.ex
@@ -262,7 +262,8 @@ defmodule HostCore.Actors.ActorSupervisor do
 
       # Current count is greater than desired count, terminate instances
       diff > 0 ->
-        terminate_actor(public_key, diff)
+        # wadm won't use the scale actor call, so we don't care about annotations here
+        terminate_actor(public_key, diff, %{})
 
       # Current count is less than desired count, start more instances
       diff < 0 && ociref != "" ->
@@ -279,8 +280,14 @@ defmodule HostCore.Actors.ActorSupervisor do
   end
 
   # Terminate `count` instances of an actor
-  def terminate_actor(public_key, count) when count > 0 do
-    actors = Registry.lookup(Registry.ActorRegistry, public_key)
+  def terminate_actor(public_key, count, annotations) when count > 0 do
+    actors =
+      Registry.lookup(Registry.ActorRegistry, public_key)
+      |> Enum.filter(fn {pid, _v} ->
+        existing = HostCore.Actors.ActorModule.annotations(pid)
+        Map.merge(existing, annotations) == existing
+      end)
+
     remaining = length(actors) - count
 
     actors
@@ -296,8 +303,12 @@ defmodule HostCore.Actors.ActorSupervisor do
   end
 
   # Terminate all instances of an actor
-  def terminate_actor(public_key, 0) do
+  def terminate_actor(public_key, 0, annotations) do
     Registry.lookup(Registry.ActorRegistry, public_key)
+    |> Enum.filter(fn {pid, _v} ->
+      existing = HostCore.Actors.ActorModule.annotations(pid)
+      Map.merge(existing, annotations) == existing
+    end)
     |> Enum.map(fn {pid, _v} -> pid end)
     |> Enum.each(fn pid -> ActorModule.halt(pid) end)
 
@@ -309,6 +320,6 @@ defmodule HostCore.Actors.ActorSupervisor do
   def terminate_all() do
     all_actors()
     |> Enum.map(fn {k, v} -> {k, Enum.count(v)} end)
-    |> Enum.each(fn {pk, count} -> terminate_actor(pk, count) end)
+    |> Enum.each(fn {pk, count} -> terminate_actor(pk, count, %{}) end)
   end
 end

--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -251,7 +251,8 @@ defmodule HostCore.ControlInterface.Server do
              |> Enum.all?(&Map.has_key?(stop_actor_command, &1)) do
         HostCore.Actors.ActorSupervisor.terminate_actor(
           stop_actor_command["actor_ref"],
-          stop_actor_command["count"]
+          stop_actor_command["count"],
+          Map.get(stop_actor_command, "annotations", %{})
         )
 
         {:reply, success_ack()}

--- a/host_core/test/host_core/actors_test.exs
+++ b/host_core/test/host_core/actors_test.exs
@@ -117,7 +117,7 @@ defmodule HostCore.ActorsTest do
              %{"is_testing" => "youbetcha"}
 
     assert actor_count == 5
-    HostCore.Actors.ActorSupervisor.terminate_actor(@kvcounter_key, 5)
+    HostCore.Actors.ActorSupervisor.terminate_actor(@kvcounter_key, 5, %{})
 
     :ok =
       HostCoreTest.EventWatcher.wait_for_event(
@@ -233,7 +233,7 @@ defmodule HostCore.ActorsTest do
       end
 
     assert res != :fail
-    HostCore.Actors.ActorSupervisor.terminate_actor(@echo_key, 1)
+    HostCore.Actors.ActorSupervisor.terminate_actor(@echo_key, 1, %{})
 
     ir = res |> Msgpax.unpack!()
 
@@ -293,7 +293,7 @@ defmodule HostCore.ActorsTest do
       end
 
     assert res != :fail
-    HostCore.Actors.ActorSupervisor.terminate_actor(@echo_key, 1)
+    HostCore.Actors.ActorSupervisor.terminate_actor(@echo_key, 1, %{})
 
     ir = res |> Msgpax.unpack!()
 
@@ -398,7 +398,7 @@ defmodule HostCore.ActorsTest do
       |> length
 
     assert actor_count == 5
-    HostCore.Actors.ActorSupervisor.terminate_actor(@kvcounter_key, 0)
+    HostCore.Actors.ActorSupervisor.terminate_actor(@kvcounter_key, 0, %{})
 
     :ok =
       HostCoreTest.EventWatcher.wait_for_event(


### PR DESCRIPTION
If an annotation map is supplied to the stop actor control interface function (and thereby the `terminate_actor` function), those annotations will be used to narrow the pool of candidate actors against which the stop operation works.

For context, `wadm` will supply such annotations where one annotation contains the "appspec" label, a key that wadm uses to identify which resources belong to which applications.