### PR TITLE
Fixed x86 musl nif build error

### DIFF
--- a/host_core/native/hostcore_wasmcloud_native/.cargo/config
+++ b/host_core/native/hostcore_wasmcloud_native/.cargo/config
@@ -10,6 +10,11 @@ rustflags = [
   "-C", "link-arg=dynamic_lookup",
 ]
 
+[target.x86_64-unknown-linux-musl]
+rustflags = [
+    "-C", "target-feature=-crt-static"
+]
+
 [target.aarch64-unknown-linux-musl]
 rustflags = [
     "-C", "target-feature=-crt-static"


### PR DESCRIPTION
For the x86 musl nif, I forgot to add in the crt-static flag for Rust. You can see a successful run of this at https://github.com/wasmCloud/wasmcloud-otp/actions/runs/2973824076