### PR TITLE
Update otel docker-compose to support seach traces

### DIFF
--- a/otel/compose.yaml
+++ b/otel/compose.yaml
@@ -1,10 +1,11 @@
 services:
   grafana:
-    image: grafana/grafana:8.1.2
+    image: grafana/grafana:9.2.0
     ports:
       - 5050:3000
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - ./grafana.ini:/etc/grafana/grafana.ini
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
@@ -12,10 +13,10 @@ services:
     depends_on:
       - tempo  
   tempo:
-    image: grafana/tempo:1.1.0
+    image: grafana/tempo:1.5.0
     command: ["-config.file=/etc/tempo.yaml"]
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml
     ports:
       - 8000:8000 # tempo
-      - 55681:55681 # otlp http  
+      - 55681:4318 # otlp http

--- a/otel/grafana.ini
+++ b/otel/grafana.ini
@@ -1,0 +1,2 @@
+[feature_toggles]
+enable = tempoSearch tempoBackendSearch

--- a/otel/tempo.yaml
+++ b/otel/tempo.yaml
@@ -2,11 +2,14 @@ server:
   http_listen_port: 8000
 
 distributor:
-  log_received_traces: true
   receivers:
     otlp:
       protocols:
         http:
+  log_received_spans:
+    enabled: true
+    include_all_attributes: true
+    filter_by_status_error: true
 
 storage:
   trace:
@@ -15,6 +18,8 @@ storage:
       encoding: zstd
     wal:
       path: /tmp/tempo/wal
-      encoding: none
+      encoding: snappy
     local:
       path: /tmp/tempo/blocks
+
+search_enabled: true


### PR DESCRIPTION
The new docker-compose example supports search traces. So that we do not need to inspect the otel docker log or wasmhost log to get traceID.

<img width="1822" alt="image" src="https://user-images.githubusercontent.com/9459488/195247057-2cbde7f3-8138-4406-aa83-771a063d6353.png">
