### PR TITLE
Adding WASI support

### DIFF
--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -131,7 +131,6 @@ defmodule HostCore.Actors.ActorModule do
       {:ok, stdout} = Wasmex.Pipe.create()
       {:ok, stderr} = Wasmex.Pipe.create()
 
-
       wasi = %{
         args: [],
         env: %{},

--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -432,7 +432,7 @@ defmodule HostCore.Actors.ActorModule do
       end
 
     case Wasmex.start_link(opts)
-         |> prepare_module(agent, oci, false) do
+         |> prepare_module(agent, oci, true) do
       {:ok, agent} ->
         Agent.update(agent, fn state ->
           %State{state | ociref: oci}

--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -432,7 +432,7 @@ defmodule HostCore.Actors.ActorModule do
       end
 
     case Wasmex.start_link(opts)
-         |> prepare_module(agent, oci) do
+         |> prepare_module(agent, oci, false) do
       {:ok, agent} ->
         Agent.update(agent, fn state ->
           %State{state | ociref: oci}

--- a/host_core/test/support/constants.exs
+++ b/host_core/test/support/constants.exs
@@ -1,7 +1,8 @@
 defmodule HostCoreTest.Constants do
   # Actor related constants
   @echo_key "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5"
-  @echo_wasi_key "MCUXITMGLSPAFIMNHQVCC6DLXS6CHJN3NTER2NPP3F6QLR4QHR2SSPCW" # fixture key, not stored in OCI
+  # fixture key, not stored in OCI
+  @echo_wasi_key "MCUXITMGLSPAFIMNHQVCC6DLXS6CHJN3NTER2NPP3F6QLR4QHR2SSPCW"
   @echo_ociref "wasmcloud.azurecr.io/echo:0.3.1"
   @echo_ociref_updated "wasmcloud.azurecr.io/echo:0.3.1-liveupdate"
   @echo_path "test/fixtures/actors/echo.wasm"

--- a/host_core/test/support/constants.exs
+++ b/host_core/test/support/constants.exs
@@ -1,9 +1,11 @@
 defmodule HostCoreTest.Constants do
   # Actor related constants
   @echo_key "MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5"
+  @echo_wasi_key "MCUXITMGLSPAFIMNHQVCC6DLXS6CHJN3NTER2NPP3F6QLR4QHR2SSPCW" # fixture key, not stored in OCI
   @echo_ociref "wasmcloud.azurecr.io/echo:0.3.1"
   @echo_ociref_updated "wasmcloud.azurecr.io/echo:0.3.1-liveupdate"
   @echo_path "test/fixtures/actors/echo.wasm"
+  @echo_wasi_path "test/fixtures/actors/echo_wasi.wasm"
   @echo_unpriv_key "MCRACEYKJLCP7NLVMUTO2SCQ26JFL3Z4TBIXPXDE7KPBI2GEH5DA57L5"
   @echo_unpriv_path "test/fixtures/actors/echo_unpriv_s.wasm"
 
@@ -38,7 +40,9 @@ defmodule HostCoreTest.Constants do
 
   # Actor accessor methods
   def echo_key, do: @echo_key
+  def echo_wasi_key, do: @echo_wasi_key
   def echo_path, do: @echo_path
+  def echo_wasi_path, do: @echo_wasi_path
   def echo_ociref, do: @echo_ociref
   def echo_ociref_updated, do: @echo_ociref_updated
   def echo_unpriv_key, do: @echo_unpriv_key


### PR DESCRIPTION
This PR adds preliminary WASI support, with the following limitations:
* emissions to stdout and stderr currently go into the void (subsequent work can poll them and forward to logger)
* WASI arguments (e.g. psuedo commandline) are empty
* WASI environment variables are empty
* WASI pre-vetted files and directories are empty

The net result of this PR is that WASI modules won't break when loaded, shouldn't have runtime failures, and can access functionality like the clock and random number generator.

Documentation will be forthcoming that outlines the caveats associated with using WASI-based actors.