### PR TITLE
add custom console logger

### DIFF
--- a/host_core/config/config.exs
+++ b/host_core/config/config.exs
@@ -16,9 +16,9 @@ import Config
 #
 
 config :logger, :console,
-  format: "$time $metadata[$level] $message\n",
+  format: {HostCore.ConsoleLogger, :format},
   level: :info,
-  metadata: [:span_id, :trace_id],
+  metadata: :all,
   device: :standard_error
 
 config :opentelemetry, :resource, service: %{name: "wasmcloud"}

--- a/host_core/lib/host_core/console_logger.ex
+++ b/host_core/lib/host_core/console_logger.ex
@@ -18,17 +18,32 @@ defmodule HostCore.ConsoleLogger do
 
   require Logger
 
-  @excluded_keys MapSet.new([:erl_level, :application, :domain, :file, :function, :gl, :line, :mfa, :module, :pid, :time])
+  @excluded_keys MapSet.new([
+                   :erl_level,
+                   :application,
+                   :domain,
+                   :file,
+                   :function,
+                   :gl,
+                   :line,
+                   :mfa,
+                   :module,
+                   :pid,
+                   :time
+                 ])
 
   @without_metadata_pattern Logger.Formatter.compile("$time [$level] $message\n")
   @with_metadata_pattern Logger.Formatter.compile("$time [$level] $metadata$message\n")
 
   def format(level, message, timestamp, metadata) do
     filtered_metadata = Enum.reject(metadata, fn {k, _v} -> MapSet.member?(@excluded_keys, k) end)
-    pattern = case filtered_metadata do
-      [] -> @without_metadata_pattern
-      _ -> @with_metadata_pattern
-    end
+
+    pattern =
+      case filtered_metadata do
+        [] -> @without_metadata_pattern
+        _ -> @with_metadata_pattern
+      end
+
     Logger.Formatter.format(pattern, level, message, timestamp, filtered_metadata)
   rescue
     err -> "ERROR: FAILED TO FORMAT LOG MESSAGE! #{inspect(err)}\n"

--- a/host_core/lib/host_core/console_logger.ex
+++ b/host_core/lib/host_core/console_logger.ex
@@ -1,0 +1,36 @@
+defmodule HostCore.ConsoleLogger do
+  @moduledoc """
+  HostCore.ConsoleLogger is the default logger. It functions almost the same as the default
+  Logger.Formatter, with a notable difference: all metadata keys are printed before the message,
+  filtering built-in keys, such as :erl_level, :application, :mfa, and so on. If any of these
+  metadata keys should be printed, this logger will need to be modified.
+
+  Example statement and accompanying formatted message:
+
+    Logger.info(
+      "Started wasmCloud OTP Host Runtime",
+      version: "#{to_string(Application.spec(:host_core, :vsn))}"
+    )
+
+    12:44:43.028 [info] version=0.60.0 Started wasmCloud OTP Host Runtime
+
+  """
+
+  require Logger
+
+  @excluded_keys MapSet.new([:erl_level, :application, :domain, :file, :function, :gl, :line, :mfa, :module, :pid, :time])
+
+  @without_metadata_pattern Logger.Formatter.compile("$time [$level] $message\n")
+  @with_metadata_pattern Logger.Formatter.compile("$time [$level] $metadata$message\n")
+
+  def format(level, message, timestamp, metadata) do
+    filtered_metadata = Enum.reject(metadata, fn {k, _v} -> MapSet.member?(@excluded_keys, k) end)
+    pattern = case filtered_metadata do
+      [] -> @without_metadata_pattern
+      _ -> @with_metadata_pattern
+    end
+    Logger.Formatter.format(pattern, level, message, timestamp, filtered_metadata)
+  rescue
+    err -> "ERROR: FAILED TO FORMAT LOG MESSAGE! #{inspect(err)}\n"
+  end
+end

--- a/wasmcloud_host/config/config.exs
+++ b/wasmcloud_host/config/config.exs
@@ -23,8 +23,8 @@ config :wasmcloud_host, WasmcloudHostWeb.Endpoint,
 
 # Configures Elixir's Logger
 config :logger, :console,
-  format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id, :span_id, :trace_id],
+  format: {HostCore.ConsoleLogger, :format},
+  metadata: :all,
   device: :standard_error
 
 # Use Jason for JSON parsing in Phoenix

--- a/wasmcloud_host/config/dev.exs
+++ b/wasmcloud_host/config/dev.exs
@@ -52,10 +52,7 @@ config :wasmcloud_host, WasmcloudHostWeb.Endpoint,
   ]
 
 # Do not include metadata nor timestamps in development logs
-config :logger, :console,
-  format: "$metadata[$level] $message\n",
-  level: :debug,
-  metadata: [:span_id, :trace_id]
+config :logger, :console, level: :debug
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/wasmcloud_host/config/prod.exs
+++ b/wasmcloud_host/config/prod.exs
@@ -20,7 +20,7 @@ config :wasmcloud_host, WasmcloudHostWeb.Endpoint,
   version: Application.spec(:phoenix_distillery, :vsn)
 
 # Do not print debug messages in production
-config :logger, level: :info
+config :logger, :console, level: :info
 
 # ## SSL Support
 #

--- a/wasmcloud_host/config/test.exs
+++ b/wasmcloud_host/config/test.exs
@@ -7,4 +7,4 @@ config :wasmcloud_host, WasmcloudHostWeb.Endpoint,
   server: false
 
 # Print only warnings and errors during test
-config :logger, level: :warn
+config :logger, :console, level: :warn


### PR DESCRIPTION
This logger functions almost the same as the default logger, but includes custom metadata fields

Here are a couple sample logs that include metadata fields:

```
13:31:37.872 [info] version=0.60.0 Started wasmCloud OTP Host Runtime
```

```
13:32:07.034 [debug] oci_ref=wasmcloud.azurecr.io/echo:0.3.4 span_id=63fc79e32f360f0a trace_id=1806094e433956675e6ee30a79c382a6 Start actor request received for wasmcloud.azurecr.io/echo:0.3.4
```

Resolves https://github.com/wasmCloud/wasmcloud-otp/issues/540

Signed-off-by: Connor Smith <connor.smith.256@gmail.com>