### PR TITLE
fix double host stop event 

### DIFF
--- a/host_core/lib/host_core/vhost/virtual_host.ex
+++ b/host_core/lib/host_core/vhost/virtual_host.ex
@@ -419,9 +419,6 @@ defmodule HostCore.Vhost.VirtualHost do
   def handle_cast({:do_stop, _timeout_ms}, state) do
     Logger.debug("Host stop requested manually")
 
-    do_purge(state)
-    publish_host_stopped(state)
-
     if HostCore.Application.host_count() == 1 do
       # Give a little bit of time for the event to get sent before shutting down
       :timer.sleep(300)


### PR DESCRIPTION
This PR fixes #469 

The virtual_host.ex `handle_cast(:do_stop, _timeout_ms}, state)` function invokes `do_purge` and `publish_host_stopped`, then it returns the tuple `{:stop, :shutdown, state}`  triggering the `terminate\2` function.

In `terminate` those two functions are invoked again resulting in a double `host_stopped` event and a double purging of the processes (visible in the logs).

It should be enough not calling those functions immediately in the handle cast but letting `terminate` handle it.