### PR TITLE
Add start provider configuration

### DIFF
--- a/host_core/lib/host_core/providers/provider_supervisor.ex
+++ b/host_core/lib/host_core/providers/provider_supervisor.ex
@@ -171,9 +171,16 @@ defmodule HostCore.Providers.ProviderSupervisor do
           host_id :: String.t(),
           path :: String.t(),
           link_name :: String.t(),
-          annotations :: map()
+          annotations :: map(),
+          provider_configuration :: String.t()
         ) :: DynamicSupervisor.on_start_child()
-  def start_provider_from_file(host_id, path, link_name, annotations \\ %{}) do
+  def start_provider_from_file(
+        host_id,
+        path,
+        link_name,
+        annotations \\ %{},
+        provider_configuration \\ ""
+      ) do
     Tracer.with_span "Start Provider from File" do
       case Native.par_from_path(path, link_name) do
         {:ok, par} ->
@@ -189,7 +196,7 @@ defmodule HostCore.Providers.ProviderSupervisor do
             link_name,
             par.contract_id,
             "",
-            "",
+            provider_configuration,
             annotations
           )
 

--- a/wasmcloud_host/lib/wasmcloud_host/lattice/control_interface.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/lattice/control_interface.ex
@@ -31,7 +31,7 @@ defmodule WasmcloudHost.Lattice.ControlInterface do
     end
   end
 
-  def start_provider(provider_ociref, link_name, host_id) do
+  def start_provider(provider_ociref, link_name, host_id, provider_configuration \\ "") do
     {_pk, _pid, prefix} = WasmcloudHost.Application.first_host()
 
     topic = "#{@wasmbus_prefix}#{prefix}.cmd.#{host_id}.lp"
@@ -39,7 +39,8 @@ defmodule WasmcloudHost.Lattice.ControlInterface do
     payload =
       Jason.encode!(%{
         "provider_ref" => provider_ociref,
-        "link_name" => link_name
+        "link_name" => link_name,
+        "configuration" => provider_configuration
       })
 
     case ctl_request(prefix, topic, payload, 2_000) do

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_provider_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_provider_component.ex
@@ -59,7 +59,8 @@ defmodule StartProviderComponent do
         %{
           "provider_ociref" => provider_ociref,
           "provider_link_name" => provider_link_name,
-          "host_id" => host_id
+          "host_id" => host_id,
+          "provider_configuration" => provider_configuration
         },
         socket
       ) do
@@ -71,22 +72,23 @@ defmodule StartProviderComponent do
                %{}
              ) do
           {:ok, auction_host_id} ->
-            start_provider(provider_ociref, provider_link_name, auction_host_id, socket)
+            start_provider(provider_ociref, provider_link_name, auction_host_id, socket, provider_configuration)
 
           {:error, error} ->
             {:noreply, assign(socket, error_msg: error)}
         end
 
       host_id ->
-        start_provider(provider_ociref, provider_link_name, host_id, socket)
+        start_provider(provider_ociref, provider_link_name, host_id, socket, provider_configuration)
     end
   end
 
-  defp start_provider(provider_ociref, provider_link_name, host_id, socket) do
+  defp start_provider(provider_ociref, provider_link_name, host_id, socket, provider_configuration \\ "") do
     case ControlInterface.start_provider(
            provider_ociref,
            provider_link_name,
-           host_id
+           host_id,
+           provider_configuration
          ) do
       :ok ->
         Phoenix.PubSub.broadcast(WasmcloudHost.PubSub, "frontend", :hide_modal)
@@ -162,6 +164,14 @@ defmodule StartProviderComponent do
             value="default" required>
         </div>
       </div>
+      <%= if assigns.id == :start_provider_ociref_modal do %>
+      <div class="form-group row">
+        <label class="col-md-3 col-form-label" for="text-input">Configuration</label>
+        <div class="col-md-9">
+          <input class="form-control" id="text-input" type="text" name="provider_configuration" placeholder="{&quot;K1&quot;:&quot;V1&quot;,&quot;K2&quot;:&quot;V2&quot;}">
+        </div>
+      </div>
+      <% end %>
       <div class="modal-footer">
         <button class="btn btn-secondary" type="button" phx-click="hide_modal">Close</button>
         <button class="btn btn-primary" type="submit">Submit</button>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_provider_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_provider_component.ex
@@ -22,7 +22,8 @@ defmodule StartProviderComponent do
   def handle_event(
         "start_provider_file",
         %{
-          "provider_link_name" => provider_link_name
+          "provider_link_name" => provider_link_name,
+          "provider_configuration" => provider_configuration
         },
         socket
       ) do
@@ -33,7 +34,9 @@ defmodule StartProviderComponent do
         case ProviderSupervisor.start_provider_from_file(
                pk,
                path,
-               provider_link_name
+               provider_link_name,
+               %{},
+               provider_configuration
              ) do
           {:ok, _pid} -> ""
           {:error, reason} -> reason
@@ -182,14 +185,12 @@ defmodule StartProviderComponent do
             value="default" required>
         </div>
       </div>
-      <%= if assigns.id == :start_provider_ociref_modal do %>
       <div class="form-group row">
         <label class="col-md-3 col-form-label" for="text-input">Configuration</label>
         <div class="col-md-9">
           <input class="form-control" id="text-input" type="text" name="provider_configuration" placeholder="{&quot;K1&quot;:&quot;V1&quot;,&quot;K2&quot;:&quot;V2&quot;}">
         </div>
       </div>
-      <% end %>
       <div class="modal-footer">
         <button class="btn btn-secondary" type="button" phx-click="hide_modal">Close</button>
         <button class="btn btn-primary" type="submit">Submit</button>

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_provider_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_provider_component.ex
@@ -72,18 +72,36 @@ defmodule StartProviderComponent do
                %{}
              ) do
           {:ok, auction_host_id} ->
-            start_provider(provider_ociref, provider_link_name, auction_host_id, socket, provider_configuration)
+            start_provider(
+              provider_ociref,
+              provider_link_name,
+              auction_host_id,
+              socket,
+              provider_configuration
+            )
 
           {:error, error} ->
             {:noreply, assign(socket, error_msg: error)}
         end
 
       host_id ->
-        start_provider(provider_ociref, provider_link_name, host_id, socket, provider_configuration)
+        start_provider(
+          provider_ociref,
+          provider_link_name,
+          host_id,
+          socket,
+          provider_configuration
+        )
     end
   end
 
-  defp start_provider(provider_ociref, provider_link_name, host_id, socket, provider_configuration \\ "") do
+  defp start_provider(
+         provider_ociref,
+         provider_link_name,
+         host_id,
+         socket,
+         provider_configuration \\ ""
+       ) do
     case ControlInterface.start_provider(
            provider_ociref,
            provider_link_name,


### PR DESCRIPTION
Some providers may need configuration to start, so we can input the configuration in UI, and pass the configuration to host_core.

<img width="1338" alt="image" src="https://user-images.githubusercontent.com/9459488/202387108-f6f8382e-90a0-487f-b012-5eb9137086c5.png">
