### PR TITLE
remove JS domain from LATTICEDATA stream filter subject

### DIFF
--- a/host_core/lib/host_core/jetstream/client.ex
+++ b/host_core/lib/host_core/jetstream/client.ex
@@ -243,7 +243,7 @@ defmodule HostCore.Jetstream.Client do
     do: "$KV.LATTICEDATA_#{lattice_prefix}.#{key}"
 
   defp kv_operation_topic(lattice_prefix, key, js_domain) when is_binary(js_domain),
-    do: "#{js_domain}.$KV.LATTICEDATA_#{lattice_prefix}.#{key}"
+    do: "$JS.#{js_domain}.API.$KV.LATTICEDATA_#{lattice_prefix}.#{key}"
 
   defp stream_delete_topic(stream_name, nil), do: "$JS.API.STREAM.DELETE.#{stream_name}"
 

--- a/host_core/lib/host_core/jetstream/client.ex
+++ b/host_core/lib/host_core/jetstream/client.ex
@@ -35,7 +35,7 @@ defmodule HostCore.Jetstream.Client do
     end
 
     create_topic = create_bucket_topic(state.lattice_prefix, state.domain)
-    stream_topic = kv_stream_topic(state.lattice_prefix, state.domain)
+    stream_topic = kv_stream_topic(state.lattice_prefix)
 
     payload_json =
       Jason.encode!(%{
@@ -232,10 +232,7 @@ defmodule HostCore.Jetstream.Client do
   defp create_bucket_topic(lattice_prefix, js_domain) when is_binary(js_domain),
     do: "$JS.#{js_domain}.API.STREAM.CREATE.KV_LATTICEDATA_#{lattice_prefix}"
 
-  defp kv_stream_topic(lattice_prefix, nil), do: "$KV.LATTICEDATA_#{lattice_prefix}.>"
-
-  defp kv_stream_topic(lattice_prefix, js_domain) when is_binary(js_domain),
-    do: "#{js_domain}.$KV.LATTICEDATA_#{lattice_prefix}.>"
+  defp kv_stream_topic(lattice_prefix), do: "$KV.LATTICEDATA_#{lattice_prefix}.>"
 
   defp create_consumer_topic(stream_name, nil), do: "$JS.API.CONSUMER.CREATE.#{stream_name}"
 


### PR DESCRIPTION
It appears that the current `subjects` filter on this bucket prevents clients from interacting with it. Interacting with a bucket created by a host on `main`:

```
nats stream info KV_LATTICEDATA_f5581cea-c19f-4380-9657-24456c2a917c  
Information for Stream KV_LATTICEDATA_f5581cea-c19f-4380-9657-24456c2a917c created 2023-01-18 17:30:22

             Subjects: foobar.$KV.LATTICEDATA_f5581cea-c19f-4380-9657-24456c2a917c.>
...

nats kv ls --js-domain foobar LATTICEDATA_f5581cea-c19f-4380-9657-24456c2a917c
nats: error: unable to fetch keys in bucket: nats: no stream matches subject
```

This can be manually fixed by editing the underlying stream's subjects:
```
nats stream edit -a KV_LATTICEDATA_f5581cea-c19f-4380-9657-24456c2a917c --subjects '$KV.LATTICEDATA_f5581cea-c19f-4380-9657-24456c2a917c.>'     
Differences (-old +new):
  api.StreamConfig{
  	Name:         "KV_LATTICEDATA_f5581cea-c19f-4380-9657-24456c2a917c",
  	Description:  "",
- 	Subjects:     []string(Inverse(Sort, []string{"foobar.$KV.LATTICEDATA_f5581cea-c19f-4380-9657-24456c2a917c.>"})),
+ 	Subjects:     []string(Inverse(Sort, []string{"$KV.LATTICEDATA_f5581cea-c19f-4380-9657-24456c2a917c.>"})),
  	Retention:    s"Limits",
  	MaxConsumers: -1,
  	... // 21 identical fields
  }
? Really edit Stream KV_LATTICEDATA_f5581cea-c19f-4380-9657-24456c2a917c Yes
```

After this change, a client can interact with the bucket:
```
nats kv ls --js-domain foobar LATTICEDATA_f5581cea-c19f-4380-9657-24456c2a917c        
No keys found in bucket
```

Signed-off-by: Connor Smith <connor.smith.256@gmail.com>