### PR TITLE
Corrected nil port parse

### DIFF
--- a/wasmcloud_host/lib/wasmcloud_host_web/endpoint.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/endpoint.ex
@@ -52,7 +52,7 @@ defmodule WasmcloudHostWeb.Endpoint do
 
   def init(_key, config) do
     host = System.get_env("WASMCLOUD_DASHBOARD_HOST")
-    port = System.get_env("WASMCLOUD_DASHBOARD_PORT") |> String.to_integer()
+    port = System.get_env("WASMCLOUD_DASHBOARD_PORT", "4000") |> String.to_integer()
 
     case {host, port} do
       {nil, nil} ->


### PR DESCRIPTION
While parsing the port, if the environment variable isn't specified, it ends up piping a `nil` into `String.to_integer()` which panics on startup 😕 