### PR TITLE
More credo warnings cleaning for host_core

### DIFF
--- a/host_core/lib/host_core/lattice/lattice_supervisor.ex
+++ b/host_core/lib/host_core/lattice/lattice_supervisor.ex
@@ -7,16 +7,16 @@ defmodule HostCore.Lattice.LatticeSupervisor do
 
   use Supervisor
 
+  alias HostCore.Lattice.LatticeRoot
   require Logger
 
   @spec start_link(HostCore.Vhost.Configuration.t()) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(config) do
-    Supervisor.start_link(__MODULE__, config,
-      name: HostCore.Lattice.LatticeRoot.via_tuple(config.lattice_prefix)
-    )
+    Supervisor.start_link(__MODULE__, config, name: LatticeRoot.via_tuple(config.lattice_prefix))
   end
 
-  # Uses the same strongly typed host configuration as other supervisors in the hierarchy (though it only cares about the lattice info)
+  # Uses the same strongly typed host configuration as other supervisors in the hierarchy
+  # (though it only cares about the lattice info)
   @impl true
   def init(config) do
     Logger.metadata(lattice_prefix: config.lattice_prefix)

--- a/host_core/lib/host_core/providers/builtin/numbergen.ex
+++ b/host_core/lib/host_core/providers/builtin/numbergen.ex
@@ -1,6 +1,12 @@
 defmodule HostCore.Providers.Builtin.Numbergen do
+  @moduledoc """
+  A provider that generates random numbers and GUIDs.
+  """
+
   def invoke("NumberGen.GenerateGuid", _payload) do
-    IO.iodata_to_binary(Msgpax.pack!(UUID.uuid4()))
+    UUID.uuid4()
+    |> Msgpax.pack!()
+    |> IO.iodata_to_binary()
   end
 
   def invoke("NumberGen.RandomInRange", payload) do
@@ -8,10 +14,15 @@ defmodule HostCore.Providers.Builtin.Numbergen do
 
     min = max(params["min"], 0)
     max = min(params["max"], 4_294_967_295)
-    IO.iodata_to_binary(Msgpax.pack!(Enum.random(min..max)))
+
+    Enum.random(min..max)
+    |> Msgpax.pack!()
+    |> IO.iodata_to_binary()
   end
 
   def invoke("NumberGen.Random32", _payload) do
-    IO.iodata_to_binary(Msgpax.pack!(Enum.random(0..4_294_967_295)))
+    Enum.random(0..4_294_967_295)
+    |> Msgpax.pack!()
+    |> IO.iodata_to_binary()
   end
 end

--- a/host_core/lib/host_core/vhost/config_plan.ex
+++ b/host_core/lib/host_core/vhost/config_plan.ex
@@ -8,8 +8,8 @@ defmodule HostCore.Vhost.ConfigPlan do
   """
   @behaviour Vapor.Plan
 
-  alias Vapor.Provider.{Dotenv, Env}
   alias HostCore.Vhost.FilesConfigProvider
+  alias Vapor.Provider.{Dotenv, Env}
 
   @prefix_var "WASMCLOUD_LATTICE_PREFIX"
   @default_prefix "default"
@@ -72,7 +72,7 @@ defmodule HostCore.Vhost.ConfigPlan do
     ]
   end
 
-  defp json_bindings() do
+  defp json_bindings do
     [
       {:host_config, "host_config", required: false, default: nil},
       {:lattice_prefix, "lattice_prefix", required: false, default: @default_prefix},

--- a/host_core/lib/host_core/vhost/files_config_provider.ex
+++ b/host_core/lib/host_core/vhost/files_config_provider.ex
@@ -1,4 +1,9 @@
 defmodule HostCore.Vhost.FilesConfigProvider do
+  @moduledoc """
+  A configuration provider that loads configuration from a file.
+  The file is expected to be either in json, toml or yml/yaml format.
+  """
+
   defstruct paths: [], bindings: []
 
   defimpl Vapor.Provider do

--- a/host_core/lib/host_core/vhost/heartbeats.ex
+++ b/host_core/lib/host_core/vhost/heartbeats.ex
@@ -3,18 +3,24 @@ defmodule HostCore.Vhost.Heartbeats do
   Responsible for the generation of heartbeats. Note that publication of heartbeats is done by the
   virtual host from which the heartbeat eminates.
   """
