### PR TITLE
Wasmcloud_host credo warnings

### DIFF
--- a/wasmcloud_host/lib/wasmcloud_host/application.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/application.ex
@@ -35,7 +35,7 @@ defmodule WasmcloudHost.Application do
 
   # returns {host public key, <pid>, lattice prefix}
   @spec first_host() :: {String.t(), pid(), String.t()}
-  def first_host() do
+  def first_host do
     HostCore.Application.all_hosts()
     |> List.first()
   end

--- a/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
@@ -1,5 +1,7 @@
 defmodule WasmcloudHost.Lattice.StateMonitor do
   use GenServer, restart: :transient
+
+  alias HostCore.Vhost.VirtualHost
   alias Phoenix.PubSub
 
   require Logger
@@ -18,7 +20,7 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
   @impl true
   def init(_opts) do
     {pk, pid, prefix} = WasmcloudHost.Application.first_host()
-    labels = HostCore.Vhost.VirtualHost.labels(pid)
+    labels = VirtualHost.labels(pid)
 
     state = %State{
       lattice_prefix: prefix,
@@ -87,27 +89,27 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
     {:reply, state.refmaps, state}
   end
 
-  def get_hosts() do
+  def get_hosts do
     GenServer.call(:state_monitor, :hosts_query)
   end
 
-  def get_actors() do
+  def get_actors do
     GenServer.call(:state_monitor, :actor_query)
   end
 
-  def get_providers() do
+  def get_providers do
     GenServer.call(:state_monitor, :provider_query)
   end
 
-  def get_linkdefs() do
+  def get_linkdefs do
     GenServer.call(:state_monitor, :linkdef_query)
   end
 
-  def get_claims() do
+  def get_claims do
     GenServer.call(:state_monitor, :claims_query)
   end
 
-  def get_ocirefs() do
+  def get_ocirefs do
     GenServer.call(:state_monitor, :refmaps_query)
   end
 

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/link_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/link_row_component.ex
@@ -1,12 +1,14 @@
 defmodule LinkRowComponent do
   use Phoenix.LiveComponent
 
+  alias WasmcloudHost.Lattice.ControlInterface
+
   def handle_event(
         "delete_linkdef",
         %{"actor_id" => actor_id, "contract_id" => contract_id, "link_name" => link_name},
         socket
       ) do
-    WasmcloudHost.Lattice.ControlInterface.delete_linkdef(actor_id, contract_id, link_name)
+    ControlInterface.delete_linkdef(actor_id, contract_id, link_name)
     {:noreply, socket}
   end
 
@@ -66,8 +68,6 @@ defmodule LinkRowComponent do
   end
 
   defp str_values(value) do
-    value
-    |> Enum.map(fn {a, b} -> "#{a}=#{b}" end)
-    |> Enum.join(",")
+    Enum.map_join(value, ",", fn {a, b} -> "#{a}=#{b}" end)
   end
 end

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/provider_row_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/provider_row_component.ex
@@ -1,6 +1,8 @@
 defmodule ProviderRowComponent do
   use Phoenix.LiveComponent
 
+  alias WasmcloudHost.Lattice.ControlInterface
+
   def mount(socket) do
     {:ok, socket}
   end
@@ -10,7 +12,7 @@ defmodule ProviderRowComponent do
         %{"provider" => provider, "link_name" => link_name, "host_id" => host_id},
         socket
       ) do
-    WasmcloudHost.Lattice.ControlInterface.stop_provider(provider, link_name, host_id)
+    ControlInterface.stop_provider(provider, link_name, host_id)
     {:noreply, socket}
   end
 

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/scale_actor_component.ex
@@ -1,6 +1,8 @@
 defmodule ScaleActorComponent do
   use Phoenix.LiveComponent
 
+  alias WasmcloudHost.Lattice.ControlInterface
+
   def mount(socket) do
     {:ok,
      socket
@@ -21,7 +23,7 @@ defmodule ScaleActorComponent do
         },
         socket
       ) do
-    case WasmcloudHost.Lattice.ControlInterface.scale_actor(
+    case ControlInterface.scale_actor(
            actor_id,
            actor_ref,
            String.to_integer(count),

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_provider_component.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/components/start_provider_component.ex
@@ -1,5 +1,11 @@
 defmodule StartProviderComponent do
+  @moduledoc """
+  LiveComponent for starting a provider.
+  """
   use Phoenix.LiveComponent
+
+  alias HostCore.Providers.ProviderSupervisor
+  alias WasmcloudHost.Lattice.ControlInterface
 
   def mount(socket) do
     {:ok,
@@ -24,7 +30,7 @@ defmodule StartProviderComponent do
 
     error_msg =
       Phoenix.LiveView.consume_uploaded_entries(socket, :provider, fn %{path: path}, _entry ->
-        case HostCore.Providers.ProviderSupervisor.start_provider_from_file(
+        case ProviderSupervisor.start_provider_from_file(
                pk,
                path,
                provider_link_name
@@ -59,7 +65,7 @@ defmodule StartProviderComponent do
       ) do
     case host_id do
       "" ->
-        case WasmcloudHost.Lattice.ControlInterface.auction_provider(
+        case ControlInterface.auction_provider(
                provider_ociref,
                provider_link_name,
                %{}
@@ -77,7 +83,7 @@ defmodule StartProviderComponent do
   end
 
   defp start_provider(provider_ociref, provider_link_name, host_id, socket) do
-    case WasmcloudHost.Lattice.ControlInterface.start_provider(
+    case ControlInterface.start_provider(
            provider_ociref,
            provider_link_name,
            host_id

--- a/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/page_live.ex
@@ -1,5 +1,8 @@
 defmodule WasmcloudHostWeb.PageLive do
   use WasmcloudHostWeb, :live_view
+
+  alias WasmcloudHost.Lattice.StateMonitor
+
   require Logger
 
   @impl true
@@ -12,21 +15,21 @@ defmodule WasmcloudHostWeb.PageLive do
     {:ok,
      socket
      |> assign(
-       hosts: WasmcloudHost.Lattice.StateMonitor.get_hosts(),
-       linkdefs: WasmcloudHost.Lattice.StateMonitor.get_linkdefs(),
-       ocirefs: WasmcloudHost.Lattice.StateMonitor.get_ocirefs(),
-       claims: WasmcloudHost.Lattice.StateMonitor.get_claims(),
+       hosts: StateMonitor.get_hosts(),
+       linkdefs: StateMonitor.get_linkdefs(),
+       ocirefs: StateMonitor.get_ocirefs(),
+       claims: StateMonitor.get_claims(),
        open_modal: nil,
        selected_host: pk
      )}
   end
 
-  def first_host_key() do
+  def first_host_key do
     {pk, _pid, _prefix} = WasmcloudHost.Application.first_host()
     pk
   end
 
-  def first_host_prefix() do
+  def first_host_prefix do
     {_pk, _pid, prefix} = WasmcloudHost.Application.first_host()
     prefix
   end


### PR DESCRIPTION
This PR fixes the Software Design warnings except the TODOs, the Readability warnings except the module_tag missing (I can't give a proper description of all those modules, sorry) and the Refactoring opportunities. 

All the warnings left between host_core and wasmcloud_host are mainly the leftover TODOs, some Refactoring Opportunities and the module_tag descriptions.