### PR TITLE
Initial support for lattice-local artifact storage

### DIFF
--- a/host_core/lib/host_core/actors/actor_supervisor.ex
+++ b/host_core/lib/host_core/actors/actor_supervisor.ex
@@ -150,7 +150,7 @@ defmodule HostCore.Actors.ActorSupervisor do
     Tracer.with_span "Starting Actor from lattice object store", kind: :server do
       case HostCore.WasmCloud.Native.get_actor_localobject(pk) do
         {:error, error} ->
-          Tracer.add_event("Fetch from lattice object store failed", reason: "#{inspect(err)}")
+          Tracer.add_event("Fetch from lattice object store failed", reason: "#{inspect(error)}")
           Logger.error("Failed to download actor (#{pk}) from lattice object store")
 
           {:error, error}

--- a/host_core/lib/host_core/wasmcloud/native.ex
+++ b/host_core/lib/host_core/wasmcloud/native.ex
@@ -24,6 +24,7 @@ defmodule HostCore.WasmCloud.Native do
   def dechunk_inv(_inv_id), do: error()
   def chunk_inv(_inv_id, _bytes), do: error()
 
+  def get_actor_localobject(_actor_id), do: error()
   def get_oci_bytes(_creds, _oci_ref, _allow_latest, _allowed_insecure), do: error()
   def get_oci_path(_creds, _path, _allow_latest, _allowed_insecure), do: error()
   def par_from_path(_path, _link_name), do: error()

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.lock
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.lock
@@ -1127,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "nats"
-version = "0.20.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a916657662da9799246f1ac8dda022c48c4d1c97a9208121ffecc658cef20f"
+checksum = "4f42b51fc2560ec17f242ca715a3ece4e97704e6d798162b91f99c3cabef8980"
 dependencies = [
  "base64",
  "base64-url",
@@ -1719,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "rustler"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1d0129006c447df2939ea2d370a31cd1c1a5103c2777545b14da9aefd656df"
+checksum = "d61e8ddf75de20513455d7b6f17241a595abbb01b53a6340cecc798a1b13422d"
 dependencies = [
  "lazy_static",
  "rustler_codegen",
@@ -1730,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "rustler_codegen"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0335f95feb990dc7eebb69cfc29cc93cbbe813b3d7dc1edb915c59e4079a6"
+checksum = "baa2e45c0165272070f80ce93bcd7dd5407a3c84a1ef73ab9900e00f00ef3d36"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.toml
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-rustler = "0.24.0"
+rustler = "0.26.0"
 lazy_static = "1.0"
 serde = {version = "1.0.126", features = ["derive"] }
 serde_bytes = "0.11.5"
@@ -32,4 +32,4 @@ tokio-stream = "0.1"
 bindle = { version = "0.8", git = "https://github.com/deislabs/bindle", rev = "7a5f11ca9986837f8ee54e8d577204ec520b6764", default-features = false, features = ["client", "caching", "rustls-tls"] }
 async-trait = "0.1"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
-nats = "0.20.1"
+nats = "0.22.0"

--- a/host_core/native/hostcore_wasmcloud_native/src/objstore.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/objstore.rs
@@ -32,6 +32,20 @@ pub(crate) fn unchonk_from_object_store(id: &str) -> Result<Vec<u8>, Error> {
     Ok(result)
 }
 
+pub(crate) fn read_from_artifact_store(id: &str) -> Result<Vec<u8>, Error> {
+    let mut result = Vec::new();
+    let store = crate::ARTIFACT_STORE.read().unwrap();
+    if let Some(ref store) = *store {
+        store
+            .get(id)
+            .map_err(to_rustler_err)?
+            .read_to_end(&mut result)
+            .map_err(to_rustler_err)?;
+    }
+
+    Ok(result)
+}
+
 pub(crate) fn create_or_reuse_store(
     js: &JetStream,
     name: &str,


### PR DESCRIPTION
This adds support for the "launch actor" control interface command to contain actor references with the scheme/prefix of `lattice://`. When the host receives such an instruction, it will pull the bytes from a NATS object store named `ARTIFACT_{lattice}` and the object ID is the public key of the actor.

For example, if the actor module has a public key of `MAXGZOTHQGIISDCJQS577NY4NAFBOUI5MNFL43IMPEWX5V3YOGNYWO6D`, then you could send a request to launch this actor with the reference `lattice://MAXGZOTHQGIISDCJQS577NY4NAFBOUI5MNFL43IMPEWX5V3YOGNYWO6D`. The object must already exist in the `ARTIFACT_{lattice}` object store with the key `MAXGZOTHQGIISDCJQS577NY4NAFBOUI5MNFL43IMPEWX5V3YOGNYWO6D`.

_The host will not automatically create this object store_ because the host never writes to this store, it only ever reads. Therefore, tooling that writes to this store will be responsible for creation. (e.g. `wash`).

⚠️ **NOTE** - we are awaiting a change/fix to the NATS Rust client that deals with object name encoding. Until this release is adopted, objects uploaded using the `golang` client (which includes the `nats` CLI!) will not be visible to the host. Additionally, we've discovered that this same issue prevents `golang` capability providers from exchanging chunked invocations with the host. 