### PR TITLE
add provider contract ID to health check events

### DIFF
--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -431,6 +431,7 @@ defmodule HostCore.Providers.ProviderModule do
   defp publish_health_event(state, evt) do
     %{
       public_key: state.public_key,
+      contract_id: state.contract_id,
       link_name: state.link_name
     }
     |> CloudEvent.new(evt, state.host_id)


### PR DESCRIPTION
## Feature or Problem
Host heartbeats include the contract ID on providers, but the provider health check events do not. This adds the contract ID to health check events

## Related Issues
N/A

## Release Information
Next

## Consumer Impact
Downstream consumers (e.g. wadm, lattice observer) can consume the contract ID on provider health events now

## Testing

### Manual Verification
I started a host, started a provider, and waited for health check events:

```
{"data":{"contract_id":"wasmcloud:httpserver","link_name":"default","public_key":"VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M"},"datacontenttype":"application/json","id":"1921d01d-e9d9-4092-bd2e-2a5fafff1a99","source":"NBXBB5KSNH6MPK5ZRNDUDTHBAPKGZTERVSW6UDH4NKOJPNJRXCPVN5KA","specversion":"1.0","time":"2023-03-20T20:45:14.903196Z","type":"com.wasmcloud.lattice.health_check_passed"}
```

```
{"data":{"contract_id":"wasmcloud:httpserver","link_name":"default","public_key":"VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M"},"datacontenttype":"application/json","id":"650b5ae9-875d-466b-b3c8-7929bf80795f","source":"NBXBB5KSNH6MPK5ZRNDUDTHBAPKGZTERVSW6UDH4NKOJPNJRXCPVN5KA","specversion":"1.0","time":"2023-03-20T20:45:39.917511Z","type":"com.wasmcloud.lattice.health_check_status"}
```