### PR TITLE
Putting contract ID back on heartbeat

### DIFF
--- a/host_core/lib/host_core/claims/manager.ex
+++ b/host_core/lib/host_core/claims/manager.ex
@@ -84,7 +84,7 @@ defmodule HostCore.Claims.Manager do
         end,
       version: claims.version,
       sub: claims.public_key,
-      contract_id: Map.get(claims, :contract_id)
+      contract_id: Map.get(claims, :contract_id) || ""
     }
 
     cache_call_alias(lattice_prefix, claims.call_alias, claims.sub)

--- a/host_core/lib/host_core/claims/manager.ex
+++ b/host_core/lib/host_core/claims/manager.ex
@@ -15,7 +15,8 @@ defmodule HostCore.Claims.Manager do
           rev: String.t(),
           tags: String.t(),
           version: String.t(),
-          sub: String.t()
+          sub: String.t(),
+          contract_id: String.t() | nil
         }
 
   @spec lookup_claims(lattice_prefix :: String.t(), public_key :: String.t()) ::
@@ -82,7 +83,8 @@ defmodule HostCore.Claims.Manager do
           Enum.join(claims.tags, ",")
         end,
       version: claims.version,
-      sub: claims.public_key
+      sub: claims.public_key,
+      contract_id: Map.get(claims, :contract_id)
     }
 
     cache_call_alias(lattice_prefix, claims.call_alias, claims.sub)

--- a/host_core/lib/host_core/providers/provider_supervisor.ex
+++ b/host_core/lib/host_core/providers/provider_supervisor.ex
@@ -65,7 +65,7 @@ defmodule HostCore.Providers.ProviderSupervisor do
             par.contract_id,
             link_name
           ),
-          par.claims,
+          Map.put(par.claims, :contract_id, par.contract_id),
           link_name,
           par.contract_id,
           ref,
@@ -133,7 +133,7 @@ defmodule HostCore.Providers.ProviderSupervisor do
               par.contract_id,
               link_name
             ),
-            par.claims,
+            Map.put(par.claims, :contract_id, par.contract_id),
             link_name,
             par.contract_id,
             bindle_id,
@@ -185,7 +185,7 @@ defmodule HostCore.Providers.ProviderSupervisor do
               par.contract_id,
               link_name
             ),
-            par.claims,
+            Map.put(par.claims, :contract_id, par.contract_id),
             link_name,
             par.contract_id,
             "",
@@ -356,11 +356,22 @@ defmodule HostCore.Providers.ProviderSupervisor do
         ]
   def all_providers_for_hb(host_id) do
     providers_on_host = providers_on_host(host_id)
+    lattice_prefix = HostCore.Vhost.VirtualHost.get_lattice_for_host(host_id)
 
     Enum.map(providers_on_host, fn {{pk, link_name}, _pid} ->
+      contract_id =
+        case HostCore.Claims.Manager.lookup_claims(lattice_prefix, pk) do
+          {:ok, claims} ->
+            Map.get(claims, :contract_id, "n/a")
+
+          _ ->
+            "n/a"
+        end
+
       %{
         public_key: pk,
-        link_name: link_name
+        link_name: link_name,
+        contract_id: contract_id
       }
     end)
   end


### PR DESCRIPTION
This puts the capability provider's contract ID into the claims cache, which in turn stores it in the kv bucket. Once this data is in the claims cache, we can now query it and put it back on the heartbeat without performing a blocking GenServer call