### PR TITLE
Add provider health status event

### DIFF
--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -395,6 +395,7 @@ defmodule HostCore.Providers.ProviderModule do
           %State{state | healthy: true}
 
         {:ok, _body} ->
+          publish_health_status(state)
           state
 
         {:error, _} ->
@@ -419,21 +420,18 @@ defmodule HostCore.Providers.ProviderModule do
     HostCore.Refmaps.Manager.put_refmap(host_id, lattice_prefix, oci, public_key)
   end
 
-  defp publish_health_passed(state) do
-    %{
-      public_key: state.public_key,
-      link_name: state.link_name
-    }
-    |> CloudEvent.new("health_check_passed", state.host_id)
-    |> CloudEvent.publish(state.lattice_prefix)
-  end
+  defp publish_health_status(state), do: publish_health_event(state, "health_check_status")
 
-  defp publish_health_failed(state) do
+  defp publish_health_passed(state), do: publish_health_event(state, "health_check_passed")
+
+  defp publish_health_failed(state), do: publish_health_event(state, "health_check_failed")
+
+  defp publish_health_event(state, type) do
     %{
       public_key: state.public_key,
       link_name: state.link_name
     }
-    |> CloudEvent.new("health_check_failed", state.host_id)
+    |> CloudEvent.new(type, state.host_id)
     |> CloudEvent.publish(state.lattice_prefix)
   end
 

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -426,12 +426,12 @@ defmodule HostCore.Providers.ProviderModule do
 
   defp publish_health_failed(state), do: publish_health_event(state, "health_check_failed")
 
-  defp publish_health_event(state, type) do
+  defp publish_health_event(state, evt) do
     %{
       public_key: state.public_key,
       link_name: state.link_name
     }
-    |> CloudEvent.new(type, state.host_id)
+    |> CloudEvent.new(evt, state.host_id)
     |> CloudEvent.publish(state.lattice_prefix)
   end
 

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -387,32 +387,24 @@ defmodule HostCore.Providers.ProviderModule do
           {:error, "Received no response on health check topic from provider"}
       end
 
-    # Only publish health check pass/fail when state changes
-    state =
+    new_state =
       case res do
         {:ok, _body} when not state.healthy ->
-          publish_health_passed(state)
           %State{state | healthy: true}
 
-        {:ok, _body} ->
-          publish_health_status(state)
-          state
+        {:error, _} when state.healthy ->
+          %State{state | healthy: false}
 
-        {:error, _} ->
-          if state.healthy do
-            publish_health_failed(state)
-            %State{state | healthy: false}
-          else
-            state
-          end
+        _ ->
+          state
       end
 
-    {:noreply, state}
+    publish_health_status(new_state, state.healthy)
+    {:noreply, new_state}
   end
 
   def handle_info({_ref, msg}, state) do
     Logger.debug(msg)
-
     {:noreply, state}
   end
 
@@ -420,11 +412,21 @@ defmodule HostCore.Providers.ProviderModule do
     HostCore.Refmaps.Manager.put_refmap(host_id, lattice_prefix, oci, public_key)
   end
 
-  defp publish_health_status(state), do: publish_health_event(state, "health_check_status")
+  defp publish_health_status(state, previous_health_check_passed) do
+    cond do
+      # publish health_passed if previous state was unhealthy and current state is healthy
+      state.healthy and not previous_health_check_passed ->
+        publish_health_event(state, "health_check_passed")
 
-  defp publish_health_passed(state), do: publish_health_event(state, "health_check_passed")
+      # publish health_failed if previous state was healthy and current state is unhealthy
+      not state.healthy and previous_health_check_passed ->
+        publish_health_event(state, "health_check_failed")
 
-  defp publish_health_failed(state), do: publish_health_event(state, "health_check_failed")
+      # publish health_status if state has not changed
+      true ->
+        publish_health_event(state, "health_check_status")
+    end
+  end
 
   defp publish_health_event(state, evt) do
     %{


### PR DESCRIPTION
## Feature or Problem
From the discussions of the following issues, providers should emit the health events on the `wasmbus.evt` topic.
Please let me know if I misunderstood what was being asked in those issues or if there is something missing.

## Related Issues
- #517 
- #519 

## Release Information
Next

## Consumer Impact
N/A

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux

### Unit Test(s)
I've added a test in test/host_core/provider_tests.exs to start a provider from file and wait on the health_check events. It first waits for the health_check_passed event when the provider is started and afterwards waits for the health_check_status event once, which is emitted every 30 seconds.

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
I've launched nats and subscribed to `wasmbus.evt.*` and to ">". 
I've used `make run` from the dashboard project and from the web page started a provider from file to checkout that the health_status event was being correctly sent.
