### PR TITLE
need to push static image build in case build gets scheduled on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,12 +344,12 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           builder: ${{ steps.buildx-builder.outputs.name }}
-          push: false
+          push: true
           context: .
           file: Dockerfile.localstatic
           platforms: linux/amd64 #,linux/arm64
           tags: |
-            localstatic
+            wasmcloud.azurecr.io/wasmcloud_static_base:${{ env.app-version }}
       - name: Build and release static docker image
         uses: docker/build-push-action@v3
         with:
@@ -357,8 +357,9 @@ jobs:
           push: true
           context: .
           file: ${{ env.app-name }}/Dockerfile.static
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64 #,linux/arm64
           build-args: |
+            BASEIMAGE=wasmcloud.azurecr.io/wasmcloud_static_base:${{ env.app-version }}
             APP_NAME=${{ env.app-name }}
             APP_VSN=${{ env.app-version }}
             SECRET_KEY_BASE=${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}

--- a/host_core/Dockerfile.static
+++ b/host_core/Dockerfile.static
@@ -1,7 +1,8 @@
 # we use a common Dockerfile with statically compiled erlang+openssl
 # the Makefile handles this for you
 # ../Dockerfile.localstatic
-FROM localstatic
+ARG BASEIMAGE=localstatic
+FROM BASEIMAGE
 COPY ./host_core /opt/app/host_core
 
 WORKDIR /opt/app/host_core

--- a/wasmcloud_host/Dockerfile.static
+++ b/wasmcloud_host/Dockerfile.static
@@ -1,7 +1,8 @@
 # we use a common Dockerfile with statically compiled erlang+openssl
 # the Makefile handles this for you
 # ../Dockerfile.localstatic
-FROM localstatic
+ARG BASEIMAGE=localstatic
+FROM BASEIMAGE
 
 COPY ./host_core /opt/app/host_core
 COPY ./wasmcloud_host /opt/app/wasmcloud_host


### PR DESCRIPTION
different node. also might be helpful if we ever need to figure out what was in a static build image base

## Feature or Problem
broken release

## Related Issues
#570
#572 

## Release Information
next

## Consumer Impact
n/a

## Testing
can't test outside GH actions unfortunately

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
n/a

### Acceptance or Integration
soon

### Manual Verification
n/a
