### PR TITLE
Added configurable host and port to the dashboard

### DIFF
--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.57.0"
+  @app_vsn "0.57.1"
 
   def project do
     [

--- a/wasmcloud_host/Makefile
+++ b/wasmcloud_host/Makefile
@@ -48,6 +48,11 @@ buildx-cross-image: build esbuild ## Compile wasmcloud_host docker image using b
 		-f $(DOCKERFILE) \
 		.
 
+release: build ## Creates a mix release with a generated secret key base
+	@SECRET_KEY_BASE=$(shell mix phx.gen.secret) \
+		MIX_ENV=prod \
+		mix release
+
 run: build ## Run development wasmcloud_host
 	mix phx.server
 

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 
 version: 0.6.3
 
-appVersion: "0.57.0"
+appVersion: "0.57.1"

--- a/wasmcloud_host/config/dev.exs
+++ b/wasmcloud_host/config/dev.exs
@@ -7,7 +7,8 @@ import Config
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :wasmcloud_host, WasmcloudHostWeb.Endpoint,
-  http: [port: System.get_env("PORT") || 4000],
+  # The port can be configured by WASMCLOUD_DASBOARD_PORT, check endpoint.ex for implementation
+  http: [port: 4000],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/wasmcloud_host/config/prod.exs
+++ b/wasmcloud_host/config/prod.exs
@@ -10,9 +10,10 @@ import Config
 # which you should run after static files are built and
 # before starting your production server.
 config :wasmcloud_host, WasmcloudHostWeb.Endpoint,
-  http: [:inet6, port: System.get_env("PORT") || 4000],
+  # The host/port can be configured by WASMCLOUD_DASBOARD_HOST/PORT, check endpoint.ex for implementation
+  http: [:inet6, port: 4000],
   # This is critical for ensuring web-sockets properly authorize.
-  url: [host: "localhost", port: System.get_env("PORT")],
+  url: [host: "localhost", port: 4000],
   cache_static_manifest: "priv/static/cache_manifest.json",
   server: true,
   root: ".",

--- a/wasmcloud_host/config/prod.secret.exs
+++ b/wasmcloud_host/config/prod.secret.exs
@@ -11,19 +11,4 @@ secret_key_base =
     You can generate one by calling: mix phx.gen.secret
     """
 
-config :wasmcloud_host, WasmcloudHostWeb.Endpoint,
-  http: [
-    port: String.to_integer(System.get_env("PORT") || "4000"),
-    transport_options: [socket_opts: [:inet6]]
-  ],
-  secret_key_base: secret_key_base
-
-# ## Using releases (Elixir v1.9+)
-#
-# If you are doing OTP releases, you need to instruct Phoenix
-# to start each relevant endpoint:
-#
-#     config :wasmcloud_host, WasmcloudHostWeb.Endpoint, server: true
-#
-# Then you can assemble a release by calling `mix release`.
-# See `mix help release` for more information.
+config :wasmcloud_host, WasmcloudHostWeb.Endpoint, secret_key_base: secret_key_base

--- a/wasmcloud_host/lib/wasmcloud_host_web/endpoint.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/endpoint.ex
@@ -51,12 +51,24 @@ defmodule WasmcloudHostWeb.Endpoint do
   plug(WasmcloudHostWeb.Router)
 
   def init(_key, config) do
-    host = System.get_env("DASHBOARD_HOST")
+    host = System.get_env("WASMCLOUD_DASHBOARD_HOST")
+    port = System.get_env("WASMCLOUD_DASHBOARD_PORT") |> String.to_integer()
 
-    if host != nil do
-      {:ok, Keyword.put(config, :url, host: host)}
-    else
-      {:ok, config}
+    case {host, port} do
+      {nil, nil} ->
+        {:ok, config}
+
+      {host, nil} ->
+        {:ok, config |> Keyword.put(:url, host: host)}
+
+      {nil, port} ->
+        {:ok, config |> Keyword.put(:url, port: port) |> Keyword.put(:http, port: port)}
+
+      {host, port} ->
+        {:ok,
+         config
+         |> Keyword.put(:url, host: host, port: port)
+         |> Keyword.put(:http, port: port)}
     end
   end
 end

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.57.0"
+  @app_vsn "0.57.1"
 
   def project do
     [


### PR DESCRIPTION
Previously the dashboard host could be configured at runtime, but the PORT was only configurable at release time. This led to some confusion, and this PR adds `WASMCLOUD_DASHBOARD_HOST` and `WASMCLOUD_DASHBOARD_PORT` which are read at runtime and used to set the host/port.

By default, the host and port will be localhost & 4000 respectively, and this PR actually fixes #417 (in my testing, not setting the dashboard host will allow connections on localhost and 127.0.0.1)

I also added a `make release` target to easily create the release for wasmcloud_host