### PR TITLE
Bumping the version of wascap to the newest

### DIFF
--- a/host_core/native/hostcore_wasmcloud_native/Cargo.lock
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.lock
@@ -1600,7 +1600,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "uuid",
- "wascap 0.10.0",
+ "wascap 0.10.1",
  "wasmcloud",
 ]
 
@@ -3985,9 +3985,9 @@ dependencies = [
 
 [[package]]
 name = "wascap"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d4cb21a92b02469a7586135a2f52753815ff8599992744de5a9e7db54873b3"
+checksum = "f3a85c9ab66dd6a39400cc7235b803c8819c3b76405bce83f8e6c540a8abf89a"
 dependencies = [
  "base64 0.13.1",
  "data-encoding",
@@ -4272,7 +4272,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "wascap 0.10.0",
+ "wascap 0.10.1",
  "wasi-cap-std-sync 0.0.0",
  "wasi-common 0.0.0",
  "wasmbus-rpc",

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.toml
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.toml
@@ -18,7 +18,7 @@ serde = {version = "1.0.126", features = ["derive"] }
 serde_bytes = "0.11.5"
 nkeys = "0.2.0"
 futures = "0.3.27"
-wascap = "0.10.0"
+wascap = "0.10.1"
 ring = "0.16.20"
 rand = "0.8.5"
 log = "0.4.17"


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Version 0.10.0 of wascap doesn't properly validate the hashes of modules signed with wascap versions 0.9.0 through 0.10.0. The 0.10.1 version fixes this

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
N/A

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->
Next (0.62.0)

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->
Without this, wasmCloud host will reject wasm modules signed by 0.9.0/0.10.0 of wascap, breaking functionality

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->
N/A

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
Tested this manually with a number of different modules, including old ones and ones signed with 0.9.0
