### PR TITLE
Fix native NIF compilation with cross for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,13 @@ jobs:
       working-directory: ./host_core/native/hostcore_wasmcloud_native
       artifact-name: hostcore_wasmcloud_native
     strategy:
+      fail-fast: false
       matrix:
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
-          - aarch64-unknown-linux-gnu
+          # https://github.com/wasmCloud/wasmcloud-otp/issues/589
+          # - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl
           - x86_64-apple-darwin
           - x86_64-pc-windows-gnu
@@ -256,7 +258,6 @@ jobs:
   # So, sorry about the code duplication, perhaps in the future we'll find a way to make this happen
   release-wasmcloud-docker:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
-    needs: compile-native-nif
     name: Release Image (wasmcloud_host)
     runs-on: ubuntu-22.04
     env:
@@ -293,17 +294,6 @@ jobs:
         run: |
           make esbuild
 
-      # Download the NIF in the path that Docker expects for x86
-      - uses: actions/download-artifact@v3
-        with:
-          path: ./host_core/priv/built/x86_64
-          name: x86_64-unknown-linux-gnu
-      # Download the NIF in the path that Docker expects for aarch64
-      - uses: actions/download-artifact@v3
-        with:
-          path: ./host_core/priv/built/aarch64
-          name: aarch64-unknown-linux-gnu
-
       - name: Login to AzureCR
         uses: azure/docker-login@v1
         with:
@@ -336,8 +326,8 @@ jobs:
             SECRET_KEY_BASE=${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}
             MIX_ENV=release_prod
           tags: |
-            wasmcloud.azurecr.io/${{ env.app-name }}:${{ env.app-version }}
             wasmcloud.azurecr.io/${{ env.app-name }}:latest
+            wasmcloud.azurecr.io/${{ env.app-name }}:${{ env.app-version }}
             wasmcloud/${{ env.app-name }}:${{ env.app-version }}
             wasmcloud/${{ env.app-name }}:latest
       - name: Build common static image

--- a/wasmcloud_host/Dockerfile
+++ b/wasmcloud_host/Dockerfile
@@ -81,10 +81,6 @@ RUN apt update && \
 RUN mix local.rebar --force && \
   mix local.hex --force
 
-# Grab platform-specific NIF if building with release_prod, otherwise install rust for building the NIF manually
-RUN if [ "$MIX_ENV" = "release_prod" ] ; then cp ./host_core/priv/built/`uname -m`/libhostcore_wasmcloud_native.so ./host_core/priv/built/libhostcore_wasmcloud_native.so ; else curl https://sh.rustup.rs -sSf | bash -s -- -y ; fi
-# Ensure intermediate artifacts don't get bundled into the final release
-RUN rm -rf host_core/priv/built/aarch64 host_core/priv/built/x86_64 host_core/priv/native
 # Set PATH to include Rust toolchain
 ENV PATH="/root/.cargo/bin:${PATH}"
 


### PR DESCRIPTION
As of the latest attempted release, something about `cross` trying to use Rust nightly to build our native NIF fails. This PR resolves the issues by moving the NIF builds inside of the Docker image for both aarch64/x86 linux, which arguably keeps this simpler.

## Feature or Problem
Related to #589, this is a temporary workaround to simplify the CI and avoid the failure

## Related Issues
#589 is the issue, that this doesn't quite fix but works around

## Release Information
v0.62.0

## Consumer Impact
No change, even if you built the image locally you build inside the docker image so this is just making the process the same everywhere.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Manual Verification
I built the image locally!
