### PR TITLE
publish link deleted events

### DIFF
--- a/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
+++ b/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
@@ -92,6 +92,11 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
   defp handle_action(:key_deleted, %{key: @linkdef_prefix <> ldid, prefix: lattice_prefix}, _body) do
     Logger.debug("Removing cached reference for linkdef ID #{ldid}")
 
+    case LinkdefsManager.lookup_link_definition(lattice_prefix, ldid) do
+      {:ok, ld} -> LinkdefsManager.publish_link_definition_deleted(lattice_prefix, ld)
+      _ -> Logger.warn("Failed to look up link definition with ID #{ldid}")
+    end
+
     # Remove from in-memory cache. No need to remove from bucket (removal from bucket causes this handler)
     LinkdefsManager.uncache_link_definition(lattice_prefix, ldid)
   end

--- a/host_core/lib/host_core/linkdefs/manager.ex
+++ b/host_core/lib/host_core/linkdefs/manager.ex
@@ -191,7 +191,7 @@ defmodule HostCore.Linkdefs.Manager do
   # Publishes the removal of a link definition to the event stream and sends an indication
   # of the removal to the appropriate capability provider. Other hosts will already have been
   # informed of the deletion via key subscriptions on the bucket
-  defp publish_link_definition_deleted(prefix, ld) do
+  def publish_link_definition_deleted(prefix, ld) do
     provider_topic = "wasmbus.rpc.#{prefix}.#{ld.provider_id}.#{ld.link_name}.linkdefs.del"
 
     %{


### PR DESCRIPTION
This PR ensures the host emits at least one `linkdef_deleted` cloud event when a link is deleted from the KV bucket

Signed-off-by: Connor Smith <connor.smith.256@gmail.com>