### PR TITLE
reference updated function

### DIFF
--- a/wasmcloud_host/lib/wasmcloud_host_web/live/metrics_live.ex
+++ b/wasmcloud_host/lib/wasmcloud_host_web/live/metrics_live.ex
@@ -1,6 +1,11 @@
 defmodule WasmcloudHostWeb.MetricsLive do
   use Phoenix.LiveView
 
+  def first_host_key do
+    {pk, _pid, _prefix} = WasmcloudHost.Application.first_host()
+    pk
+  end
+
   def render(assigns) do
     ~L"""
     <main class="c-main">
@@ -13,9 +18,9 @@ defmodule WasmcloudHostWeb.MetricsLive do
                   <div class="card-header">
                     Erlang Metrics for
                     <button class="btn btn-ghost-dark btn-sm id-monospace" type="button"
-                      onClick="navigator.clipboard.writeText('<%= HostCore.Host.host_key() %>')" data-toggle="popover"
+                      onClick="navigator.clipboard.writeText('<%= first_host_key() %>')" data-toggle="popover"
                       data-trigger="focus" title="" data-content="Copied!">
-                      <%= String.slice(HostCore.Host.host_key(), 0..4) %>...
+                      <%= String.slice(first_host_key(), 0..4) %>...
                       <svg class="c-icon">
                         <use xlink:href="/coreui/free.svg#cil-copy"></use>
                       </svg>


### PR DESCRIPTION
This PR removes a reference to a function that doesn't exist anymore. On main, trying to load metrics results in an internal server error. This references the replacement function, allowing the page to load again

I'm unfamiliar with the metrics page, so I can't attest this is now showing the correct information, but I can say the page loads now

Signed-off-by: Connor Smith <connor.smith.256@gmail.com>