### PR TITLE
Fixes issues with deleting linkdefs

### DIFF
--- a/host_core/lib/host_core/control_interface/lattice_server.ex
+++ b/host_core/lib/host_core/control_interface/lattice_server.ex
@@ -121,6 +121,8 @@ defmodule HostCore.ControlInterface.LatticeServer do
     Tracer.with_span "Handle Linkdef Del (ctl)", kind: :server do
       with {:ok, ld} <- Jason.decode(body),
            true <- has_values(ld, ["actor_id", "contract_id", "link_name"]) do
+        # Removes linkdef from bucket and just in case we lose the subscription
+        # message from the bucket, uncache it from memory
         LinkdefsManager.del_link_definition_by_triple(
           prefix,
           ld["actor_id"],

--- a/host_core/lib/host_core/jetstream/client.ex
+++ b/host_core/lib/host_core/jetstream/client.ex
@@ -196,7 +196,6 @@ defmodule HostCore.Jetstream.Client do
     # delete requires us to make a request on the topic with headers
     # KV-Operation : PURGE
     topic = kv_operation_topic(lattice_prefix, key, js_domain)
-    IO.inspect(topic)
     headers = [{@kvoperation, @kvpurge}]
 
     # TODO: once the Jetstream hex package support js_domains, switch this

--- a/host_core/lib/host_core/jetstream/legacy_cache_loader.ex
+++ b/host_core/lib/host_core/jetstream/legacy_cache_loader.ex
@@ -32,16 +32,13 @@ defmodule HostCore.Jetstream.LegacyCacheLoader do
   def handle_request({"linkdefs", key}, body, prefix, js_domain) do
     case Jason.decode(body, keys: :atoms) do
       {:ok, %{deleted: true} = ld} ->
-        LinkdefsManager.uncache_link_definition(
-          prefix,
-          ld.id
-        )
-
         Logger.debug(
           "Skipping migration of deleted linkdef from #{ld.actor_id} to #{ld.provider_id}"
         )
 
       {:ok, ld} ->
+        ld = LinkdefsManager.reidentify_linkdef(ld)
+
         JetstreamClient.kv_put(
           prefix,
           js_domain,

--- a/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
+++ b/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
@@ -91,7 +91,9 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
 
   defp handle_action(:key_deleted, %{key: @linkdef_prefix <> ldid, prefix: lattice_prefix}, _body) do
     Logger.debug("Removing cached reference for linkdef ID #{ldid}")
-    LinkdefsManager.del_link_definition(lattice_prefix, ldid)
+
+    # Remove from in-memory cache. No need to remove from bucket (removal from bucket causes this handler)
+    LinkdefsManager.uncache_link_definition(lattice_prefix, ldid)
   end
 
   defp handle_action(:key_deleted, %{key: @claims_prefix <> pk, prefix: lattice_prefix}, _body) do

--- a/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
+++ b/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
@@ -15,6 +15,7 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
 
   @operation_header "kv-operation"
   @operation_del "DEL"
+  @operation_purge "PURGE"
 
   @bucket_prefix "LATTICEDATA_"
   @claims_prefix "CLAIMS_"
@@ -27,7 +28,8 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
   def request(%{topic: topic, body: body, headers: headers}) do
     tokenmap = tokenize(topic)
 
-    if {@operation_header, @operation_del} in headers do
+    if {@operation_header, @operation_del} in headers ||
+         {@operation_header, @operation_purge} in headers do
       handle_action(:key_deleted, tokenmap, body)
     else
       handle_action(:key_added, tokenmap, body)

--- a/host_core/lib/host_core/linkdefs/manager.ex
+++ b/host_core/lib/host_core/linkdefs/manager.ex
@@ -66,8 +66,7 @@ defmodule HostCore.Linkdefs.Manager do
     :ets.insert(table_atom(lattice_prefix), {ld.id, ld})
   end
 
-  def uncache_link_definition(lattice_prefix, ldid, js_domain) do
-    HostCore.Jetstream.Client.kv_del(lattice_prefix, js_domain, "LINKDEF_#{ldid}")
+  def uncache_link_definition(lattice_prefix, ldid) do
     :ets.delete(table_atom(lattice_prefix), ldid)
   end
 
@@ -131,7 +130,8 @@ defmodule HostCore.Linkdefs.Manager do
               nil
             end
 
-          uncache_link_definition(lattice_prefix, linkdef.id, js_domain)
+          uncache_link_definition(lattice_prefix, linkdef.id)
+          HostCore.Jetstream.Client.kv_del(lattice_prefix, js_domain, "LINKDEF_#{ldid}")
         end
 
         publish_link_definition_deleted(lattice_prefix, linkdef)


### PR DESCRIPTION
This addresses two problems:

1) This will change the ID of legacy linkdefs to the new hash-based ID so they can be properly looked up in the new host
2) This actually deletes linkdefs from the metadata cache via the control interface server

## Testing Method
Added a link (these are fake IDs)
```
wash ctl link put --link-name default MC7KRLM6QAMNTJY2S7YEMINQ27CADS2UT27EYT4CBQHLZAMGYBRYAIYD VCOX3XM5ZQTX6W7DETWQM4U7JZ7T7EJPUOHNQQX4F3JPJJWCNB6LTWSY wasmcloud:messaging
```
Made sure it shows up in the cache:
```
 nats kv ls LATTICEDATA_default
LINKDEF_13599B7EBAA569030B1B9580585B05B2980682D5717F7C9E1910F27339D47F3D
```
Now delete the link:
```
wash ctl link del MC7KRLM6QAMNTJY2S7YEMINQ27CADS2UT27EYT4CBQHLZAMGYBRYAIYD wasmcloud:messaging
```
And now verify that the link is indeed gone:
```
nats kv ls LATTICEDATA_default
No keys found in bucket
```

Restart the host and verify that it ignores (or no-op deletes) the now-purged key:
```
14:03:11.782 [debug] Removing cached reference for linkdef ID 13599B7EBAA569030B1B9580585B05B2980682D5717F7C9E1910F27339D47F3D
14:03:11.782 [warning] Attempted to remove non-existent linkdef 13599B7EBAA569030B1B9580585B05B2980682D5717F7C9E1910F27339D47F3D (this is OK)
```

It's interesting to note that if a host starts up in a lattice that has had an enormous amount of churn, it could see a few dozen no-op skip deletes at startup, but this won't grow infinitely because the hash of a linkdef will always be the same regardless of the values payload.