### PR TITLE
Quick fix, return quick ack for provider start fail

### DIFF
--- a/host_core/lib/host_core/control_interface/server.ex
+++ b/host_core/lib/host_core/control_interface/server.ex
@@ -362,6 +362,8 @@ defmodule HostCore.ControlInterface.Server do
             end
           end
         end)
+
+        {:reply, success_ack()}
       else
         warning =
           "Ignoring request to start provider, #{start_provider_command["provider_ref"]} (#{start_provider_command["link_name"]}) is already running"
@@ -369,9 +371,8 @@ defmodule HostCore.ControlInterface.Server do
         Logger.warn(warning)
 
         publish_provider_start_failed(start_provider_command, warning)
+        {:reply, failure_ack("Provider with that link name is already running on this host")}
       end
-
-      {:reply, success_ack()}
     else
       _ ->
         {:reply, failure_ack("Improperly formed start provider command JSON")}

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.57.3"
+  @app_vsn "0.57.4"
 
   def project do
     [

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 
 version: 0.6.5
 
-appVersion: "0.57.3"
+appVersion: "0.57.4"

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.57.3"
+  @app_vsn "0.57.4"
 
   def project do
     [


### PR DESCRIPTION
In #467 I added the `provider_start_failed` event to this scenario, but really we should return a failed ack in this case.