### PR TITLE
Removed host_core release from actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,82 +171,82 @@ jobs:
           name: ${{ matrix.release-tarball }}
           path: ${{env.working-directory}}/${{ matrix.release-tarball }}
 
-  release-hostcore-docker:
-    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
-    needs: compile-native-nif
-    name: Release Image (host_core)
-    runs-on: ubuntu-22.04
-    env:
-      MIX_ENV: release_prod
-      working-directory: wasmcloud_host
-      SECRET_KEY_BASE: ${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}
-      app-name: host_core
-      arm-tarball: aarch64-linux-musl-core.tar.gz
-      builder-image: elixir:1.13.4-alpine
-      release-image: alpine:3.16
-    steps:
-      - uses: actions/checkout@v3
-      - name: Determine version
-        run: echo "app-version=$(grep '@app_vsn "' ${{env.working-directory}}/mix.exs | cut -d '"' -f2)" > $GITHUB_ENV
+  # release-hostcore-docker:
+  #   if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+  #   needs: compile-native-nif
+  #   name: Release Image (host_core)
+  #   runs-on: ubuntu-22.04
+  #   env:
+  #     MIX_ENV: release_prod
+  #     working-directory: wasmcloud_host
+  #     SECRET_KEY_BASE: ${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}
+  #     app-name: host_core
+  #     arm-tarball: aarch64-linux-musl-core.tar.gz
+  #     builder-image: elixir:1.13.4-alpine
+  #     release-image: alpine:3.16
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Determine version
+  #       run: echo "app-version=$(grep '@app_vsn "' ${{env.working-directory}}/mix.exs | cut -d '"' -f2)" > $GITHUB_ENV
 
-      # Download the NIF in the path that Docker expects for x86
-      - uses: actions/download-artifact@v3
-        with:
-          path: ./host_core/priv/built/x86_64
-          name: x86_64-unknown-linux-musl
-      # Download the NIF in the path that Docker expects for aarch64
-      - uses: actions/download-artifact@v3
-        with:
-          path: ./host_core/priv/built/aarch64
-          name: aarch64-unknown-linux-musl
+  #     # Download the NIF in the path that Docker expects for x86
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         path: ./host_core/priv/built/x86_64
+  #         name: x86_64-unknown-linux-musl
+  #     # Download the NIF in the path that Docker expects for aarch64
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         path: ./host_core/priv/built/aarch64
+  #         name: aarch64-unknown-linux-musl
 
-      - name: Login to AzureCR
-        uses: azure/docker-login@v1
-        with:
-          login-server: ${{ secrets.AZURECR_PUSH_URL }}
-          username: ${{ secrets.AZURECR_PUSH_USER }}
-          password: ${{ secrets.AZURECR_PUSH_PASSWORD }}
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_PUSH_USER }}
-          password: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        id: buildx-builder
-      - name: Build and release docker image
-        uses: docker/build-push-action@v3
-        with:
-          builder: ${{ steps.buildx-builder.outputs.name }}
-          push: true
-          context: ${{ env.app-name}}/
-          file: ${{ env.app-name}}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          build-args: |
-            BUILDER_IMAGE=${{ env.builder-image }}
-            RELEASE_IMAGE=${{ env.release-image }}
-            APP_NAME=${{ env.app-name }}
-            APP_VSN=${{ env.app-version }}
-            MIX_ENV=${{ env.MIX_ENV }}
-          tags: |
-            wasmcloud.azurecr.io/${{ env.app-name }}:${{ env.app-version }}
-            wasmcloud.azurecr.io/${{ env.app-name }}:latest
-            wasmcloud/${{ env.app-name }}:${{ env.app-version }}
-            wasmcloud/${{ env.app-name }}:latest
+  #     - name: Login to AzureCR
+  #       uses: azure/docker-login@v1
+  #       with:
+  #         login-server: ${{ secrets.AZURECR_PUSH_URL }}
+  #         username: ${{ secrets.AZURECR_PUSH_USER }}
+  #         password: ${{ secrets.AZURECR_PUSH_PASSWORD }}
+  #     - name: Login to DockerHub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_PUSH_USER }}
+  #         password: ${{ secrets.DOCKERHUB_PUSH_PASSWORD }}
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v2
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
+  #       id: buildx-builder
+  #     - name: Build and release docker image
+  #       uses: docker/build-push-action@v3
+  #       with:
+  #         builder: ${{ steps.buildx-builder.outputs.name }}
+  #         push: false
+  #         context: ${{ env.app-name}}/
+  #         file: ${{ env.app-name}}/Dockerfile
+  #         platforms: linux/amd64,linux/arm64
+  #         build-args: |
+  #           BUILDER_IMAGE=${{ env.builder-image }}
+  #           RELEASE_IMAGE=${{ env.release-image }}
+  #           APP_NAME=${{ env.app-name }}
+  #           APP_VSN=${{ env.app-version }}
+  #           MIX_ENV=${{ env.MIX_ENV }}
+  #         tags: |
+  #           wasmcloud.azurecr.io/${{ env.app-name }}:${{ env.app-version }}
+  #           wasmcloud.azurecr.io/${{ env.app-name }}:latest
+  #           wasmcloud/${{ env.app-name }}:${{ env.app-version }}
+  #           wasmcloud/${{ env.app-name }}:latest
 
-      - name: Retrieve aarch64 tarball from Docker
-        run: |
-          docker run --rm --platform linux/arm64/v8 -iv ${PWD}:/aarch64temp wasmcloud/${{ env.app-name }}:${{ env.app-version}} sh -s <<EOF
-          tar -czvf ${{ env.arm-tarball }} bin erts-*/ lib/ releases/
-          cp ${{ env.arm-tarball }} /aarch64temp/
-          EOF
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.arm-tarball }}
-          path: ${{ env.arm-tarball }}
+  #     - name: Retrieve aarch64 tarball from Docker
+  #       run: |
+  #         docker run --rm --platform linux/arm64/v8 -iv ${PWD}:/aarch64temp wasmcloud/${{ env.app-name }}:${{ env.app-version}} sh -s <<EOF
+  #         tar -czvf ${{ env.arm-tarball }} bin erts-*/ lib/ releases/
+  #         cp ${{ env.arm-tarball }} /aarch64temp/
+  #         EOF
+  #     - name: Upload artifact
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: ${{ env.arm-tarball }}
+  #         path: ${{ env.arm-tarball }}
 
   # Dear reviewer, you may be thinking to yourself, "hey, this looks like a great candidate for a matrix with the above"
   # I once thought so too, and to spare you some incredible pain, turns out _something_ about QEMU does


### PR DESCRIPTION
As of the `0.58.0` release, we're seeing the host_core Dockerfile fail to build. This is unfortunate, and with an opaque error message difficult to debug. This PR removes this build from our release pipeline, for now.

This is acceptable only because the host_core docker image and tarball don't provide the wasmCloud experience that we want, at this moment. Capability providers that are destined for this image (a musl libc image) need to be compiled _specifically_ with this in mind which is a lot to ask of both our users and ourselves. Until we can transition to architecture-agnostic capability providers, the complexity of compiling our Wasmex package manually and maintaining a Docker image isn't reasonable for the benefit.