### PR TITLE
fix createTooltip error

### DIFF
--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/actor_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/actor_row_component.ex
@@ -51,7 +51,6 @@ defmodule ActorRowComponent do
         <script>
           createTooltip(document.getElementById("scale_actor_button_<%= @actor %>_<%= @host_id %>"))
           createTooltip(document.getElementById("copy_actor_id_<%= @actor %>_<%= @host_id %>"))
-          createTooltip(document.getElementById("copy_host_id_<%= @actor %>_<%= @host_id %>"))
           createTooltip(document.getElementById("stop_hotwatch_button_<%= @actor %>_<%= @host_id %>"))
         </script>
       </td>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/provider_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/provider_row_component.ex
@@ -51,7 +51,6 @@ defmodule ProviderRowComponent do
     </tr>
     <script>
       createTooltip(document.getElementById("copy_provider_id_<%= @provider %>_<%= @link_name %>_<%= @host_id %>"))
-      createTooltip(document.getElementById("copy_host_id_<%= @provider %>_<%= @link_name %>_<%= @host_id %>"))
       createTooltip(document.getElementById("delete_provider_<%= @provider %>_<%= @link_name %>_<%= @host_id %>"))
     </script>
     """

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.heex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.heex
@@ -1,6 +1,11 @@
 <script>
    // Custom function that can be called to create a CoreUI tooltip
    var createTooltip = (element) => {
+      if (!element) {
+         // The element does not exist, skip
+         return
+      }
+
       if (window.TooltipCreate === undefined) {
          setTimeout(() => createTooltip(element), 200)
       } else if (element.dataset.toggle = "tooltip") {


### PR DESCRIPTION
Here are two changes:

1. Remove createTooltip for element with id prefix `copy_host_id_ `, because there is no button with `copy_host_id_` id prefix. (By the way, the host id copy button uses `popover`(not `tooltip`) to hint `Copied`, see `wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.heex#273`)

2.  Add element checks in `createTooltip` function, see file `wasmcloud_host/lib/wasmcloud_host_web/live/page_live.html.heex#4`.  Because element with id prefix `stop_hotwatch_button_`  may not exist, see `wasmcloud_host/lib/wasmcloud_host_web/live/components/actor_row_component.ex#42`


With this PR, the console errors can be fixed.

<img width="1604" alt="image" src="https://user-images.githubusercontent.com/9459488/186112397-d65bd2c6-248c-4c0e-baa8-475f4250352f.png">
