### PR TITLE
changes to get static builds were not quite ready yet for cross

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,7 +347,7 @@ jobs:
           push: false
           context: .
           file: Dockerfile.localstatic
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64 #,linux/arm64
           tags: |
             localstatic
       - name: Build and release static docker image
@@ -372,9 +372,9 @@ jobs:
           docker run --rm --platform linux/arm64/v8 -iv ${PWD}:/aarch64temp wasmcloud/${{ env.app-name }}:${{ env.app-version }} sh -s <<EOF
           tar -czvf ${{ env.arm-tarball }} bin erts-*/ lib/ releases/
           cp ${{ env.arm-tarball }} /aarch64temp/
-          docker run --rm --platform linux/arm64/v8 -iv ${PWD}:/aarch64temp wasmcloud/${{ env.app-name }}:${{ env.app-version }} sh -s <<EOF
-          tar czvf ${{ env.arm-tarball-static }} /usr/local/bin/wasmcloud_host 
-          cp ${{ env.arm-tarball-static }} /aarch64temp/
+          # docker run --rm --platform linux/arm64/v8 -iv ${PWD}:/aarch64temp wasmcloud/${{ env.app-name }}:${{ env.app-version }} sh -s <<EOF
+          # tar czvf ${{ env.arm-tarball-static }} /usr/local/bin/wasmcloud_host
+          # cp ${{ env.arm-tarball-static }} /aarch64temp/
           docker run --rm --platform linux/amd64 -iv ${PWD}:/amd64temp wasmcloud/${{ env.app-name }}:${{ env.app-version }} sh -s <<EOF
           tar czvf ${{ env.amd-tarball-static }} /usr/local/bin/wasmcloud_host
           cp ${{ env.amd-tarball-static }} /amd64temp/
@@ -384,11 +384,11 @@ jobs:
         with:
           name: ${{ env.arm-tarball }}
           path: ${{ env.arm-tarball }}
-      - name: Upload artifact (arm64 static)
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.arm-tarball-static }}
-          path: ${{ env.arm-tarball-static }}
+      # - name: Upload artifact (arm64 static)
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: ${{ env.arm-tarball-static }}
+      #     path: ${{ env.arm-tarball-static }}
       - name: Upload artifact (amd64 static)
         uses: actions/upload-artifact@v2
         with:

--- a/wasmcloud_host/Makefile
+++ b/wasmcloud_host/Makefile
@@ -11,6 +11,7 @@ SECRET_KEY_BASE ?= $(shell mix phx.gen.secret)
 
 BASE_ARGS ?= --build-arg APP_NAME=$(NAME) --build-arg APP_VSN=$(VERSION) --build-arg SECRET_KEY_BASE=$(SECRET_KEY_BASE) --build-arg SKIP_PHOENIX=$(SKIP_PHOENIX)
 BASE_TAGS ?= -t $(NAME):$(VERSION)-$(BUILD) -t $(NAME):$(TAG)
+BASE_TAGS_STATIC ?= -t $(NAME):$(VERSION)-$(BUILD)-static -t $(NAME):$(TAG)-static
 
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_\-.*]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -43,7 +44,7 @@ build-image-static: build esbuild ## build statically compiled docker image
 	&& docker build -f Dockerfile.localstatic -t localstatic . \
 	&& docker build $(BASE_ARGS) \
 		--build-arg MIX_ENV=prod \
-		$(BASE_TAGS) \
+		$(BASE_TAGS_STATIC) \
 		-f $(DOCKERFILESTATIC) \
 		.
 


### PR DESCRIPTION
compilation so we will comment them out for now... amd64 is ok

## Feature or Problem
remove static arm64 releases for now since cross-compiling is error prone

## Related Issues
#572 and #570 

## Release Information
next

## Consumer Impact
amd64 static releases pass

## Testing
locally

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
n/a

### Acceptance or Integration
n/a

### Manual Verification
locally built
