### PR TITLE
Added devcontainer for wasmcloud-otp

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,7 @@
+# wasmcloud-otp devcontainer
+
+A simple devcontainer that has `rust`, `elixir`, `erlang`, and `nats-server` installed. Try it out with `devcontainer open` at the root of this repository!
+
+## Prerequisites
+- [devcontainer CLI](https://code.visualstudio.com/docs/devcontainers/devcontainer-cli#_installation)
+- VSCode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+	"name": "wasmcloud-otp",
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/rust:1": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers-contrib/features/elixir-asdf:2": {
+			"elixirVersion": "1.14.2",
+			"erlangVersion": "25.0"
+		},
+		"./wasmcloudfeature": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"rust-lang.rust-analyzer",
+				"JakeBecker.elixir-ls"
+			],
+			"settings": {
+				"rust-analyzer.linkedProjects": [
+					"host_core/native/hostcore_wasmcloud_native.Cargo.toml"
+				]
+			}
+		}
+	},
+	"workspaceMount": "source=${localWorkspaceFolder},target=/wash,type=bind,consistency=cached",
+	"workspaceFolder": "/wasmcloud-otp"
+}

--- a/.devcontainer/wasmcloudfeature/devcontainer-feature.json
+++ b/.devcontainer/wasmcloudfeature/devcontainer-feature.json
@@ -1,0 +1,10 @@
+{
+    "name": "wasmCloud OTP",
+    "id": "wasmcloud",
+    "version": "0.0.1",
+    "description": "A feature to install wasmCloud OTP development components",
+    "installsAfter": [
+      "ghcr.io/devcontainers/features/rust",
+      "ghcr.io/devcontainers-contrib/features/elixir-asdf"
+    ]
+}

--- a/.devcontainer/wasmcloudfeature/install.sh
+++ b/.devcontainer/wasmcloudfeature/install.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+NATS_VERSION=2.9.14
+ARCH=$(uname -m)
+echo $ARCH
+# Rename arch to match NATS scheme
+if [[ "$ARCH" == "aarch64" ]]; then
+  NATS_ARCH="arm64"
+elif [[ "$ARCH" == "x86_64" ]]; then
+  NATS_ARCH="amd64"
+else
+  NATS_ARCH=$ARCH
+fi
+URL=https://github.com/nats-io/nats-server/releases/download/v$NATS_VERSION/nats-server-v$NATS_VERSION-$NATS_ARCH.deb
+
+echo "Performing NATS server install"
+echo "Downloading from $URL"
+
+curl -fLO $URL
+dpkg -i ./nats-server-v$NATS_VERSION-$NATS_ARCH.deb
+
+# Set up PATH to properly pick up elixir/erlang binaries
+echo 'export PATH="/home/vscode/.asdf/installs/elixir/1.14.2/bin:/home/vscode/.asdf/installs/erlang/25.0/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+
+# Install mix tools for Elixir compilation
+mix local.hex --force
+mix local.rebar --force


### PR DESCRIPTION
This PR is a simple devcontainer that installs elixir, erlang, Rust, nats-server, and a few VScode extensions. This should serve as a good starting point for people who are used to devcontainers / codespaces to develop in a reproduce-able environment!

Try it for yourself, run `devcontainer open` in the root of the repo. This will take some time to build the first time, but I'd like to see if we can publish that image in GHCR sometime