### PR TITLE
fix various bugs related to policy checks

### DIFF
--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -498,15 +498,17 @@ defmodule HostCore.Actors.ActorModule do
   defp policy_check(%{source_target: true} = token, agent) do
     lattice_prefix = Agent.get(agent, fn contents -> contents.lattice_prefix end)
     host_id = Agent.get(agent, fn contents -> contents.host_id end)
-    config = VirtualHost.config(host_id)
-    origin = token.invocation["origin"]
+    source = token.invocation["origin"]
     target = token.invocation["target"]
 
     decision =
-      with {:ok, _topic} <- PolicyManager.policy_topic(config),
+      with {:ok, {pid, _}} <- VirtualHost.lookup(host_id),
+           config <- VirtualHost.config(pid),
+           labels <- VirtualHost.labels(pid),
+           {:ok, _topic} <- PolicyManager.policy_topic(config),
            {:ok, source_claims} <-
-             ClaimsManager.lookup_claims(lattice_prefix, origin["public_key"]),
-           {:ok, _target_claims} <-
+             ClaimsManager.lookup_claims(lattice_prefix, source["public_key"]),
+           {:ok, target_claims} <-
              ClaimsManager.lookup_claims(lattice_prefix, target["public_key"]) do
         expired =
           case source_claims[:exp] do
@@ -518,18 +520,31 @@ defmodule HostCore.Actors.ActorModule do
         if expired do
           %{permitted: false}
         else
-          config = VirtualHost.config(host_id)
-
           PolicyManager.evaluate_action(
             config,
-            origin,
-            target,
+            labels,
+            %{
+              publicKey: source["public_key"],
+              contractId: source["contract_id"],
+              linkName: source["link_name"],
+              capabilities: source_claims[:caps],
+              issuer: source_claims[:iss],
+              issuedOn: source_claims[:iat],
+              expiresAt: source_claims[:exp],
+              expired: expired
+            },
+            %{
+              publicKey: target["public_key"],
+              contractId: target["contract_id"],
+              linkName: target["link_name"],
+              issuer: target_claims[:iss]
+            },
             @perform_invocation
           )
         end
       else
-        # Failed to check claims for source or target, denying
         :policy_eval_disabled -> %{permitted: true}
+        # Failed to get host info or check claims for source or target, denying
         :error -> %{permitted: false}
       end
 

--- a/host_core/lib/host_core/policy/manager.ex
+++ b/host_core/lib/host_core/policy/manager.ex
@@ -50,11 +50,12 @@ defmodule HostCore.Policy.Manager do
 
   @spec evaluate_action(
           host_config :: HostCore.Vhost.Configuration.t(),
+          labels :: Map.t(),
           source :: Map.t(),
           target :: Map.t(),
           action :: String.t()
         ) :: Map.t()
-  def evaluate_action(host_config, source, target, action) do
+  def evaluate_action(host_config, labels, source, target, action) do
     with {:ok, topic} <- Manager.policy_topic(host_config),
          nil <- cached_decision(source, target, action, host_config.lattice_prefix),
          :ok <- validate_source(source),
@@ -71,7 +72,7 @@ defmodule HostCore.Policy.Manager do
           publicKey: host_config.host_key,
           issuer: host_config.cluster_key,
           latticeId: host_config.lattice_prefix,
-          labels: host_config.labels,
+          labels: labels,
           clusterIssuers: host_config.cluster_issuers
         }
       }
@@ -175,6 +176,20 @@ defmodule HostCore.Policy.Manager do
       [] ->
         nil
     end
+  end
+
+  @spec default_source() :: Map.t()
+  def default_source() do
+    %{
+      publicKey: "",
+      contractId: "",
+      linkName: "",
+      capabilities: [],
+      issuer: "",
+      issuedOn: "",
+      expiresAt: DateTime.utc_now() |> DateTime.add(60) |> DateTime.to_unix(),
+      expired: false
+    }
   end
 
   ##

--- a/host_core/lib/host_core/vhost/virtual_host.ex
+++ b/host_core/lib/host_core/vhost/virtual_host.ex
@@ -191,6 +191,7 @@ defmodule HostCore.Vhost.VirtualHost do
   def lookup(host_id) do
     case Registry.lookup(Registry.HostRegistry, host_id) do
       [] ->
+        Logger.warn("Failed to look up host ID #{host_id}")
         :error
 
       [{pid, value}] ->
@@ -233,6 +234,7 @@ defmodule HostCore.Vhost.VirtualHost do
         config
 
       [] ->
+        Logger.warn("Failed to find config for host ID #{host_id}")
         nil
     end
   end


### PR DESCRIPTION
This PR fixes a few bugs that would prevent actors/providers from starting/invocations from being processed. I also refactored `start_actor` to have significantly less nesting in an attempt to make it easier to read.

I tested these changes by:
- starting a host
- starting actors on the host (including multiple counts)
- starting providers on the host
- linking actors and providers
- issuing requests that generate both actor -> provider and provider -> actor invocations

Everything seems to be working now

Signed-off-by: Connor Smith <connor.smith.256@gmail.com>