### PR TITLE
Credo warnings for host_core/test files 

### DIFF
--- a/host_core/test/host_core/policy_test.exs
+++ b/host_core/test/host_core/policy_test.exs
@@ -5,6 +5,10 @@ defmodule HostCore.PolicyTest do
 
   use ExUnit.Case, async: false
 
+  alias HostCore.Actors.ActorSupervisor
+  alias HostCore.Providers.ProviderSupervisor
+  alias HostCore.Vhost.VirtualHost
+
   import Mock
   import HostCoreTest.Common, only: [sudo_make_me_a_host: 1, cleanup: 2]
 
@@ -20,7 +24,7 @@ defmodule HostCore.PolicyTest do
   setup_all do
     lattice_prefix = "policyhome"
     {:ok, pid} = sudo_make_me_a_host(lattice_prefix)
-    config = HostCore.Vhost.VirtualHost.config(pid)
+    config = VirtualHost.config(pid)
 
     HostCore.Linkdefs.Manager.put_link_definition(
       lattice_prefix,
@@ -34,10 +38,10 @@ defmodule HostCore.PolicyTest do
     )
 
     {:ok, bytes} = File.read(@policy_path)
-    {:ok, _pid} = HostCore.Actors.ActorSupervisor.start_actor(bytes, config.host_key)
+    {:ok, _pid} = ActorSupervisor.start_actor(bytes, config.host_key)
 
     {:ok, _pid} =
-      HostCore.Providers.ProviderSupervisor.start_provider_from_oci(
+      ProviderSupervisor.start_provider_from_oci(
         config.host_key,
         @nats_ociref,
         "default"
@@ -50,7 +54,7 @@ defmodule HostCore.PolicyTest do
 
   setup do
     {:ok, test_pid} = sudo_make_me_a_host(UUID.uuid4())
-    test_config = HostCore.Vhost.VirtualHost.config(test_pid)
+    test_config = VirtualHost.config(test_pid)
     [hconfig: test_config, host_pid: test_pid]
   end
 
@@ -61,7 +65,7 @@ defmodule HostCore.PolicyTest do
     capabilities: [],
     issuer: "ADT2YUKCRQUGXXM73BBWVI33E4QLQX2LWRCMSC3ZUSCVKBZ6KQMJNU3L",
     issuedOn: "September 21",
-    expiresAt: DateTime.utc_now() |> DateTime.add(60),
+    expiresAt: DateTime.add(DateTime.utc_now(), 60),
     expired: false
   }
 
@@ -144,7 +148,7 @@ defmodule HostCore.PolicyTest do
     invalid_source =
       HostCore.Policy.Manager.evaluate_action(
         config,
-        @source_provider |> Map.delete(:publicKey),
+        Map.delete(@source_provider, :publicKey),
         @target_actor,
         @perform_invocation
       )
@@ -159,7 +163,7 @@ defmodule HostCore.PolicyTest do
       HostCore.Policy.Manager.evaluate_action(
         config,
         @source_provider,
-        @target_actor |> Map.delete(:issuer),
+        Map.delete(@target_actor, :issuer),
         @perform_invocation
       )
 
@@ -227,29 +231,31 @@ defmodule HostCore.PolicyTest do
   #   )
 
   #   {:error,
-  #    "Starting actor MB2ZQB6ROOMAYBO4ZCTFYWN7YIVBWA3MTKZYAQKJMTIHE2ELLRW2E3ZW denied: Issuer was not the official wasmCloud issuer"} =
-  #     HostCore.Actors.ActorSupervisor.start_actor_from_oci(
+  #    "Starting actor MB2ZQB6ROOMAYBO4ZCTFYWN7YIVBWA3MTKZYAQKJMTIHE2ELLRW2E3ZW denied: "
+  #   <> "Issuer was not the official wasmCloud issuer"} =
+  #     ActorSupervisor.start_actor_from_oci(
   #       config.host_key,
   #       "ghcr.io/brooksmtownsend/wadice:0.1.0"
   #     )
 
   #   {:error,
-  #    "Starting provider VAHMIAAVLEZLKHF4CZJVBVBGGZTWGUUKBCH3MABLNMPPUPA6CJ2HSJCT denied: Issuer was not the official wasmCloud issuer"} =
-  #     HostCore.Providers.ProviderSupervisor.start_provider_from_oci(
+  #    "Starting provider VAHMIAAVLEZLKHF4CZJVBVBGGZTWGUUKBCH3MABLNMPPUPA6CJ2HSJCT denied: "
+  #     <> "Issuer was not the official wasmCloud issuer"} =
+  #     ProviderSupervisor.start_provider_from_oci(
   #       config.host_key,
   #       "ghcr.io/brooksmtownsend/factorial:0.1.0",
   #       "default"
   #     )
 
   #   # Ensure the host doesn't start the actor that's denied
-  #   assert !(HostCore.Actors.ActorSupervisor.all_actors(config.host_key)
+  #   assert !(ActorSupervisor.all_actors(config.host_key)
   #            |> Map.keys()
   #            |> Enum.any?(fn public_key ->
   #              public_key == "MB2ZQB6ROOMAYBO4ZCTFYWN7YIVBWA3MTKZYAQKJMTIHE2ELLRW2E3ZW"
   #            end))
 
   #   # Ensure the host doesn't start the provider that's denied
-  #   assert !(HostCore.Providers.ProviderSupervisor.all_providers(config.host_key)
+  #   assert !(ProviderSupervisor.all_providers(config.host_key)
   #            |> Enum.any?(fn {_, public_key, _, _, _} ->
   #              public_key == "VAHMIAAVLEZLKHF4CZJVBVBGGZTWGUUKBCH3MABLNMPPUPA6CJ2HSJCT"
   #            end))

--- a/host_core/test/host_core/private_registry_test.exs
+++ b/host_core/test/host_core/private_registry_test.exs
@@ -1,6 +1,8 @@
 defmodule HostCore.PrivateRegistryTest do
   use ExUnit.Case, async: false
 
+  alias HostCore.Vhost.VirtualHost
+
   import HostCoreTest.Common, only: [cleanup: 2, standard_setup: 1]
 
   setup :standard_setup
@@ -41,24 +43,24 @@ defmodule HostCore.PrivateRegistryTest do
   test "all creds are nil when no creds have been set", %{:hconfig => config, :host_pid => pid} do
     on_exit(fn -> cleanup(pid, config) end)
 
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, "foobar") == nil
+    assert VirtualHost.get_creds(config.host_key, :oci, "foobar") == nil
   end
 
   test "malformed credentials are ignored", %{:hconfig => config, :host_pid => pid} do
     on_exit(fn -> cleanup(pid, config) end)
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @bad_credsmap)
+    VirtualHost.set_credsmap(pid, @bad_credsmap)
 
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
+    assert VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
              nil
   end
 
   test "credentials without a type are ignored", %{:hconfig => config, :host_pid => pid} do
     on_exit(fn -> cleanup(pid, config) end)
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @missing_type_credsmap)
+    VirtualHost.set_credsmap(pid, @missing_type_credsmap)
 
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
+    assert VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
              nil
   end
 
