### PR TITLE
Fixing orphan processes during actor shutdown

### DIFF
--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -221,7 +221,11 @@ defmodule HostCore.Actors.ActorModule do
 
     publish_actor_stopped(public_key, instance_id)
 
-    {:stop, :normal, :ok, agent}
+    # PRO TIP - if you return :normal here as the stop reason, the GenServer will NOT auto-terminate
+    # all of its children. If you want all children established via start_link to be terminated here,
+    # you -have- to use :shutdown as the reason.
+    # That's right, the stop reason :normal automatically results in orphaned processes.
+    {:stop, :shutdown, :ok, agent}
   end
 
   @impl true

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -160,7 +160,7 @@ defmodule HostCore.Providers.ProviderModule do
       "normal"
     )
 
-    {:stop, :normal, :ok, state}
+    {:stop, :shutdown, :ok, state}
   end
 
   @impl true
@@ -214,7 +214,7 @@ defmodule HostCore.Providers.ProviderModule do
       "normal"
     )
 
-    {:stop, :normal, state}
+    {:stop, :shutdown, state}
   end
 
   def handle_info({:DOWN, _ref, :port, _port, reason}, state) do

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.58.2"
+  @app_vsn "0.58.3"
 
   def project do
     [


### PR DESCRIPTION
This change resolves a subtle memory leak. Every time we create an actor we create two child processes - an agent for state, and a `wasmex` genserver for the webassembly module itself. Apparently when using `:normal` as a termination reason, children created with `start_link` are orphaned rather than terminated. This means that the memory consumed by those orphaned children isn't reclaimed.

This changes the shutdown reason to `:shutdown`, which will explicitly cause the GenServer to terminate children and therefore be able to reclaim the resources used by them.