### PR TITLE
Return better error message when call alias is not found

### DIFF
--- a/host_core/lib/host_core/web_assembly/imports.ex
+++ b/host_core/lib/host_core/web_assembly/imports.ex
@@ -230,7 +230,7 @@ defmodule HostCore.WebAssembly.Imports do
     if target == :unknown do
       {:error, :alias_not_found, token}
     else
-      {:ok, Map.put(token, :target, target)}
+      {:ok, %{token | target: target}}
     end
   end
 


### PR DESCRIPTION
Fixes #419.

Short circuits the piping in `host_call` to return a better error message when `identify_target` fails to find a target entirely.

I considered turning the entire pipe into the `with` syntax, but that looked too scary for my first `wasmcloud-otp`/Elixir change 😅. Let me know if there's a better way to do this.

Signed-off-by: Matt Wilkinson <matt@mattwilkinson.dev>