### PR TITLE
Puts js_domain in host info for providers. Adds cluster key (issuer) to host probes

### DIFF
--- a/host_core/lib/host_core.ex
+++ b/host_core/lib/host_core.ex
@@ -196,8 +196,7 @@ defmodule HostCore do
 
             %{
               config
-              | cluster_seed: config.cluster_seed,
-                cluster_key: config.cluster_key,
+              | cluster_key: pk,
                 cluster_issuers: issuers,
                 cluster_adhoc: false
             }

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -46,6 +46,7 @@ defmodule HostCore.Host do
     friendly_name = HostCore.Namegen.generate()
 
     Logger.info("Host #{opts.host_key} (#{friendly_name}) started.")
+    Logger.info("Host issuer public key: #{opts.cluster_key}")
     Logger.info("Valid cluster signers: #{opts.cluster_issuers}")
 
     if opts.cluster_adhoc do
@@ -391,12 +392,13 @@ defmodule HostCore.Host do
   end
 
   def generate_hostinfo_for(provider_key, link_name, instance_id, config_json) do
-    {url, jwt, seed, tls, timeout, enable_structured_logging} =
+    {url, jwt, seed, tls, timeout, enable_structured_logging, js_domain} =
       case :ets.lookup(:config_table, :config) do
         [config: config_map] ->
           {"#{config_map[:prov_rpc_host]}:#{config_map[:prov_rpc_port]}",
            config_map[:prov_rpc_jwt], config_map[:prov_rpc_seed], config_map[:prov_rpc_tls],
-           config_map[:rpc_timeout_ms], config_map[:enable_structured_logging]}
+           config_map[:rpc_timeout_ms], config_map[:enable_structured_logging],
+           config_map[:js_domain]}
 
         _ ->
           {"127.0.0.1:4222", "", "", 2000, false}
@@ -425,6 +427,7 @@ defmodule HostCore.Host do
       default_rpc_timeout_ms: timeout,
       cluster_issuers: cluster_issuers(),
       invocation_seed: cluster_seed(),
+      js_domain: js_domain,
       # In case providers want to be aware of this for their own logging
       enable_structured_logging: to_bool(enable_structured_logging)
     }

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -338,6 +338,13 @@ defmodule HostCore.Host do
     end
   end
 
+  def issuer() do
+    case :ets.lookup(:config_table, :config) do
+      [config: config_map] -> config_map[:cluster_key]
+      _ -> ""
+    end
+  end
+
   def get_creds(ref) do
     GenServer.call(__MODULE__, {:get_creds, ref})
   end

--- a/host_core/lib/host_core/policy/manager.ex
+++ b/host_core/lib/host_core/policy/manager.ex
@@ -60,6 +60,7 @@ defmodule HostCore.Policy.Manager do
         action: action,
         host: %{
           publicKey: HostCore.Host.host_key(),
+          issuer: HostCore.Host.issuer(),
           latticeId: HostCore.Host.lattice_prefix(),
           labels: HostCore.Host.host_labels(),
           clusterIssuers: HostCore.Host.cluster_issuers()


### PR DESCRIPTION
1. This adds the `js_domain` field to the host information data payload sent to providers during startup. This is only useful if the provider (or underlying RPC library) needs to access things like jetstream for RPC "chunking", etc.
2. Adds the `issuer` field to the host ping response
3. Adds the `issuer` field to the host inventory response

This shouldn't break the control interface clients written in Rust because serde will ignore the unknown field(s). However, @jordan-rash this might break the corresponding Go client (I'm not sure how its JSON deserialization handles unexpected fields)