### PR TITLE
Emit provider start failed when identical provider exists

### DIFF
--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -358,9 +358,12 @@ defmodule HostCore.ControlInterface.Server do
           end
         end)
       else
-        Logger.warn(
+        warning =
           "Ignoring request to start provider, #{start_provider_command["provider_ref"]} (#{start_provider_command["link_name"]}) is already running"
-        )
+
+        Logger.warn(warning)
+
+        publish_provider_start_failed(start_provider_command, warning)
       end
 
       {:reply, success_ack()}

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.57.1"
+  @app_vsn "0.57.2"
 
   def project do
     [


### PR DESCRIPTION
This PR adds the emission of the ProviderStartFailed event when an identical provider already exists. Previously we ignored this case but that just resulted in confusing cases where the start seemed to be "lost"