### PR TITLE
small mistake in Dockerfile.static FROM definition

### DIFF
--- a/host_core/Dockerfile.static
+++ b/host_core/Dockerfile.static
@@ -2,7 +2,7 @@
 # the Makefile handles this for you
 # ../Dockerfile.localstatic
 ARG BASEIMAGE=localstatic
-FROM BASEIMAGE
+FROM ${BASEIMAGE}
 COPY ./host_core /opt/app/host_core
 
 WORKDIR /opt/app/host_core

--- a/wasmcloud_host/Dockerfile.static
+++ b/wasmcloud_host/Dockerfile.static
@@ -2,7 +2,7 @@
 # the Makefile handles this for you
 # ../Dockerfile.localstatic
 ARG BASEIMAGE=localstatic
-FROM BASEIMAGE
+FROM ${BASEIMAGE}
 
 COPY ./host_core /opt/app/host_core
 COPY ./wasmcloud_host /opt/app/wasmcloud_host


### PR DESCRIPTION
## Feature or Problem
Dockerfile.static issues

## Related Issues
n/a

## Release Information
next

## Consumer Impact
fix release build

## Testing
ran `make build-image-static` locally

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
n/a

### Acceptance or Integration
n/a

### Manual Verification
`make build-image-static`
