### PR TITLE
Return error when attempting to overwrite existing linkdef

### DIFF
--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -158,8 +158,11 @@ defmodule HostCore.ControlInterface.Server do
              ) do
         {:reply, success_ack()}
       else
-        {:error, {:duplicate_key, {_, _, link_name}}} ->
-          {:reply, failure_ack("Duplicate link definition entry for '#{link_name}'")}
+        {:error, {:duplicate_key, {actor_id, contract_id, link_name}}} ->
+          {:reply,
+           failure_ack(
+             "Link definition for #{actor_id} on contract #{contract_id} and link #{link_name} already exists and must be deleted first"
+           )}
 
         _ ->
           {:reply, failure_ack("Invalid link definition put request")}
@@ -588,7 +591,9 @@ defmodule HostCore.ControlInterface.Server do
     })
   end
 
-  defp has_keys?(keys, request) do
+  defp has_keys?(keys, request) when is_map(request) do
     Enum.all?(keys, &Map.has_key?(request, &1))
   end
+
+  def has_keys(_keys, _request), do: false
 end

--- a/host_core/test/e2e/controlinterface_test.exs
+++ b/host_core/test/e2e/controlinterface_test.exs
@@ -81,20 +81,21 @@ defmodule HostCore.E2E.ControlInterfaceTest do
 
   test "cannot cache multiple linkdefs" do
     assert :ok =
-      HostCore.Linkdefs.Manager.put_link_definition(
-        @kvcounter_key,
-        @redis_contract,
-        @redis_link,
-        @redis_key,
-        %{URL: "redis://127.0.0.1:6379"}
-      )
+             HostCore.Linkdefs.Manager.put_link_definition(
+               @kvcounter_key,
+               @redis_contract,
+               @redis_link,
+               @redis_key,
+               %{URL: "redis://127.0.0.1:6379"}
+             )
 
-    assert {:error, {:duplicate_key, {@kvcounter_key, @redis_contract, @redis_link}}} = HostCore.Linkdefs.Manager.put_link_definition(
-        @kvcounter_key,
-        @redis_contract,
-        @redis_link,
-        @redis_key,
-        %{URL: "redis://127.0.0.1:6379"}
-      )
+    assert {:error, {:duplicate_key, {@kvcounter_key, @redis_contract, @redis_link}}} =
+             HostCore.Linkdefs.Manager.put_link_definition(
+               @kvcounter_key,
+               @redis_contract,
+               @redis_link,
+               @redis_key,
+               %{URL: "redis://127.0.0.1:6379"}
+             )
   end
 end

--- a/host_core/test/e2e/echo_test.exs
+++ b/host_core/test/e2e/echo_test.exs
@@ -5,9 +5,9 @@ defmodule HostCore.E2E.EchoTest do
   setup do
     {:ok, evt_watcher} =
       GenServer.start_link(HostCoreTest.EventWatcher, HostCore.Host.lattice_prefix())
-    on_exit(fn ->
-      :ets.delete_all_objects(:linkdef_table)
-    end)
+
+    on_exit(fn -> HostCore.Host.purge() end)
+
     [
       evt_watcher: evt_watcher
     ]
@@ -23,7 +23,6 @@ defmodule HostCore.E2E.EchoTest do
   @httpserver_contract HostCoreTest.Constants.httpserver_contract()
 
   test "echo roundtrip", %{:evt_watcher => evt_watcher} do
-    on_exit(fn -> HostCore.Host.purge() end)
     {:ok, bytes} = File.read(@echo_path)
     {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
 
@@ -78,8 +77,6 @@ defmodule HostCore.E2E.EchoTest do
   end
 
   test "unprivileged actor cannot receive undeclared invocations", %{:evt_watcher => evt_watcher} do
-    on_exit(fn -> HostCore.Host.purge() end)
-
     {:ok, bytes} = File.read(@echo_unpriv_path)
     {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes)
     :ok = HostCoreTest.EventWatcher.wait_for_actor_start(evt_watcher, @echo_unpriv_key)

--- a/host_core/test/e2e/echo_test.exs
+++ b/host_core/test/e2e/echo_test.exs
@@ -5,7 +5,9 @@ defmodule HostCore.E2E.EchoTest do
   setup do
     {:ok, evt_watcher} =
       GenServer.start_link(HostCoreTest.EventWatcher, HostCore.Host.lattice_prefix())
-
+    on_exit(fn ->
+      :ets.delete_all_objects(:linkdef_table)
+    end)
     [
       evt_watcher: evt_watcher
     ]
@@ -110,15 +112,6 @@ defmodule HostCore.E2E.EchoTest do
         @httpserver_link,
         @httpserver_key
       )
-
-    # For now, okay to put a link definition without proper claims
-    assert HostCore.Linkdefs.Manager.put_link_definition(
-             @echo_unpriv_key,
-             @httpserver_contract,
-             @httpserver_link,
-             @httpserver_key,
-             %{PORT: "8884"}
-           ) == :ok
 
     {:ok, _okay} = HTTPoison.start()
     {:ok, resp} = request_http("http://localhost:8884/foobar", 10)

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/define_link_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/define_link_component.ex
@@ -55,7 +55,8 @@ defmodule DefineLinkComponent do
                  values_map
                ) do
             :ok -> nil
-            _any -> "Error publishing link definition"
+            {:error, ""} -> "Error publishing link definition"
+            {:error, message} -> message
           end
       end
 


### PR DESCRIPTION
Use [`:ets.insert_new/2`](https://www.erlang.org/doc/man/ets.html#insert_new-2) to only insert link defs which does not already exist in the ets table. Closes #371
