### PR TITLE
Compare OCI sha with disk cache sha before pulling an image

### DIFF
--- a/host_core/native/hostcore_wasmcloud_native/Cargo.lock
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.1.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bcrypt"
@@ -902,6 +902,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +925,7 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "data-encoding",
+ "hex",
  "lazy_static",
  "nats",
  "nkeys",
@@ -932,6 +939,7 @@ dependencies = [
  "rustler",
  "serde",
  "serde_bytes",
+ "sha2 0.10.6",
  "tokio",
  "tokio-stream",
  "uuid",
@@ -1545,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e93a3b1cc0510b03020f33f21e62acdde3dcaef432edc95bea377fbd4c2cd4"
+checksum = "8f22eb0e3c593294a99e9ff4b24cf6b752d43f193aa4415fe5077c159996d497"
 dependencies = [
  "base64ct",
 ]

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.lock
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.lock
@@ -902,12 +902,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,7 +919,6 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "data-encoding",
- "hex",
  "lazy_static",
  "nats",
  "nkeys",
@@ -939,7 +932,6 @@ dependencies = [
  "rustler",
  "serde",
  "serde_bytes",
- "sha2 0.10.6",
  "tokio",
  "tokio-stream",
  "uuid",

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.toml
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.toml
@@ -32,3 +32,5 @@ bindle = { version = "0.9", default-features = false, features = ["client", "cac
 async-trait = "0.1"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 nats = "0.23.1"
+sha2 = "0.10.6"
+hex = "0.4.3"

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.toml
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.toml
@@ -32,5 +32,3 @@ bindle = { version = "0.9", default-features = false, features = ["client", "cac
 async-trait = "0.1"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 nats = "0.23.1"
-sha2 = "0.10.6"
-hex = "0.4.3"

--- a/host_core/native/hostcore_wasmcloud_native/src/oci.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/oci.rs
@@ -1,12 +1,9 @@
-use oci_distribution::manifest::OciManifest;
-use oci_distribution::secrets::RegistryAuth;
-use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::env::{temp_dir, var};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use tokio::fs::File;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use oci_distribution::secrets::RegistryAuth;
+use tokio::io::AsyncWriteExt;
 
 pub(crate) const OCI_VAR_REGISTRY: &str = "OCI_REGISTRY";
 pub(crate) const OCI_VAR_USER: &str = "OCI_REGISTRY_USER";
@@ -51,7 +48,8 @@ pub(crate) async fn fetch_oci_path(
         return Err(
             "Fetching images tagged 'latest' is currently prohibited in this host. This option can be overridden with WASMCLOUD_OCI_ALLOW_LATEST".into());
     }
-    let cf = get_cached_file_path(img).await?;
+    let cache_file = get_cached_filepath(img).await?;
+    let digest_file = get_digest_filepath(img).await?;
 
     let auth = determine_auth(img, creds_override);
     let img = oci_distribution::Reference::from_str(img)?;
@@ -64,11 +62,11 @@ pub(crate) async fn fetch_oci_path(
     let mut c = oci_distribution::Client::new(config);
 
     // In case of a cache miss where the file does not exist, pull a fresh OCI Image
-    if tokio::fs::metadata(&cf).await.is_err() {
+    if tokio::fs::metadata(&cache_file).await.is_err() {
         let imgdata = pull(&mut c, &img, &auth).await;
         match imgdata {
             Ok(imgdata) => {
-                cache_oci_image(&imgdata, &cf).await?;
+                cache_oci_image(imgdata, &cache_file, digest_file).await?;
             }
             Err(e) => return Err(format!("Failed to fetch OCI bytes: {}", e).into()),
         }
@@ -76,34 +74,18 @@ pub(crate) async fn fetch_oci_path(
         let manifest = c.pull_manifest(&img, &auth).await;
         match manifest {
             Ok(manifest) => {
-                let (oci_manifest, _) = manifest;
-                if let OciManifest::Image(image_manifest) = oci_manifest {
-                    let layers = image_manifest.layers;
-                    if layers.is_empty() {
-                        return Err(
-                            format!("Failed to fetch OCI bytes: Empty manifest layers").into()
-                        );
-                    }
-                    // The digest will be string like sha256:asdf, and the first 7 characters are removed
-                    let oci_sha = &layers[0].digest.trim_start_matches("sha256:");
-                    let oci_sha_bytes: Vec<u8> = hex::decode(oci_sha).expect("Invalid Hex String");
-
-                    let mut cache_file = File::open(cf.clone()).await?;
-                    let mut cache_contents = Vec::new();
-                    cache_file.read_to_end(&mut cache_contents).await?;
-                    let cache_sha = Sha256::digest(cache_contents);
-                    
-                    // compare the OCI digest with the cache file hash and pull the OCI image in case of a mismatch
-                    if oci_sha_bytes[..] != cache_sha[..] {
-                        let imgdata = pull(&mut c, &img, &auth).await;
-                        match imgdata {
-                            Ok(imgdata) => {
-                                cache_oci_image(&imgdata, &cf).await?;
-                            }
-                            Err(e) => {
-                                return Err(format!("Failed to fetch OCI bytes: {}", e).into())
-                            }
+                let (_, oci_digest) = manifest;
+                // If the digest file doesn't exist that is ok, we just unwrap to an empty string
+                let file_digest = tokio::fs::read_to_string(&digest_file)
+                    .await
+                    .unwrap_or_default();
+                if oci_digest.is_empty() || file_digest.is_empty() || file_digest != oci_digest {
+                    let imgdata = pull(&mut c, &img, &auth).await;
+                    match imgdata {
+                        Ok(imgdata) => {
+                            cache_oci_image(imgdata, &cache_file, digest_file).await?;
                         }
+                        Err(e) => return Err(format!("Failed to fetch OCI bytes: {}", e).into()),
                     }
                 }
             }
@@ -111,20 +93,32 @@ pub(crate) async fn fetch_oci_path(
         }
     }
 
-    Ok(cf)
+    Ok(cache_file)
 }
 
-async fn get_cached_file_path(img: &str) -> std::io::Result<PathBuf> {
+async fn get_cached_filepath(img: &str) -> std::io::Result<PathBuf> {
+    let mut path = create_filepath(img).await?;
+    path.set_extension("bin");
+
+    Ok(path)
+}
+
+async fn get_digest_filepath(img: &str) -> std::io::Result<PathBuf> {
+    let mut path = create_filepath(img).await?;
+    path.set_extension("digest");
+
+    Ok(path)
+}
+
+async fn create_filepath(img: &str) -> std::io::Result<PathBuf> {
     let path = temp_dir();
     let path = path.join("wasmcloud_ocicache");
     ::tokio::fs::create_dir_all(&path).await?;
-    // should produce a file like wasmcloud_azurecr_io_kvcounter_v1.bin
+    // should produce a file like wasmcloud_azurecr_io_kvcounter_v1
     let img = img.replace(':', "_");
     let img = img.replace('/', "_");
     let img = img.replace('.', "_");
-    let mut path = path.join(img);
-    path.set_extension("bin");
-
+    let path = path.join(img);
     Ok(path)
 }
 
@@ -147,17 +141,22 @@ async fn pull(
 }
 
 async fn cache_oci_image(
-    imgdata: &oci_distribution::client::ImageData,
-    cache_filepath: &PathBuf,
+    image: oci_distribution::client::ImageData,
+    cache_filepath: impl AsRef<Path>,
+    digest_filepath: impl AsRef<Path>,
 ) -> ::std::io::Result<()> {
-    let mut f = tokio::fs::File::create(&cache_filepath).await?;
-    let content = imgdata
+    let mut cache_file = tokio::fs::File::create(cache_filepath).await?;
+    let content = image
         .layers
-        .clone()
         .into_iter()
         .flat_map(|l| l.data)
         .collect::<Vec<_>>();
-    f.write_all(&content).await?;
-    f.flush().await?;
+    cache_file.write_all(&content).await?;
+    cache_file.flush().await?;
+    if let Some(digest) = image.digest {
+        let mut digest_file = tokio::fs::File::create(digest_filepath).await?;
+        digest_file.write_all(digest.as_bytes()).await?;
+        digest_file.flush().await?;
+    }
     Ok(())
 }


### PR DESCRIPTION
## Feature or Problem
When fetching an OCI image, the code checked whether a cache existed and pulled the image if it did not exist.
Now it checks the cache file she with the latest oci image she to verify whether the latest image is cached and pulls if the she digest does not match.

## Related Issues
NA

## Release Information
next

## Consumer Impact
Users will have no breaking changes. 

## Testing
Manual testing was performed using the nif since unit tests are not supported yet. End to end tests can be added as future work.



<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
Manual unit tests were performed. Following is a log showing a sha digest match on 3 cache files resulting in no additional image pulls.

```
..cache file: "/var/folders/k6/7fp1nc5s7w1987jh7vzpnyn40000gn/T/wasmcloud_ocicache/wasmcloud_azurecr_io_echo_0_3_1.bin" 
oci image: Reference { registry: "wasmcloud.azurecr.io", repository: "echo", tag: Some("0.3.1"), digest: None } 
OCI digest: [109, 8, 23, 54, 89, 105, 252, 166, 166, 139, 200, 184, 80, 191, 212, 68, 48, 192, 232, 180, 191, 115, 141, 176, 201, 169, 227, 234, 80, 144, 79, 197] 
cache file sha: [109, 8, 23, 54, 89, 105, 252, 166, 166, 139, 200, 184, 80, 191, 212, 68, 48, 192, 232, 180, 191, 115, 141, 176, 201, 169, 227, 234, 80, 144, 79, 197] 
MATCH!!!!

..cache file: "/var/folders/k6/7fp1nc5s7w1987jh7vzpnyn40000gn/T/wasmcloud_ocicache/wasmcloud_azurecr_io_echo_0_3_1.bin" 
oci image: Reference { registry: "wasmcloud.azurecr.io", repository: "echo", tag: Some("0.3.1"), digest: None } 
OCI digest: [109, 8, 23, 54, 89, 105, 252, 166, 166, 139, 200, 184, 80, 191, 212, 68, 48, 192, 232, 180, 191, 115, 141, 176, 201, 169, 227, 234, 80, 144, 79, 197] 
cache file sha: [109, 8, 23, 54, 89, 105, 252, 166, 166, 139, 200, 184, 80, 191, 212, 68, 48, 192, 232, 180, 191, 115, 141, 176, 201, 169, 227, 234, 80, 144, 79, 197] 
MATCH!!!!

cache file: "/var/folders/k6/7fp1nc5s7w1987jh7vzpnyn40000gn/T/wasmcloud_ocicache/wasmcloud_azurecr_io_httpserver_0_14_0.bin" 
oci image: Reference { registry: "wasmcloud.azurecr.io", repository: "httpserver", tag: Some("0.14.0"), digest: None } 
OCI digest: [79, 231, 157, 100, 0, 141, 55, 210, 159, 204, 234, 250, 180, 55, 182, 136, 58, 57, 26, 209, 103, 109, 251, 19, 21, 29, 51, 120, 160, 23, 203, 241] 
cache file sha: [79, 231, 157, 100, 0, 141, 55, 210, 159, 204, 234, 250, 180, 55, 182, 136, 58, 57, 26, 209, 103, 109, 251, 19, 21, 29, 51, 120, 160, 23, 203, 241] 
MATCH!!!!
```

### Acceptance or Integration
NA

### Manual Verification
Manual verification described above.
