### PR TITLE
get & compile deps on cache hits

### DIFF
--- a/.github/workflows/host_core.yml
+++ b/.github/workflows/host_core.yml
@@ -94,12 +94,13 @@ jobs:
           path: host_core/priv/plts
           key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plts-${{ hashFiles('host_core/mix.exs', 'host_core/mix.lock') }}
       - name: Create PLTs
+        if: steps.plt-cache.outputs.cache-hit != 'true' && !startswith(matrix.os, 'windows')
         working-directory: ${{env.working-directory}}
-        if: steps.plt-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p priv/plts
           mix dialyzer --plt
       - name: Run dialyzer
+        if: ${{ !startswith(matrix.os, 'windows') }}
         working-directory: ${{env.working-directory}}
         run: mix dialyzer
 # Thank you https://hashrocket.com/blog/posts/build-the-ultimate-elixir-ci-with-github-actions for this action setup

--- a/.github/workflows/wasmcloud_host.yml
+++ b/.github/workflows/wasmcloud_host.yml
@@ -91,11 +91,12 @@ jobs:
           path: wasmcloud_host/priv/plts
           key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-plts-${{ hashFiles('wasmcloud_host/mix.exs', 'wasmcloud_host/mix.lock') }}
       - name: Create PLTs
+        if: steps.plt-cache.outputs.cache-hit != 'true' && !startswith(matrix.os, 'windows')
         working-directory: ${{env.working-directory}}
-        if: steps.plt-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p priv/plts
           mix dialyzer --plt
       - name: Run dialyzer
+        if: ${{ !startswith(matrix.os, 'windows') }}
         working-directory: ${{env.working-directory}}
         run: mix dialyzer


### PR DESCRIPTION
## Feature or Problem
We're seeing build failures when running dialyzer with cache hits. We suspect it's because the PLTs need to be created

Example failure: https://github.com/wasmCloud/wasmcloud-otp/actions/runs/4356483679/jobs/7614915759

## Related Issues
N/A

## Release Information
Next

## Consumer Impact
N/A

## Testing
Waiting to see if builds pass on this PR