### PR TITLE
replace nil with empty binary on 'msg' field of invocation responses

### DIFF
--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -263,7 +263,7 @@ defmodule HostCore.Actors.ActorModule do
               Tracer.set_status(:error, "Anti-forgery check failed #{msg}")
 
               {%{
-                 msg: nil,
+                 msg: <<>>,
                  invocation_id: inv["id"],
                  error: msg,
                  instance_id: iid
@@ -301,7 +301,7 @@ defmodule HostCore.Actors.ActorModule do
                   Tracer.set_status(:error, "Invocation failure: #{error}")
 
                   {%{
-                     msg: nil,
+                     msg: <<>>,
                      error: error,
                      invocation_id: inv["id"],
                      instance_id: iid
@@ -313,7 +313,7 @@ defmodule HostCore.Actors.ActorModule do
             Tracer.set_status(:error, "Failed to deserialize msgpack invocation")
 
             {%{
-               msg: nil,
+               msg: <<>>,
                invocation_id: "",
                error: "Failed to deserialize msgpack invocation",
                instance_id: iid

--- a/host_core/lib/host_core/actors/actor_rpc_server.ex
+++ b/host_core/lib/host_core/actors/actor_rpc_server.ex
@@ -38,7 +38,7 @@ defmodule HostCore.Actors.ActorRpcServer do
     Logger.error("Actor RPC handler failure: #{inspect(error)}")
 
     ir = %{
-      msg: nil,
+      msg: <<>>,
       invocation_id: "",
       error: "Failed to handle actor RPC: #{inspect(error)}",
       instance_id: ""


### PR DESCRIPTION
When wasmbus-rpc attempts to deserialize the MessagePack envelope, nils fail to deserialize to an empty Vec. This was causing a bunch of illegible error messages any time the invocation response didn't include a message

Signed-off-by: Connor Smith <connor@cosmonic.com>