### PR TITLE
Add host ID to provider shutdown message

### DIFF
--- a/host_core/lib/host_core/providers/provider_supervisor.ex
+++ b/host_core/lib/host_core/providers/provider_supervisor.ex
@@ -240,7 +240,7 @@ defmodule HostCore.Providers.ProviderSupervisor do
           case HostCore.Nats.safe_req(
                  :lattice_nats,
                  "wasmbus.rpc.#{prefix}.#{public_key}.#{link_name}.shutdown",
-                 "",
+                 Jason.encode!(%{host_id: HostCore.Host.host_key()}),
                  receive_timeout: 2000
                ) do
             {:ok, _msg} ->
@@ -251,6 +251,7 @@ defmodule HostCore.Providers.ProviderSupervisor do
               :error
 
             {:error, :timeout} ->
+              Logger.error("No capability providers responded to shutdown request")
               :error
           end
 

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.58.4"
+  @app_vsn "0.58.3"
 
   def project do
     [

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.58.3"
+  @app_vsn "0.58.4"
 
   def project do
     [

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 
 version: 0.6.7
 
-appVersion: "0.58.2"
+appVersion: "0.58.3"

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.58.2"
+  @app_vsn "0.58.3"
 
   def project do
     [


### PR DESCRIPTION
This code adds the host ID of the host that handled the terminate provider message to the shutdown message sent to the provider. This (in another PR) will allow the provider to decide if it was the true target of the shutdown. If it wasn't the target, it will stay running.

Testing Method:
* Updated the HTTP server interface to use new code
* Updated the HTTP server capability provider to use the new interface
* Updated the wasmCloud OTP host (this PR) to include the target host ID on the shutdown message
* Start 2 http server providers , 1 per host
* Issue a stop command for one host
* Observe 1 provider still running

![Screenshot 2022-11-07 at 9 15 21 AM](https://user-images.githubusercontent.com/13748641/200332022-5319cb47-e708-48de-8048-4ec002316047.png)
