### PR TITLE
override primary logger level when structured_log_level is set

### DIFF
--- a/host_core/lib/application.ex
+++ b/host_core/lib/application.ex
@@ -45,6 +45,11 @@ defmodule HostCore.Application do
     started = Supervisor.start_link(children, opts)
 
     if config.enable_structured_logging do
+      :logger.set_primary_config(
+        :logger.get_primary_config()
+        |> Map.put(:level, config.structured_log_level)
+      )
+
       :logger.add_handler(:structured_logger, :logger_std_h, %{
         formatter: {HostCore.StructuredLogger.FormatterJson, []},
         level: config.structured_log_level,


### PR DESCRIPTION
This fixes https://github.com/wasmCloud/wasmcloud-otp/issues/527

Credit to @brooksmtownsend for the idea of just using get + Map.put to override a single key

Signed-off-by: Connor Smith <connor@cosmonic.com>