### PR TITLE
Bumped mix.exs in wasmcloud_host and chart

### DIFF
--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 
 version: 0.6.10
 
-appVersion: "0.61.0"
+appVersion: "0.62.0"

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.61.0"
+  @app_vsn "0.62.0"
 
   def project do
     [


### PR DESCRIPTION
Simply bumping the release versions for wasmcloud_host to match host_core before cutting the first RC