### PR TITLE
use registry type to extract server names

### DIFF
--- a/host_core/lib/host_core/providers/provider_supervisor.ex
+++ b/host_core/lib/host_core/providers/provider_supervisor.ex
@@ -60,16 +60,16 @@ defmodule HostCore.Providers.ProviderSupervisor do
     end
   end
 
-  def start_provider_from_oci(oci, link_name, config_json \\ "", annotations \\ %{}) do
+  def start_provider_from_oci(ref, link_name, config_json \\ "", annotations \\ %{}) do
     Tracer.with_span "Start Provider from OCI" do
-      creds = HostCore.Host.get_creds(oci)
-      Tracer.set_attribute("oci_ref", oci)
+      creds = HostCore.Host.get_creds(:oci, ref)
+      Tracer.set_attribute("oci_ref", ref)
       Tracer.set_attribute("link_name", link_name)
 
       with {:ok, path} <-
              HostCore.WasmCloud.Native.get_oci_path(
                creds,
-               oci,
+               ref,
                HostCore.Oci.allow_latest(),
                HostCore.Oci.allowed_insecure()
              ),
@@ -90,14 +90,14 @@ defmodule HostCore.Providers.ProviderSupervisor do
           par.claims,
           link_name,
           par.contract_id,
-          oci,
+          ref,
           config_json,
           annotations
         )
       else
         {:error, err} ->
           Logger.error("Error starting provider from OCI: #{err}",
-            oci_ref: oci,
+            oci_ref: ref,
             link_name: link_name
           )
 
@@ -107,7 +107,7 @@ defmodule HostCore.Providers.ProviderSupervisor do
 
         err ->
           Tracer.set_status(:error, "#{inspect(err)}")
-          Logger.error("Error starting provider from OCI: #{inspect(err)}", oci_ref: oci)
+          Logger.error("Error starting provider from OCI: #{inspect(err)}", oci_ref: ref)
           {:error, "Error starting provider from OCI"}
       end
     end
@@ -115,7 +115,7 @@ defmodule HostCore.Providers.ProviderSupervisor do
 
   def start_provider_from_bindle(bindle_id, link_name, config_json \\ "", annotations \\ %{}) do
     Tracer.with_span "Start Provider from Bindle" do
-      creds = HostCore.Host.get_creds(bindle_id)
+      creds = HostCore.Host.get_creds(:bindle, bindle_id)
       Tracer.set_attribute("bindle_id", bindle_id)
       Tracer.set_attribute("link_name", link_name)
 