+
+  alias HostCore.Actors.ActorSupervisor
   alias HostCore.CloudEvent
+  alias HostCore.Providers.ProviderSupervisor
+  alias Timex.Format.Duration.Formatters.Humanized
 
   def generate_heartbeat(state) do
     config = state.config
     # TODO: for large numbers of actors this heartbeat becomes prohibitively large and expensive
     # refactor to only emit instance count
     actors =
-      HostCore.Actors.ActorSupervisor.all_actors_for_hb(config.host_key)
+      config.host_key
+      |> ActorSupervisor.all_actors_for_hb()
       |> Enum.map(fn {k, iid} -> %{public_key: k, instance_id: iid} end)
 
     providers =
-      HostCore.Providers.ProviderSupervisor.all_providers(config.host_key)
+      config.host_key
+      |> ProviderSupervisor.all_providers()
       |> Enum.map(fn {_pid, pk, link, contract, instance_id} ->
         %{public_key: pk, link_name: link, contract_id: contract, instance_id: instance_id}
       end)
@@ -25,17 +31,20 @@ defmodule HostCore.Vhost.Heartbeats do
     ut_human =
       ut_seconds
       |> Timex.Duration.from_seconds()
-      |> Timex.Format.Duration.Formatters.Humanized.format()
+      |> Humanized.format()
 
-    %{
-      actors: actors,
-      providers: providers,
-      labels: state.labels,
-      friendly_name: state.friendly_name,
-      version: Application.spec(:host_core, :vsn) |> to_string(),
-      uptime_seconds: ut_seconds,
-      uptime_human: ut_human
-    }
-    |> CloudEvent.new("host_heartbeat", config.host_key)
+    CloudEvent.new(
+      %{
+        actors: actors,
+        providers: providers,
+        labels: state.labels,
+        friendly_name: state.friendly_name,
+        version: :host_core |> Application.spec(:vsn) |> to_string(),
+        uptime_seconds: ut_seconds,
+        uptime_human: ut_human
+      },
+      "host_heartbeat",
+      config.host_key
+    )
   end
 end

--- a/host_core/lib/host_core/wasmcloud/native.ex
+++ b/host_core/lib/host_core/wasmcloud/native.ex
@@ -2,6 +2,8 @@ defmodule HostCore.WasmCloud.Native do
   @moduledoc false
   use Rustler, otp_app: :host_core, crate: :hostcore_wasmcloud_native
 
+  alias HostCore.WasmCloud.Native
+
   def extract_claims(_bytes), do: error()
   def generate_key(_keytype), do: error()
 
@@ -28,7 +30,7 @@ defmodule HostCore.WasmCloud.Native do
   def get_oci_path(_creds, _path, _allow_latest, _allowed_insecure), do: error()
   def par_from_path(_path, _link_name), do: error()
   def par_cache_path(_subject, _rev, _contract_id, _link_name), do: error()
-  def detect_core_host_labels(), do: error()
+  def detect_core_host_labels, do: error()
   def get_actor_bindle(_creds, _bindle_id), do: error()
   def get_provider_bindle(_creds, _bindle_id, _link_name), do: error()
 
@@ -38,6 +40,6 @@ defmodule HostCore.WasmCloud.Native do
 
   defmodule ProviderArchive do
     @moduledoc false
-    def from_path(path, link_name), do: HostCore.WasmCloud.Native.par_from_path(path, link_name)
+    def from_path(path, link_name), do: Native.par_from_path(path, link_name)
   end
 end


### PR DESCRIPTION
This PR tackles the warnings mainly in the folders `lib/control_interface`, `lib/lattice`, `lib/vhost` and `lib/providers`.

I left out the TODO warnings and some Refactoring warnings about the arity of some functions (over 8 args) to not change too much the code. Now the warnings in host_core are reduced to 13 design suggestions (TODO and aliases), 26 code readability issues  and 5 refactoring opportunities.
