### PR TITLE
fix(bindle): Makes bindle verification a little less strict

### DIFF
--- a/host_core/native/hostcore_wasmcloud_native/src/inv.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/inv.rs
@@ -21,7 +21,7 @@ pub(crate) const SYSTEM_ACTOR: &str = "system";
 pub(crate) const OP_HALT: &str = "__halt";
 
 /// An immutable representation of an invocation within wasmcloud
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[doc(hidden)]
 pub struct Invocation {
     pub origin: WasmCloudEntity,
@@ -234,7 +234,7 @@ impl WasmCloudEntity {
 /// A link definition is the description of a connection between an actor
 /// and a capability provider, along with the set of configuration values
 /// that belong to that connection
-#[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Default, Clone)]
 pub struct LinkDefinition {
     pub actor_id: String,
     pub provider_id: String,
@@ -243,7 +243,7 @@ pub struct LinkDefinition {
     pub values: std::collections::HashMap<String, String>,
 }
 
-#[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Default, Clone)]
 pub struct LinkDefinitionList {
     pub link_definitions: Vec<LinkDefinition>,
 }
@@ -255,14 +255,14 @@ pub struct ClaimsList {
 }
 
 /// A mapping of an alias (OCI or call alias) to a target entity
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
 pub struct ReferenceMap {
     pub kind: ReferenceType,
     pub target: WasmCloudEntity,
 }
 
 /// Indicates the type of reference map (alias)
-#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Serialize, Clone)]
 pub enum ReferenceType {
     Oci(String),
     CallAlias(String),

--- a/host_core/native/hostcore_wasmcloud_native/src/lib.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/lib.rs
@@ -486,7 +486,7 @@ fn dechunk_inv(inv_id: String) -> Result<(Atom, Vec<u8>), Error> {
 
 #[rustler::nif(schedule = "DirtyIo")]
 fn chunk_inv(inv_id: String, data: Binary) -> Result<Atom, Error> {
-    let _ = objstore::chonk_to_object_store(&inv_id, &mut data.as_slice())?;
+    objstore::chonk_to_object_store(&inv_id, &mut data.as_slice())?;
 
     Ok(atoms::ok())
 }

--- a/host_core/native/hostcore_wasmcloud_native/src/objstore.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/objstore.rs
@@ -26,7 +26,7 @@ pub(crate) fn unchonk_from_object_store(id: &str) -> Result<Vec<u8>, Error> {
             .map_err(to_rustler_err)?
             .read_to_end(&mut result)
             .map_err(to_rustler_err)?;
-        let _ = store.delete(id).map_err(to_rustler_err)?;
+        store.delete(id).map_err(to_rustler_err)?;
     }
 
     Ok(result)


### PR DESCRIPTION
We were trying to validate the creator signature as well by default. To keep it simple and transparent to users for now, I made it so we only validate the host signature. In the future we probably want to support a configurable value for the validation strategy