### PR TITLE
Bumping wascap version to 0.9.1

### DIFF
--- a/host_core/native/hostcore_wasmcloud_native/Cargo.lock
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.lock
@@ -223,7 +223,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "cipher",
 ]
 
@@ -232,6 +232,12 @@ name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
+name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 
 [[package]]
 name = "byteorder"
@@ -416,7 +422,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
@@ -565,6 +571,19 @@ name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
@@ -745,7 +764,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
 ]
 
 [[package]]
@@ -842,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "hostcore_wasmcloud_native"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "bindle",
@@ -865,7 +884,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "uuid",
- "wascap",
+ "wascap 0.9.0",
 ]
 
 [[package]]
@@ -1079,6 +1098,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,7 +1216,7 @@ dependencies = [
  "log",
  "memchr",
  "nkeys",
- "nuid",
+ "nuid 0.3.2",
  "once_cell",
  "parking_lot 0.12.1",
  "regex",
@@ -1215,7 +1240,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e66a7cd1358277b2a6f77078e70aea7315ff2f20db969cc61153103ec162594"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "data-encoding",
  "ed25519-dalek",
  "getrandom 0.2.8",
@@ -1231,6 +1256,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20c1bb65186718d348306bf1afdeb20d9ab45b2ab80fb793c0fdcf59ffbb4f38"
 dependencies = [
  "lazy_static",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "nuid"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b61b1710432e483e6a67b20b6c60c6afe0e2fad67aabba3bdb912f3f70ff6ae"
+dependencies = [
+ "once_cell",
  "rand 0.8.5",
 ]
 
@@ -1507,7 +1542,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tar",
- "wascap",
+ "wascap 0.8.0",
 ]
 
 [[package]]
@@ -1734,7 +1769,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "num-traits",
  "paste",
 ]
@@ -1745,7 +1780,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
 dependencies = [
- "byteorder",
+ "byteorder 1.4.3",
  "rmp",
  "serde",
 ]
@@ -2519,17 +2554,40 @@ checksum = "32d1cfad67501627ac9344cbd89be80d2d5ebc98ef3b86862041cb26a280081f"
 dependencies = [
  "base64",
  "data-encoding",
- "env_logger",
+ "env_logger 0.8.4",
  "humantime",
  "lazy_static",
  "log",
  "nkeys",
- "nuid",
+ "nuid 0.3.2",
  "parity-wasm",
  "ring",
  "serde",
  "serde_derive",
  "serde_json",
+]
+
+[[package]]
+name = "wascap"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b982c061be50ef1fa43f43e3f022b3bdb7ed7b24f0bb3dcebde996a8687ea607"
+dependencies = [
+ "base64",
+ "data-encoding",
+ "env_logger 0.9.3",
+ "humantime",
+ "lazy_static",
+ "log",
+ "nkeys",
+ "nuid 0.4.1",
+ "ring",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-gen",
+ "wasmparser",
 ]
 
 [[package]]
@@ -2615,6 +2673,34 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9424cdab516a16d4ea03c8f4a01b14e7b2d04a129dcc2bcdde5bcc5f68f06c41"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-gen"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b854b1461005a7b3365742310f7faa3cac3add809d66928c64a40c7e9e842ebb"
+dependencies = [
+ "byteorder 0.5.3",
+ "leb128",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.94.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdac7e1d98d70913ae3b4923dd7419c8ea7bdfd4c44a240a0ba305d929b7f191"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "web-sys"

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.toml
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostcore_wasmcloud_native"
-version = "0.1.1"
+version = "0.1.2"
 authors = []
 edition = "2021"
 
@@ -15,7 +15,7 @@ lazy_static = "1.0"
 serde = {version = "1.0.126", features = ["derive"] }
 serde_bytes = "0.11.5"
 nkeys = "0.2.0"
-wascap = "0.8.0"
+wascap = "0.9.0"
 ring = "0.16.20"
 uuid = {version = "1.2.1", features = ["v4"]}
 data-encoding = "2.3.2"

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.toml
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.toml
@@ -15,7 +15,7 @@ lazy_static = "1.0"
 serde = {version = "1.0.126", features = ["derive"] }
 serde_bytes = "0.11.5"
 nkeys = "0.2.0"
-wascap = "0.9.0"
+wascap = "0.9.1"
 ring = "0.16.20"
 uuid = {version = "1.2.1", features = ["v4"]}
 data-encoding = "2.3.2"


### PR DESCRIPTION
This bumps to wascap 0.9.1, which is required to support newer webassembly modules (e.g. tinygo and WASI+) signed with newer wascaps.

I had some generics issues with name overlap that led me to have to copy and paste about 7 lines of code. I'm not too worried about the duplication, just irked by the fact that it was necessary to begin with.

If any of the reviewers can figure out how to get the same `impl From` to work the way it used to, that'd be helpful.
