### PR TITLE
chore: set elixir version (explicitly) via asdf 

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+# This file works with ASDF (https://github.com/asdf-vm/asdf)
+elixir 1.14.3-otp-25

--- a/README.md
+++ b/README.md
@@ -8,34 +8,43 @@
 
 # wasmCloud Host Runtime (OTP)
 
-The wasmCloud Host Runtime is a server process that securely hosts and provides dispatch for [actors](https://wasmcloud.dev/reference/host-runtime/actors/) and [capability providers](https://wasmcloud.dev/reference/host-runtime/capabilities/). This runtime is designed to take advantage of WebAssembly's small footprint, secure sandbox, speed, and portability to allow developers to write boilerplate-free code that embraces the [actor model](https://en.wikipedia.org/wiki/Actor_model) and abstracts away dependencies on [non-functional requirements](https://www.scaledagileframework.com/nonfunctional-requirements/) via well-defined [interfaces](https://github.com/wasmCloud/interfaces/).
+The wasmCloud Host Runtime is a server process that securely hosts and provides dispatch for [actors](https://wasmcloud.dev/reference/host-runtime/actors/) and [capability providers](https://wasmcloud.dev/reference/host-runtime/capabilities/).
 
-This host runtime is written in Elixir and extensively leverages the decades of work, testing, and improvements that have gone into the **OTP** framework. There are a number of excellent Elixir and OTP references online, but we highly recommend starting with the [Pragmatic Programmers](https://pragprog.com/categories/elixir-phoenix-and-otp/) Elixir and OTP library of books.
+This runtime is designed to take advantage of WebAssembly's small footprint, secure sandbox, speed, and portability to allow developers to write boilerplate-free code that embraces the [actor model](https://en.wikipedia.org/wiki/Actor_model) and abstracts away dependencies on [non-functional requirements](https://www.scaledagileframework.com/nonfunctional-requirements/) via well-defined [interfaces](https://github.com/wasmCloud/interfaces/).
 
-To get started with installation and exploration, check out the [getting started](https://wasmcloud.dev/overview/getting-started/) section of our documentation.
+This host runtime is written in [Elixir][elixir] and extensively leverages the decades of work, testing, and improvements that have gone into the **OTP** framework. 
+There are a number of excellent Elixir and OTP references online, but we highly recommend starting with the [Pragmatic Programmers](https://pragprog.com/categories/elixir-phoenix-and-otp/) Elixir and OTP library of books.
+
+## Getting started
+
+To install and explore wasmCloud (and this host runtime), check out the [documentation for getting started](https://wasmcloud.dev/overview/getting-started/).
+
+## Architecture
 
 The wasmCloud Host Runtime is made up of two pieces:
 
 - The Host Core
 - Dashboard Web UI
 
-## Host Core
+### Host Core
 
 The **host core** consists of all of the "headless" (no UI) functional components of the system. This OTP application and its contained supervision tree represent the _core_ of the wasmCloud OTP host runtime.
 
 You can find the [host core](./host_core/README.md) in this github repository.
 
-## Dashboard Web UI
+### Dashboard Web UI
 
 The dashboard web UI (often colloquially referred to as the _washboard_) is a **Phoenix** application that fits snugly atop the host core, providing real-time web access to a variety of information, telemetry, and insight while also exposing a graphical interface to controlling the host and portions of the lattice.
 
 You can find the [dashboard UI](./wasmcloud_host/README.md) in this github repository.
 
+## Dependencies
+
 ### NATS
 
 All of wasmCloud's _lattice_ functionality requires the use of [NATS](https://nats.io). To learn more, check out the [lattice](https://wasmcloud.dev/reference/lattice/) section of our documentation.
 
-## Local development
+## Development
 
 ### Pre-requisites
 

--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ You can find the [dashboard UI](./wasmcloud_host/README.md) in this github repos
 ### NATS
 
 All of wasmCloud's _lattice_ functionality requires the use of [NATS](https://nats.io). To learn more, check out the [lattice](https://wasmcloud.dev/reference/lattice/) section of our documentation.
+
+## Local development
+
+### Pre-requisites
+
+- (optional) [`asdf`][asdf] with [`asdf-elixir`][asdf-elixir] for managing versions of [`elixir`][elixir] (see `.tool-versions`)
+
+[asdf]: https://asdf-vm.com/
+[asdf-elixir]: https://github.com/asdf-vm/asdf-elixir
+[elixir]: https://elixir-lang.org/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The wasmCloud Host Runtime is a server process that securely hosts and provides 
 
 This runtime is designed to take advantage of WebAssembly's small footprint, secure sandbox, speed, and portability to allow developers to write boilerplate-free code that embraces the [actor model](https://en.wikipedia.org/wiki/Actor_model) and abstracts away dependencies on [non-functional requirements](https://www.scaledagileframework.com/nonfunctional-requirements/) via well-defined [interfaces](https://github.com/wasmCloud/interfaces/).
 
-This host runtime is written in [Elixir][elixir] and extensively leverages the decades of work, testing, and improvements that have gone into the **OTP** framework. 
+This host runtime is written in [Elixir][elixir] and extensively leverages the decades of work, testing, and improvements that have gone into the **OTP** framework.
 There are a number of excellent Elixir and OTP references online, but we highly recommend starting with the [Pragmatic Programmers](https://pragprog.com/categories/elixir-phoenix-and-otp/) Elixir and OTP library of books.
 
 ## Getting started
@@ -48,7 +48,9 @@ All of wasmCloud's _lattice_ functionality requires the use of [NATS](https://na
 
 ### Pre-requisites
 
-- (optional) [`asdf`][asdf] with [`asdf-elixir`][asdf-elixir] for managing versions of [`elixir`][elixir] (see `.tool-versions`)
+- (optional) [`asdf`][asdf] with [`asdf-elixir`][asdf-elixir] for managing versions of your [`elixir`][elixir] toolchain (see `.tool-versions`)
+
+**NOTE** If you manage your Elixir toolchain manually, please make sure to use a version that matches the contents of `.tool-versions`.
 
 [asdf]: https://asdf-vm.com/
 [asdf-elixir]: https://github.com/asdf-vm/asdf-elixir


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Specify a version of `elixir` that should be used (via `asdf`'s support for `.tool-versions`)

## Related Issues
N/A

## Release Information
`next`

## Consumer Impact

Developers working with `wasmcloud-otp` should be using a consistent version of `elixir`'s toolchain.

## Testing

Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)

N/A

### Acceptance or Integration

N/A

### Manual Verification

Built locally, works on my machine :+1: