### PR TITLE
Caching vhost config

### DIFF
--- a/host_core/lib/application.ex
+++ b/host_core/lib/application.ex
@@ -82,7 +82,7 @@ defmodule HostCore.Application do
   end
 
   defp create_ets_tables do
-    :ets.new(:vhost_table, [:named_table, :set, :public])
+    :ets.new(:vhost_config_table, [:named_table, :set, :public])
     :ets.new(:policy_table, [:named_table, :set, :public])
     :ets.new(:module_cache, [:named_table, :set, :public])
   end

--- a/host_core/lib/host_core/vhost/virtual_host.ex
+++ b/host_core/lib/host_core/vhost/virtual_host.ex
@@ -123,7 +123,8 @@ defmodule HostCore.Vhost.VirtualHost do
       config: Map.put(config, :labels, labels),
       friendly_name: friendly_name,
       start_time: wclock,
-      labels: labels
+      labels: labels,
+      supplemental_config: nil
     }
 
     :timer.send_interval(@thirty_seconds, self(), :publish_heartbeat)

--- a/host_core/lib/host_core/vhost/virtual_host.ex
+++ b/host_core/lib/host_core/vhost/virtual_host.ex
@@ -169,7 +169,7 @@ defmodule HostCore.Vhost.VirtualHost do
       Enum.each(autostart_actors, fn actor -> start_autostart_actor(actor, state) end)
     end)
 
-    {:noreply, {:continue, :publish_started}}
+    {:noreply, state, {:continue, :publish_started}}
   end
 
   def handle_continue(:publish_started, state) do


### PR DESCRIPTION
Caches virtual host configuration in an ETS table. Previous version made GenServer calls to get this data. Moving this to an ETS cache to further reduce the narrow chance of a re-entrant GenServer call