### PR TITLE
Supporting linkdefs in bucket without ids

### DIFF
--- a/host_core/lib/host_core/jetstream/client.ex
+++ b/host_core/lib/host_core/jetstream/client.ex
@@ -226,6 +226,27 @@ defmodule HostCore.Jetstream.Client do
     |> HostCore.Nats.safe_req(del_topic, <<>>)
   end
 
+  def ensure_linkdef_id(linkdef) do
+    if Map.has_key?(linkdef, :id) do
+      linkdef
+    else
+      Map.put(
+        linkdef,
+        :id,
+        linkdef_hash(linkdef.actor_id, linkdef.contract_id, linkdef.link_name)
+      )
+    end
+  end
+
+  def linkdef_hash(actor_id, contract_id, link_name) do
+    sha = :crypto.hash_init(:sha256)
+    sha = :crypto.hash_update(sha, actor_id)
+    sha = :crypto.hash_update(sha, contract_id)
+    sha = :crypto.hash_update(sha, link_name)
+    sha_binary = :crypto.hash_final(sha)
+    sha_binary |> Base.encode16() |> String.upcase()
+  end
+
   defp create_bucket_topic(lattice_prefix, nil),
     do: "$JS.API.STREAM.CREATE.KV_LATTICEDATA_#{lattice_prefix}"
 

--- a/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
+++ b/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
@@ -72,9 +72,8 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
   defp handle_action(:key_added, %{key: @linkdef_prefix <> _ldid, prefix: lattice_prefix}, body) do
     case Jason.decode(body, keys: :atoms) do
       {:ok, ld} ->
-        Logger.debug("Caching link definition from #{ld.actor_id} on contract #{ld.contract_id}")
-
         ld = ensure_linkdef_id(ld)
+        Logger.debug("Caching link definition from #{ld.actor_id} on contract #{ld.contract_id}")
 
         # This data came from the bucket, so we don't need to re-write it to the bucket, just:
         # * store it in memory

--- a/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
+++ b/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
@@ -8,6 +8,8 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
   alias HostCore.Refmaps.Manager, as: RefmapsManager
   alias Phoenix.PubSub
 
+  import HostCore.Jetstream.Client, only: [ensure_linkdef_id: 1]
+
   require Logger
   use Gnat.Server
 
@@ -71,6 +73,8 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
     case Jason.decode(body, keys: :atoms) do
       {:ok, ld} ->
         Logger.debug("Caching link definition from #{ld.actor_id} on contract #{ld.contract_id}")
+
+        ld = ensure_linkdef_id(ld)
 
         # This data came from the bucket, so we don't need to re-write it to the bucket, just:
         # * store it in memory

--- a/host_core/lib/host_core/linkdefs/manager.ex
+++ b/host_core/lib/host_core/linkdefs/manager.ex
@@ -17,16 +17,6 @@ defmodule HostCore.Linkdefs.Manager do
           link_name :: String.t()
         ) :: map() | nil
   def lookup_link_definition(lattice_prefix, actor, contract_id, link_name) do
-    # predicates = [
-    #   {:==, {:map_get, :actor_id, :"$2"}, actor},
-    #   {:==, {:map_get, :contract_id, :"$2"}, contract_id},
-    #   {:==, {:map_get, :link_name, :"$2"}, link_name}
-    # ]
-
-    # lattice_prefix
-    # |> table_atom()
-    # |> :ets.select([{{:"$1", :"$2"}, predicates, [:"$2"]}])
-    # |> List.first()
     case lookup_link_definition(lattice_prefix, linkdef_hash(actor, contract_id, link_name)) do
       {:ok, ld} -> ld
       :error -> nil

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.lock
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.lock
@@ -96,7 +96,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -581,15 +581,36 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -837,6 +858,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -846,6 +876,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -884,7 +923,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "uuid",
- "wascap 0.9.0",
+ "wascap 0.9.2",
 ]
 
 [[package]]
@@ -998,6 +1037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,10 +1081,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "itoa"
@@ -1117,6 +1184,12 @@ checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -1305,7 +1378,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1786,6 +1859,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "rustler"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,7 +1889,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baa2e45c0165272070f80ce93bcd7dd5407a3c84a1ef73ab9900e00f00ef3d36"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2471,6 +2558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,6 +2630,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
+name = "walrus"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb08e48cde54c05f363d984bb54ce374f49e242def9468d2e1b6c2372d291f8"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "leb128",
+ "log",
+ "walrus-macro",
+ "wasmparser 0.77.0",
+]
+
+[[package]]
+name = "walrus-macro"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e5bd22c71e77d60140b0bd5be56155a37e5bd14e24f5f87298040d0cc40d7"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,13 +2688,13 @@ dependencies = [
 
 [[package]]
 name = "wascap"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b982c061be50ef1fa43f43e3f022b3bdb7ed7b24f0bb3dcebde996a8687ea607"
+checksum = "78faacaf906be20194b0e9dc84c70ed5ed3cee5da0d66b15b6c5cc1c5d6bab8e"
 dependencies = [
  "base64",
  "data-encoding",
- "env_logger 0.9.3",
+ "env_logger 0.10.0",
  "humantime",
  "lazy_static",
  "log",
@@ -2585,9 +2704,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "walrus",
  "wasm-encoder",
  "wasm-gen",
- "wasmparser",
+ "wasmparser 0.94.0",
 ]
 
 [[package]]
@@ -2676,9 +2796,9 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9424cdab516a16d4ea03c8f4a01b14e7b2d04a129dcc2bcdde5bcc5f68f06c41"
+checksum = "05632e0a66a6ed8cca593c24223aabd6262f256c3693ad9822c315285f010614"
 dependencies = [
  "leb128",
 ]
@@ -2692,6 +2812,12 @@ dependencies = [
  "byteorder 0.5.3",
  "leb128",
 ]
+
+[[package]]
+name = "wasmparser"
+version = "0.77.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35c86d22e720a07d954ebbed772d01180501afe7d03d464f413bb5f8914a8d6"
 
 [[package]]
 name = "wasmparser"


### PR DESCRIPTION
Host can now handle the edge case when there is a link definition in the lattice data bucket without the `id` field in the JSON payload.