### PR TITLE
move Registry.register calls to after module initialization

### DIFF
--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -215,16 +215,14 @@ defmodule HostCore.Providers.ProviderModule do
   end
 
   @impl true
-  def handle_continue(:register_provider, agent) do
-    agent_state = Agent.get(agent, fn contents -> contents end)
-
+  def handle_continue(:register_provider, state) do
     Registry.register(
       Registry.ProviderRegistry,
-      {agent_state.claims.public_key, agent_state.link_name},
-      agent_state.host_id
+      {state.public_key, state.link_name},
+      state.host_id
     )
 
-    {:noreply, agent}
+    {:noreply, state}
   end
 
   @propagated_env_vars ["OTEL_TRACES_EXPORTER", "OTEL_EXPORTER_OTLP_ENDPOINT"]


### PR DESCRIPTION
This is potentially a companion to https://github.com/wasmCloud/wasmcloud-otp/pull/530. Removing calls to get instance IDs might be desired anyway to reduce the size of heartbeat messages (in the case where many thousands of actors are running), but after talking with @brooksmtownsend, this seems to address the underlying issue, i.e. that we currently allow looking up a module from the registry before its `init` function has completed

To test, I ran this simple bash script:
```bash
while true; do
  wash ctl start actor ghcr.io/brooksmtownsend/wadice:0.2.0 --count 100 --skip-wait && wash ctl get hosts
done
```

On `main`, a host started via `make run` dies in ~10 seconds. With this change, the host stays up for many minutes (until eventually the host died because it was running so many actors the heartbeat payload got too big 🙂 )

Signed-off-by: Connor Smith <connor@cosmonic.com>