### PR TITLE
correct key for provider link name in supp config during vhost autostarts

### DIFF
--- a/host_core/lib/host_core/vhost/virtual_host.ex
+++ b/host_core/lib/host_core/vhost/virtual_host.ex
@@ -561,7 +561,7 @@ defmodule HostCore.Vhost.VirtualHost do
       ProviderSupervisor.start_provider_from_ref(
         state.config.host_key,
         prov["imageReference"],
-        prov["linkeName"]
+        prov["linkName"]
       )
     end
   end


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Typo in provider link name key of virtual host auto-starts config introduced [here](https://github.com/wasmCloud/wasmcloud-otp/commit/724605a2e10b619c454800947b7938a3a1a837dc#diff-d4745423f0f8ec260efa51ead41d1be18ecc4edc5b2534072816391a6d7b0780R543):
`linkeName` -> `linkName`
Presumably this would fail to supply the configured link name to the auto-started provider.
## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
Commented on in the original PR [here](https://github.com/wasmCloud/wasmcloud-otp/pull/529#issuecomment-1481987232)
## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->
`next`
## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->
No changes required from dependents.
## Testing
<!---
Declare the testing information for this pull request
--->
Test suite did not exercise the code in question.
<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s):
Whatever `make test` builds with docker.

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s):
Untested

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
None