### PR TITLE
revert to otp 24 for cross-built images as otp 25 fails under qemu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
       SECRET_KEY_BASE: ${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}
       app-name: wasmcloud_host
       arm-tarball: aarch64-linux.tar.gz
-      builder-image: hexpm/elixir:1.14.3-erlang-25.3-debian-bullseye-20230227-slim
+      builder-image: elixir:1.14.3-otp-24-slim
       release-image: debian:bullseye-slim
     steps:
       - uses: actions/checkout@v3

--- a/host_core/Makefile
+++ b/host_core/Makefile
@@ -13,20 +13,19 @@ deps: ## Fetch mix dependencies
 build: deps ## Compile host_core
 	mix compile
 
-# official hexpm elixir images
-# hub.docker.com/r/hexpm/elixir
 build-image: ## Compile host_core docker image
 	docker build \
-		--build-arg BUILDER_IMAGE=hexpm/elixir:1.14.3-erlang-25.3-alpine-3.17.2 \
-		--build-arg RELEASE_IMAGE=alpine:3.17.2  \
+		--build-arg BUILDER_IMAGE=elixir:1.14.3-alpine \
+		--build-arg RELEASE_IMAGE=alpine:3.17.2 \
 		--build-arg MIX_ENV=prod \
 		-t host_core:alpine \
 		.
 
+# erlang 24 until 25 stops segfaulting under qemu
 buildx-cross-image: ## Compile host_core docker image using buildx for amd64 and arm64
 	docker buildx build  \
-		--build-arg BUILDER_IMAGE=hexpm/elixir:1.14.3-erlang-25.3-alpine-3.17.2 \
-		--build-arg RELEASE_IMAGE=alpine:3.17.2  \
+		--build-arg BUILDER_IMAGE=elixir:1.14.3-otp-24-alpine \
+		--build-arg RELEASE_IMAGE=alpine:3.17.2 \
 		--build-arg MIX_ENV=prod \
 		-t host_core:alpine \
 		--platform linux/amd64,linux/arm64 \

--- a/wasmcloud_host/Makefile
+++ b/wasmcloud_host/Makefile
@@ -27,22 +27,21 @@ esbuild: ## Build frontend code that relies on esbuild
 build: deps ## Build wasmcloud_host for development
 	mix compile
 
-# official hexpm elixir images
-# hub.docker.com/r/hexpm/elixir
 build-image: build esbuild ## Compile wasmcloud_host docker image, requires local elixir toolchain since dart-sass doesn't work in arm64 environments
 	cd ../ && \
 	docker build $(BASE_ARGS) \
-		--build-arg BUILDER_IMAGE=hexpm/elixir:1.14.3-erlang-25.3-debian-bullseye-20230227-slim \
+		--build-arg BUILDER_IMAGE=elixir:1.14.3-slim \
 		--build-arg RELEASE_IMAGE=debian:bullseye-slim  \
 		--build-arg MIX_ENV=prod \
 		$(BASE_TAGS) \
 		-f $(DOCKERFILE) \
 		.
 
+# erlang 24 until 25 stops segfaulting under qemu
 buildx-cross-image: build esbuild ## Compile wasmcloud_host docker image using buildx for amd64 and arm64
 	cd ../ && \
 	docker buildx build $(BASE_ARGS) \
-		--build-arg BUILDER_IMAGE=hexpm/elixir:1.14.3-erlang-25.3-debian-bullseye-20230227-slim \
+		--build-arg BUILDER_IMAGE=elixir:1.14.3-otp-24-slim \
 		--build-arg RELEASE_IMAGE=debian:bullseye-slim \
 		--build-arg MIX_ENV=prod \
 		-t wasmcloud_host:slim \


### PR DESCRIPTION
natively built images can stay on otp 25

## Feature or Problem
release builds still broken for cross compilation

## Related Issues
https://github.com/erlef/docker-elixir/issues/61

## Release Information
0.61.0

## Consumer Impact
n/a (allows release to go forward)

## Testing
built using linux/amd64 host

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
n/a

### Acceptance or Integration
n/a

### Manual Verification
built on linux/amd64 host with `--platform linux/arm64`
