### PR TITLE
Attempt to create consumer regardless of stream response

### DIFF
--- a/host_core/lib/host_core/jetstream/client.ex
+++ b/host_core/lib/host_core/jetstream/client.ex
@@ -171,7 +171,9 @@ defmodule HostCore.Jetstream.Client do
           "description" => "stream name already in use with a different configuration"
         }
       }) do
-    Logger.info("Lattice cache stream name already in use, assuming previously-configured stream")
+    Logger.info(
+      "Lattice cache stream name already in use with different configuration, using previously-configured stream"
+    )
   end
 
   def handle_stream_create_response(%{
@@ -187,7 +189,7 @@ defmodule HostCore.Jetstream.Client do
   end
 
   def handle_stream_create_response(body) do
-    Logger.error(
+    Logger.warn(
       "Received unexpected response from NATS when attempting to create cache stream: #{inspect(body)}"
     )
   end

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.58.1"
+  @app_vsn "0.58.2"
 
   def project do
     [

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://github.com/wasmCloud/wasmcloud.com-dev/raw/main/static/images/wasm
 
 type: application
 
-version: 0.6.6
+version: 0.6.7
 
-appVersion: "0.58.0"
+appVersion: "0.58.2"

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.58.0"
+  @app_vsn "0.58.2"
 
   def project do
     [


### PR DESCRIPTION
This PR removes the "fail early" aspect of the jetstream client. In testing we've seen a few different error messages come from the NATS stream create message, and because we were short-circuiting if we received an unexpected response (even if it was OK to proceed) we broke some new emerging scenarios with stream creates.

After this PR, even if the stream fails to create we'll attempt to create the consumer anyways. Some valid reasons for this include:
1. Stream already exists with that name
    1. We proceed safely and create the ephemeral consumer 
3. Stream already exists with that name with a different configuration
    1. We proceed safely and attempt to create the ephemeral consumer (which should not fail, unless there's a max number of consumers)
4. The NATS user is allowed to subscribe to streams but not create them
    1. We proceed safely and create the ephemeral consumer

If the stream create fails, we `warn` and proceed regardless to create the consumer, which will error if anything goes wrong. This won't prevent the host from launching, but we may end up closing the host in this case

More scenarios probably fall under this umbrella, and in the interest of not updating the host for each emerging scenario we can just attempt to proceed with creating the ephemeral consumer. Feasibly, if this is a legitimate error scenario, we'll fail for the same reason in both places and _then_ modification of NATS config or host handlers could be required.