### PR TITLE
(Helm) Allow insecure registries and latest tag, for local/homeserver development

### DIFF
--- a/wasmcloud_host/chart/templates/deployment.yaml
+++ b/wasmcloud_host/chart/templates/deployment.yaml
@@ -150,6 +150,14 @@ spec:
                   name: {{ include "wasmcloud_host.fullname" . }}
                   key: ctlSeed
             {{- end }}
+            {{- if .Values.wasmcloud.config.ociAllowedInsecure }}
+            - name: WASMCLOUD_OCI_ALLOWED_INSECURE
+              value: {{ .Values.wasmcloud.config.ociAllowedInsecure | quote }}
+            {{- end }}
+            {{- if .Values.wasmcloud.config.ociAllowLatest }}
+            - name: WASMCLOUD_OCI_ALLOW_LATEST
+              value: {{ .Values.wasmcloud.config.ociAllowLatest | quote }}
+            {{- end }}
             {{- range $k, $v := .Values.wasmcloud.config.hostLabels }}
             - name: HOST_{{ $k }}
               value: {{ $v | quote }}

--- a/wasmcloud_host/chart/values.yaml
+++ b/wasmcloud_host/chart/values.yaml
@@ -31,6 +31,8 @@ wasmcloud:
     otel:
       exporter: ""
       endpoint: ""
+    ociAllowedInsecure: ""
+    ociAllowLatest: false
     # Sets the username and password for use with a private registry
     registry:
       url: ""


### PR DESCRIPTION
Just as the PR name states, this is only for development purposes.

My scenario for insecure registries on helm:

I run a home server with microk8s, on a desktop computer, and an insecure registry there. \
It is then used to push images from my laptop, and pull into the wasmcloud deployment. \
Without these changes I cannot deploy actors/providers in any way other than uploading manually, with a GUI.