@@ -68,34 +70,34 @@ defmodule HostCore.PrivateRegistryTest do
   } do
     on_exit(fn -> cleanup(pid, config) end)
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @missing_username_credsmap)
+    VirtualHost.set_credsmap(pid, @missing_username_credsmap)
 
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
+    assert VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
              nil
   end
 
   test "credentials can be looked up by server name", %{:hconfig => config, :host_pid => pid} do
     on_exit(fn -> cleanup(pid, config) end)
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @simple_credsmap)
+    VirtualHost.set_credsmap(pid, @simple_credsmap)
 
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
+    assert VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
              @simple_credentials
   end
 
   test "credentials for unknown servers return nil", %{:hconfig => config, :host_pid => pid} do
     on_exit(fn -> cleanup(pid, config) end)
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @simple_credsmap)
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, "foobar") == nil
+    VirtualHost.set_credsmap(pid, @simple_credsmap)
+    assert VirtualHost.get_creds(config.host_key, :oci, "foobar") == nil
   end
 
   test "credentials are segmented by registry type", %{:hconfig => config, :host_pid => pid} do
     on_exit(fn -> cleanup(pid, config) end)
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @simple_credsmap)
+    VirtualHost.set_credsmap(pid, @simple_credsmap)
 
-    assert HostCore.Vhost.VirtualHost.get_creds(
+    assert VirtualHost.get_creds(
              config.host_key,
              :bindle,
              @private_oci_registry_url
@@ -108,17 +110,15 @@ defmodule HostCore.PrivateRegistryTest do
     schemes = ["bindle", "oci", "http", "https"]
 
     creds_map =
-      schemes
-      |> Enum.reduce(%{}, fn scheme, acc ->
-        serverUrl = scheme <> "://" <> scheme <> "-server"
-        Map.put(acc, serverUrl, @simple_credentials)
+      Enum.reduce(schemes, %{}, fn scheme, acc ->
+        server_url = scheme <> "://" <> scheme <> "-server"
+        Map.put(acc, server_url, @simple_credentials)
       end)
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, creds_map)
+    VirtualHost.set_credsmap(pid, creds_map)
 
-    schemes
-    |> Enum.each(fn scheme ->
-      assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, scheme <> "-server") ==
+    Enum.each(schemes, fn scheme ->
+      assert VirtualHost.get_creds(config.host_key, :oci, scheme <> "-server") ==
                @simple_credentials
     end)
   end
@@ -126,71 +126,71 @@ defmodule HostCore.PrivateRegistryTest do
   test "credentials can be looked up by OCI ref", %{:hconfig => config, :host_pid => pid} do
     on_exit(fn -> cleanup(pid, config) end)
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @simple_credsmap)
+    VirtualHost.set_credsmap(pid, @simple_credsmap)
     oci_ref = @private_oci_registry_url <> "/echo:0.3.5"
 
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, oci_ref) ==
+    assert VirtualHost.get_creds(config.host_key, :oci, oci_ref) ==
              @simple_credentials
   end
 
   test "credentials can be looked up by bindle URI", %{:hconfig => config, :host_pid => pid} do
     on_exit(fn -> cleanup(pid, config) end)
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @bindle_credsmap)
+    VirtualHost.set_credsmap(pid, @bindle_credsmap)
     bindle_id = "mybindle@" <> @private_bindle_registry_url
 
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :bindle, bindle_id) ==
+    assert VirtualHost.get_creds(config.host_key, :bindle, bindle_id) ==
              @bindle_credentials
   end
 
   test "setting credentials is idempotent", %{:hconfig => config, :host_pid => pid} do
     on_exit(fn -> cleanup(pid, config) end)
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @simple_credsmap)
+    VirtualHost.set_credsmap(pid, @simple_credsmap)
 
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
+    assert VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
              @simple_credentials
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @simple_credsmap)
+    VirtualHost.set_credsmap(pid, @simple_credsmap)
 
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
+    assert VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
              @simple_credentials
   end
 
   test "credentials can be updated", %{:hconfig => config, :host_pid => pid} do
     on_exit(fn -> cleanup(pid, config) end)
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @simple_credsmap)
+    VirtualHost.set_credsmap(pid, @simple_credsmap)
 
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
+    assert VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
              @simple_credentials
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @simple_credsmap_updated)
+    VirtualHost.set_credsmap(pid, @simple_credsmap_updated)
 
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
+    assert VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
              @simple_credentials_updated
   end
 
   test "updates for one server do not affect another", %{:hconfig => config, :host_pid => pid} do
     on_exit(fn -> cleanup(pid, config) end)
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @oci_and_bindle_credsmap)
+    VirtualHost.set_credsmap(pid, @oci_and_bindle_credsmap)
 
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
+    assert VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
              @simple_credentials
 
