### PR TITLE
unpin from specific SHA of bindle

### DIFF
--- a/host_core/native/hostcore_wasmcloud_native/Cargo.lock
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.lock
@@ -146,19 +146,21 @@ checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
 
 [[package]]
 name = "bcrypt"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d70a6d9cd7179c1020c7f48512203ffe48cd1a442359e5f81881bf2cc165ac"
+checksum = "a7e7c93a3fb23b2fdde989b2c9ec4dd153063ec81f408507f84c090cd91c6641"
 dependencies = [
  "base64 0.13.1",
  "blowfish",
  "getrandom 0.2.8",
+ "zeroize",
 ]
 
 [[package]]
 name = "bindle"
-version = "0.8.0"
-source = "git+https://github.com/deislabs/bindle?rev=7a5f11ca9986837f8ee54e8d577204ec520b6764#7a5f11ca9986837f8ee54e8d577204ec520b6764"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e094a05735491445601e151b6094fbd48ecf2bd08fe7e0ccb036ce29a50230"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1222,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.8"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 dependencies = [
  "hashbrown",
 ]

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.toml
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.toml
@@ -28,8 +28,7 @@ once_cell = "1.2.0"
 chrono-humanize = "0.2.1"
 chrono = "0.4.19"
 tokio-stream = "0.1"
-# This should be replaced with a published version once bindle 0.9 is out
-bindle = { version = "0.8", git = "https://github.com/deislabs/bindle", rev = "7a5f11ca9986837f8ee54e8d577204ec520b6764", default-features = false, features = ["client", "caching", "rustls-tls"] }
+bindle = { version = "0.9", default-features = false, features = ["client", "caching", "rustls-tls"] }
 async-trait = "0.1"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 nats = "0.23.1"


### PR DESCRIPTION
## Feature or Problem
We've been pinned to a specific SHA of bindle because at the time v0.9 hadn't been released. It has now

## Related Issues
N/A

## Release Information
Next

## Consumer Impact
N/A

## Testing

### Manual Verification
I'll be honest, I didn't test this. Besides compiling, what should be done?