### PR TITLE
Updated version to 0.59.0 for release

### DIFF
--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.58.3"
+  @app_vsn "0.59.0"
 
   def project do
     [

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://github.com/wasmCloud/wasmcloud.com-dev/raw/main/static/images/wasm
 
 type: application
 
-version: 0.6.7
+version: 0.6.8
 
-appVersion: "0.58.3"
+appVersion: "0.59.0"

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.58.3"
+  @app_vsn "0.59.0"
 
   def project do
     [


### PR DESCRIPTION
Pr #494 is a breaking change, so this is a bump to 0.59.0 instead of releasing `0.58.3`