### PR TITLE
Fix/cache actor modules

### DIFF
--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -411,11 +411,13 @@ defmodule HostCore.Actors.ActorModule do
       wasmbus: Imports.wasmbus_imports(agent)
     }
 
-    module = case :ets.lookup(:module_cache, claims.public_key) do
-      [{_, cached_mod}] -> cached_mod
+    key = :crypto.hash(:sha256, bytes) |> Base.encode16() # we consider a hash of bytes as a unique key
+    module = case :ets.lookup(:module_cache, key) do
+      [{_, cached_mod}] ->
+        cached_mod
       [] ->
         {:ok, mod} = Wasmex.Module.compile(bytes)
-        :ets.insert(:module_cache, {claims.public_key, mod})
+        :ets.insert(:module_cache, {key, mod})
         mod
     end
 

--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -411,15 +411,19 @@ defmodule HostCore.Actors.ActorModule do
       wasmbus: Imports.wasmbus_imports(agent)
     }
 
-    key = :crypto.hash(:sha256, bytes) |> Base.encode16() # we consider a hash of bytes as a unique key
-    module = case :ets.lookup(:module_cache, key) do
-      [{_, cached_mod}] ->
-        cached_mod
-      [] ->
-        {:ok, mod} = Wasmex.Module.compile(bytes)
-        :ets.insert(:module_cache, {key, mod})
-        mod
-    end
+    # we consider a hash of bytes as a unique key
+    key = :crypto.hash(:sha256, bytes) |> Base.encode16()
+
+    module =
+      case :ets.lookup(:module_cache, key) do
+        [{_, cached_mod}] ->
+          cached_mod
+
+        [] ->
+          {:ok, mod} = Wasmex.Module.compile(bytes)
+          :ets.insert(:module_cache, {key, mod})
+          mod
+      end
 
     # TODO - in the future, poll these so we can forward the err/out pipes
     # to our logger

--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -411,7 +411,13 @@ defmodule HostCore.Actors.ActorModule do
       wasmbus: Imports.wasmbus_imports(agent)
     }
 
-    {:ok, module} = Wasmex.Module.compile(bytes)
+    module = case :ets.lookup(:module_cache, claims.public_key) do
+      [{_, cached_mod}] -> cached_mod
+      [] ->
+        {:ok, mod} = Wasmex.Module.compile(bytes)
+        :ets.insert(:module_cache, {claims.public_key, mod})
+        mod
+    end
 
     # TODO - in the future, poll these so we can forward the err/out pipes
     # to our logger

--- a/host_core/lib/host_core/host.ex
+++ b/host_core/lib/host_core/host.ex
@@ -319,6 +319,7 @@ defmodule HostCore.Host do
     :ets.new(:callalias_table, [:named_table, :set, :public])
     :ets.new(:config_table, [:named_table, :set, :public])
     :ets.new(:policy_table, [:named_table, :set, :public])
+    :ets.new(:module_cache, [:named_table, :set, :public])
   end
 
   def set_credsmap(credsmap) do


### PR DESCRIPTION
This adds a `:module_cache` ets table used to cache the compiled bytes for an actor. I had a suspicion re-compiling on every actor instantiation was contributing to the host consuming more memory than it should.

I tested this change with the following script:

```bash
host_id=$(wash ctl get hosts -o json | jq -r '.hosts | .[0].id')
actor_id=MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5
actor_ref=wasmcloud.azurecr.io/echo:0.3.5
N=10

while true; do
    for i in $(seq 1 $N); do
        wash ctl scale actor $host_id $actor_id $actor_ref --count $i
    done
done
```

On main, if you leave this running, the host's memory will quickly grow, and grow, and grow, and.... With this change, the host uses less memory per instance, and it also reclaims nearly(?) all memory when an instance is terminated