### PR TITLE
emit uptime_seconds and version when publishing a host_started event

### DIFF
--- a/host_core/lib/host_core/vhost/heartbeats.ex
+++ b/host_core/lib/host_core/vhost/heartbeats.ex
@@ -52,7 +52,7 @@ defmodule HostCore.Vhost.Heartbeats do
       |> ProviderSupervisor.all_providers_for_hb()
 
     {total, _} = :erlang.statistics(:wall_clock)
-    ut_seconds = div(total, 1000)
+    ut_seconds = div(total - state.start_time, 1000)
 
     ut_human =
       ut_seconds

--- a/host_core/lib/host_core/vhost/virtual_host.ex
+++ b/host_core/lib/host_core/vhost/virtual_host.ex
@@ -511,9 +511,15 @@ defmodule HostCore.Vhost.VirtualHost do
 
   @spec publish_host_started(state :: State.t()) :: :ok
   defp publish_host_started(state) do
+    {total, _} = :erlang.statistics(:wall_clock)
+
+    ut_seconds = div(total - state.start_time, 1000)
+
     %{
       labels: state.labels,
-      friendly_name: state.friendly_name
+      friendly_name: state.friendly_name,
+      uptime_seconds: ut_seconds,
+      version: :host_core |> Application.spec(:vsn) |> to_string()
     }
     |> CloudEvent.new("host_started", state.config.host_key)
     |> CloudEvent.publish(state.config.lattice_prefix)


### PR DESCRIPTION
This PR adds the `uptime_seconds` and `version` fields to the `host_started` event. The purpose of this is so the lattice observer will be able to pick up this information immediately, rather than having to wait for the first heartbeat

Before:
```
{
    "data": {
        "friendly_name": "bold-wind-2335",
        "labels": {
            "hostcore.arch": "aarch64",
            "hostcore.os": "macos",
            "hostcore.osfamily": "unix"
        }
    },
    "datacontenttype": "application/json",
    "id": "ecfa5fb7-6291-45aa-8687-dd0c46509e62",
    "source": "NA3WSC2YF246TZZ2RMI5SOUUBBOL7FWHBRLZZ2JAQNX5MHHJ5JI7TZG5",
    "specversion": "1.0",
    "time": "2023-02-10T19:46:39.079821Z",
    "type": "com.wasmcloud.lattice.host_started"
}
```

After:
```
{
    "data": {
        "friendly_name": "weathered-ocean-8637",
        "labels": {
            "hostcore.arch": "aarch64",
            "hostcore.os": "macos",
            "hostcore.osfamily": "unix"
        },
        "uptime_seconds": 0,
        "version": "0.60.0"
    },
    "datacontenttype": "application/json",
    "id": "bd950e2f-0b1f-4893-9a91-73fde401b57d",
    "source": "NCFSEUMEQX7SBN6QCEPDTS5WT23J45AHRHO7U6WXGT57SHLJ3O4XCINP",
    "specversion": "1.0",
    "time": "2023-02-10T19:47:54.990586Z",
    "type": "com.wasmcloud.lattice.host_started"
}
```

Signed-off-by: Connor Smith <connor.smith.256@gmail.com>