### PR TITLE
Host_config.json double write fix and customization

### DIFF
--- a/host_core/lib/host_core/vhost/config_plan.ex
+++ b/host_core/lib/host_core/vhost/config_plan.ex
@@ -26,6 +26,7 @@ defmodule HostCore.Vhost.ConfigPlan do
       # so we don't specify them here
       %Env{
         bindings: [
+          {:host_config, "HOST_CONFIG", required: false},
           {:lattice_prefix, @prefix_var, required: false},
           {:host_seed, "WASMCLOUD_HOST_SEED", required: false},
           {:rpc_host, "WASMCLOUD_RPC_HOST", required: false},
@@ -73,6 +74,7 @@ defmodule HostCore.Vhost.ConfigPlan do
 
   defp json_bindings() do
     [
+      {:host_config, "host_config", required: false, default: nil},
       {:lattice_prefix, "lattice_prefix", required: false, default: @default_prefix},
       {:host_seed, "host_seed", required: false, default: nil},
       {:rpc_host, "rpc_host", required: false, default: "127.0.0.1"},


### PR DESCRIPTION
Closes #480 

This PR removes the double write_json for the host_config.json file and adds a `HOST_CONFIG` env variable, so that it is possible to customize the configuration file to use. 

It adds `:host_config` bindings in config_plan.ex and a nil check in `post_process_config` in case the var was not given, in which case it defaults to `~/.wash/host_config.json`.