--- a/host_core/test/host_core/private_registry_test.exs
+++ b/host_core/test/host_core/private_registry_test.exs
@@ -1,0 +1,127 @@
+defmodule HostCore.PrivateRegistryTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    HostCore.Host.clear_credsmap()
+  end
+
+  @private_oci_registry_url HostCoreTest.Constants.private_oci_registry_url()
+  @private_bindle_registry_url HostCoreTest.Constants.private_bindle_registry_url()
+
+  @bad_credentials %{"tee" => "hee"}
+  @missing_type_credentials %{"username" => "foo", "password" => "bar"}
+  @missing_username_credentials %{"registryType" => "oci", "tee" => "hee"}
+  @simple_credentials %{
+    "registryType" => "oci",
+    "username" => "oci-user",
+    "password" => "oci-pass"
+  }
+  @simple_credentials_updated %{
+    "registryType" => "oci",
+    "username" => "oci-user-2",
+    "password" => "oci-pass-2"
+  }
+  @bindle_credentials %{
+    "registryType" => "bindle",
+    "username" => "bindle-user-1",
+    "password" => "bindle-pass-1"
+  }
+
+  @bad_credsmap %{@private_oci_registry_url => @bad_credentials}
+  @missing_type_credsmap %{@private_oci_registry_url => @missing_type_credentials}
+  @missing_username_credsmap %{@private_oci_registry_url => @missing_username_credentials}
+  @simple_credsmap %{@private_oci_registry_url => @simple_credentials}
+  @simple_credsmap_updated %{@private_oci_registry_url => @simple_credentials_updated}
+  @bindle_credsmap %{@private_bindle_registry_url => @bindle_credentials}
+  @oci_and_bindle_credsmap %{
+    @private_oci_registry_url => @simple_credentials,
+    @private_bindle_registry_url => @bindle_credentials
+  }
+
+  test "all creds are nil when no creds have been set" do
+    assert HostCore.Host.get_creds(:oci, "foobar") == nil
+  end
+
+  test "malformed credentials are ignored" do
+    HostCore.Host.set_credsmap(@bad_credsmap)
+    assert HostCore.Host.get_creds(:oci, @private_oci_registry_url) == nil
+  end
+
+  test "credentials without a type are ignored" do
+    HostCore.Host.set_credsmap(@missing_type_credsmap)
+    assert HostCore.Host.get_creds(:oci, @private_oci_registry_url) == nil
+  end
+
+  test "credentials without a username/password/token are ignored" do
+    HostCore.Host.set_credsmap(@missing_username_credsmap)
+    assert HostCore.Host.get_creds(:oci, @private_oci_registry_url) == nil
+  end
+
+  test "credentials can be looked up by server name" do
+    HostCore.Host.set_credsmap(@simple_credsmap)
+    assert HostCore.Host.get_creds(:oci, @private_oci_registry_url) == @simple_credentials
+  end
+
+  test "credentials for unknown servers return nil" do
+    HostCore.Host.set_credsmap(@simple_credsmap)
+    assert HostCore.Host.get_creds(:oci, "foobar") == nil
+  end
+
+  test "credentials are segmented by registry type" do
+    HostCore.Host.set_credsmap(@simple_credsmap)
+    assert HostCore.Host.get_creds(:bindle, @private_oci_registry_url) == nil
+  end
+
+  test "schemes are stripped from server names" do
+    schemes = ["bindle", "oci", "http", "https"]
+
+    creds_map =
+      schemes
+      |> Enum.reduce(%{}, fn scheme, acc ->
+        serverUrl = scheme <> "://" <> scheme <> "-server"
+        Map.put(acc, serverUrl, @simple_credentials)
+      end)
+
+    HostCore.Host.set_credsmap(creds_map)
+
+    schemes
+    |> Enum.each(fn scheme ->
+      assert HostCore.Host.get_creds(:oci, scheme <> "-server") == @simple_credentials
+    end)
+  end
+
+  test "credentials can be looked up by OCI ref" do
+    HostCore.Host.set_credsmap(@simple_credsmap)
+    oci_ref = @private_oci_registry_url <> "/echo:0.3.5"
+    assert HostCore.Host.get_creds(:oci, oci_ref) == @simple_credentials
+  end
+
+  test "credentials can be looked up by bindle URI" do
+    HostCore.Host.set_credsmap(@bindle_credsmap)
+    bindle_id = "mybindle@" <> @private_bindle_registry_url
+    assert HostCore.Host.get_creds(:bindle, bindle_id) == @bindle_credentials
+  end
+
+  test "setting credentials is idempotent" do
+    HostCore.Host.set_credsmap(@simple_credsmap)
+    assert HostCore.Host.get_creds(:oci, @private_oci_registry_url) == @simple_credentials
+    HostCore.Host.set_credsmap(@simple_credsmap)
+    assert HostCore.Host.get_creds(:oci, @private_oci_registry_url) == @simple_credentials
+  end
+
+  test "credentials can be updated" do
+    HostCore.Host.set_credsmap(@simple_credsmap)
+    assert HostCore.Host.get_creds(:oci, @private_oci_registry_url) == @simple_credentials
+    HostCore.Host.set_credsmap(@simple_credsmap_updated)
+    assert HostCore.Host.get_creds(:oci, @private_oci_registry_url) == @simple_credentials_updated
+  end
+
+  test "updates for one server do not affect another" do
+    HostCore.Host.set_credsmap(@oci_and_bindle_credsmap)
+    assert HostCore.Host.get_creds(:oci, @private_oci_registry_url) == @simple_credentials
+    assert HostCore.Host.get_creds(:bindle, @private_bindle_registry_url) == @bindle_credentials
+    HostCore.Host.set_credsmap(@simple_credsmap_updated)
+    assert HostCore.Host.get_creds(:oci, @private_oci_registry_url) == @simple_credentials_updated
+    assert HostCore.Host.get_creds(:bindle, @private_bindle_registry_url) == @bindle_credentials
+  end
+end

--- a/host_core/test/support/constants.exs
+++ b/host_core/test/support/constants.exs
@@ -38,6 +38,10 @@ defmodule HostCoreTest.Constants do
   @nats_key "VADNMSIML2XGO2X4TPIONTIC55R2UUQGPPDZPAVSC2QD7E76CR77SPW7"
   @nats_ociref "wasmcloud.azurecr.io/nats_messaging:0.14.2"
 
+  # Registry related constants
+  @private_oci_registry_url "private.azurecr.io"
+  @private_bindle_registry_url "private.bindle.com"
+
   # Other related constants
   @default_link "default"
   @wasmcloud_issuer "ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW"
@@ -74,6 +78,10 @@ defmodule HostCoreTest.Constants do
   def redis_path, do: @redis_path
   def nats_key, do: @nats_key
   def nats_ociref, do: @nats_ociref
+
+  # Registry accessor methods
+  def private_oci_registry_url, do: @private_oci_registry_url
+  def private_bindle_registry_url, do: @private_bindle_registry_url
 
   # Other accessor methods
   def default_link, do: @default_link


### PR DESCRIPTION
This adds `registryType` as a required field on credential maps, which allowed for significant simplification of how credentials for a private OCI/bindle server are looked up. I also added tests for setting/reading registry credentials

Signed-off-by: Connor Smith <connor@cosmonic.com>