### PR TITLE
derive version from GITHUB_REF rather than mix.exs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Determine version
-        run: echo "app-version=${GITHUB_REF#refs/tags/}" > $GITHUB_ENV
+        run: echo "app-version=$GITHUB_REF_NAME" > $GITHUB_ENV
 
       # Compile phoenix assets for wasmcloud_host outside of image (dart-sass doesn't support arm linux)
       - name: Install erlang and elixir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Determine version
-        run: echo "app-version=$(grep '@app_vsn "' ${{env.working-directory}}/mix.exs | cut -d '"' -f2)" > $GITHUB_ENV
+        run: echo "app-version=${GITHUB_REF#refs/tags/}" > $GITHUB_ENV
 
       # Compile phoenix assets for wasmcloud_host outside of image (dart-sass doesn't support arm linux)
       - name: Install erlang and elixir


### PR DESCRIPTION
## Feature or Problem
We currently derive `app-version` from mix.exs. This works for "real" releases, but not for RCs or other test tags. Instead we should derive `app-version` from the tag name. This should be accessible via `GITHUB_REF`, after we trim the leading `/refs/tags/`

(Bash & GHA experts should double-check this syntax. I'm not confident in it)