-    assert HostCore.Vhost.VirtualHost.get_creds(
+    assert VirtualHost.get_creds(
              config.host_key,
              :bindle,
              @private_bindle_registry_url
            ) == @bindle_credentials
 
-    HostCore.Vhost.VirtualHost.set_credsmap(pid, @simple_credsmap_updated)
+    VirtualHost.set_credsmap(pid, @simple_credsmap_updated)
 
-    assert HostCore.Vhost.VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
+    assert VirtualHost.get_creds(config.host_key, :oci, @private_oci_registry_url) ==
              @simple_credentials_updated
 
-    assert HostCore.Vhost.VirtualHost.get_creds(
+    assert VirtualHost.get_creds(
              config.host_key,
              :bindle,
              @private_bindle_registry_url

--- a/host_core/test/host_core/providers_test.exs
+++ b/host_core/test/host_core/providers_test.exs
@@ -1,6 +1,10 @@
 defmodule HostCore.ProvidersTest do
   use ExUnit.Case, async: false
 
+  alias HostCore.Providers.ProviderModule
+  alias HostCore.Providers.ProviderSupervisor
+  alias HostCore.WasmCloud.Native
+
   import HostCoreTest.Common, only: [cleanup: 2, standard_setup: 1]
 
   setup :standard_setup
@@ -19,7 +23,7 @@ defmodule HostCore.ProvidersTest do
     on_exit(fn -> cleanup(pid, config) end)
 
     {:ok, _pid} =
-      HostCore.Providers.ProviderSupervisor.start_provider_from_file(
+      ProviderSupervisor.start_provider_from_file(
         config.host_key,
         @httpserver_path,
         @httpserver_link,
@@ -28,7 +32,7 @@ defmodule HostCore.ProvidersTest do
         }
       )
 
-    {:ok, par} = HostCore.WasmCloud.Native.par_from_path(@httpserver_path, @httpserver_link)
+    {:ok, par} = Native.par_from_path(@httpserver_path, @httpserver_link)
     httpserver_key = par.claims.public_key
     httpserver_contract = par.contract_id
 
@@ -40,15 +44,15 @@ defmodule HostCore.ProvidersTest do
         httpserver_key
       )
 
-    provs = HostCore.Providers.ProviderSupervisor.all_providers(config.host_key)
+    provs = ProviderSupervisor.all_providers(config.host_key)
 
     assert elem(Enum.at(provs, 0), 1) ==
              httpserver_key
 
-    annotations = elem(Enum.at(provs, 0), 0) |> HostCore.Providers.ProviderModule.annotations()
+    annotations = Enum.at(provs, 0) |> elem(0) |> ProviderModule.annotations()
     assert annotations == %{"is_testing" => "youbetcha"}
 
-    HostCore.Providers.ProviderSupervisor.terminate_provider(
+    ProviderSupervisor.terminate_provider(
       config.host_key,
       httpserver_key,
       @httpserver_link
@@ -61,11 +65,11 @@ defmodule HostCore.ProvidersTest do
         httpserver_key
       )
 
-    if HostCore.Providers.ProviderSupervisor.all_providers(config.host_key) != [] do
+    if ProviderSupervisor.all_providers(config.host_key) != [] do
       :timer.sleep(1000)
     end
 
-    assert HostCore.Providers.ProviderSupervisor.all_providers(config.host_key) == []
+    assert ProviderSupervisor.all_providers(config.host_key) == []
   end
 
   test "can load provider from OCI", %{
@@ -76,7 +80,7 @@ defmodule HostCore.ProvidersTest do
     on_exit(fn -> cleanup(pid, config) end)
 
     {:ok, _pid} =
-      HostCore.Providers.ProviderSupervisor.start_provider_from_oci(
+      ProviderSupervisor.start_provider_from_oci(
         config.host_key,
         @httpserver_oci,
         "default"
@@ -90,13 +94,13 @@ defmodule HostCore.ProvidersTest do
         @httpserver_key
       )
 
-    assert elem(
-             Enum.at(HostCore.Providers.ProviderSupervisor.all_providers(config.host_key), 0),
-             1
-           ) ==
+    assert config.host_key
+           |> ProviderSupervisor.all_providers()
+           |> Enum.at(0)
+           |> elem(1) ==
              @httpserver_key
 
-    HostCore.Providers.ProviderSupervisor.terminate_provider(
+    ProviderSupervisor.terminate_provider(
       config.host_key,
       @httpserver_key,
       @httpserver_link
@@ -109,11 +113,11 @@ defmodule HostCore.ProvidersTest do
         @httpserver_key
       )
 
-    if HostCore.Providers.ProviderSupervisor.all_providers(config.host_key) != [] do
+    if ProviderSupervisor.all_providers(config.host_key) != [] do
       :timer.sleep(1000)
     end
 
-    assert HostCore.Providers.ProviderSupervisor.all_providers(config.host_key) == []
+    assert ProviderSupervisor.all_providers(config.host_key) == []
   end
 
   test "prevents starting duplicate local providers", %{
@@ -124,13 +128,13 @@ defmodule HostCore.ProvidersTest do
     on_exit(fn -> cleanup(pid, config) end)
 
     {:ok, _pid} =
-      HostCore.Providers.ProviderSupervisor.start_provider_from_file(
+      ProviderSupervisor.start_provider_from_file(
         config.host_key,
         @httpserver_path,
         @httpserver_link
       )
 
-    {:ok, par} = HostCore.WasmCloud.Native.par_from_path(@httpserver_path, @httpserver_link)
+    {:ok, par} = Native.par_from_path(@httpserver_path, @httpserver_link)
     httpserver_key = par.claims.public_key
     httpserver_contract = par.contract_id
 
@@ -142,14 +146,14 @@ defmodule HostCore.ProvidersTest do
         httpserver_key
       )
 
-    assert elem(
-             Enum.at(HostCore.Providers.ProviderSupervisor.all_providers(config.host_key), 0),
-             1
-           ) ==
+    assert config.host_key
+           |> ProviderSupervisor.all_providers()
+           |> Enum.at(0)
+           |> elem(1) ==
              httpserver_key
 
     {:error, reason} =
-      HostCore.Providers.ProviderSupervisor.start_provider_from_file(
+      ProviderSupervisor.start_provider_from_file(
         config.host_key,
         @httpserver_path,
         @httpserver_link
@@ -158,21 +162,16 @@ defmodule HostCore.ProvidersTest do
     assert reason == "Provider is already running on this host"
 
     provider_started_evts =
-      HostCoreTest.EventWatcher.events_for_type(
-        evt_watcher,
-        "com.wasmcloud.lattice.provider_started"
-      )
+      evt_watcher
+      |> HostCoreTest.EventWatcher.events_for_type("com.wasmcloud.lattice.provider_started")
       |> Enum.count()
 
     assert provider_started_evts == 1
 
-    assert elem(
-             Enum.at(HostCore.Providers.ProviderSupervisor.all_providers(config.host_key), 0),
-             1
-           ) ==
+    assert config.host_key |> ProviderSupervisor.all_providers() |> Enum.at(0) |> elem(1) ==
              httpserver_key
 
-    HostCore.Providers.ProviderSupervisor.terminate_provider(
+    ProviderSupervisor.terminate_provider(
       config.host_key,
       httpserver_key,
       @httpserver_link
@@ -185,10 +184,10 @@ defmodule HostCore.ProvidersTest do
         httpserver_key
       )
 
-    if HostCore.Providers.ProviderSupervisor.all_providers(config.host_key) != [] do
+    if ProviderSupervisor.all_providers(config.host_key) != [] do
       :timer.sleep(1000)
     end
 
-    assert HostCore.Providers.ProviderSupervisor.all_providers(config.host_key) == []
+    assert ProviderSupervisor.all_providers(config.host_key) == []
   end
 end

--- a/host_core/test/support/common.exs
+++ b/host_core/test/support/common.exs
@@ -1,6 +1,17 @@
 defmodule HostCoreTest.Common do
   require Logger
 
+  alias HostCore.Actors.ActorSupervisor
+  alias HostCore.Vhost.VirtualHost
+  alias HostCore.WasmCloud.Native
+
+  def actor_count(host_key, counter_key) do
+    host_key
+    |> ActorSupervisor.all_actors()
+    |> Map.get(counter_key)
+    |> length
+  end
+
   def request_http(url, retries) when retries > 0 do
     case HTTPoison.get(url) do
       {:ok, resp} ->
@@ -23,7 +34,7 @@ defmodule HostCoreTest.Common do
     config = default_vhost_config()
     config = %{config | lattice_prefix: lattice_id}
 
-    HostCore.Vhost.VirtualHost.start_link(config)
+    VirtualHost.start_link(config)
   end
 
   def standard_setup(_context) do
@@ -35,16 +46,17 @@ defmodule HostCoreTest.Common do
     [
       evt_watcher: evt_watcher,
       host_pid: host_pid,
-      hconfig: HostCore.Vhost.VirtualHost.config(host_pid)
+      hconfig: VirtualHost.config(host_pid)
     ]
   end
 
   def cleanup(pid, config) do
-    HostCore.Vhost.VirtualHost.stop(pid, 300)
+    VirtualHost.stop(pid, 300)
     purge_topic = "$JS.API.STREAM.DELETE.LATTICECACHE_#{config.lattice_prefix}"
 
-    case HostCore.Nats.safe_req(
-           HostCore.Nats.control_connection(config.lattice_prefix),
+    case config.lattice_prefix
+         |> HostCore.Nats.control_connection()
+         |> HostCore.Nats.safe_req(
            purge_topic,
            []
          ) do
@@ -56,9 +68,9 @@ defmodule HostCoreTest.Common do
     end
   end
 
-  def default_vhost_config() do
-    {pk, seed} = HostCore.WasmCloud.Native.generate_key(:server)
-    {ck, cseed} = HostCore.WasmCloud.Native.generate_key(:cluster)
+  def default_vhost_config do
+    {pk, seed} = Native.generate_key(:server)
+    {ck, cseed} = Native.generate_key(:cluster)
 
     s =
       Hashids.new(

--- a/host_core/test/support/event_watcher.exs
+++ b/host_core/test/support/event_watcher.exs
@@ -105,7 +105,8 @@ defmodule HostCoreTest.EventWatcher do
   # Returns all events for a given event type, e.g.
   # `events_for_type(pid, "com.wasmcloud.lattice.actor_stopped")`
   def events_for_type(pid, type) do
-    GenServer.call(pid, :events)
+    pid
+    |> GenServer.call(:events)
     |> Enum.filter(fn evt -> evt["type"] == type end)
   end
 


### PR DESCRIPTION
Another PR for more credo warnings. I focused the changes on the host_core/test files, using the command mix credo --strict "test/**/*ex" from the host_core folder.

I left out 1 TODO warning to not remove that comment. This PR removes a good chunk of the alias/nested modules readability warnings.
