### PR TITLE
Adding support for builtin providers and deferring builtin logging to the OTP host

### DIFF
--- a/host_core/lib/host_core/wasmcloud/rpc_invocations.ex
+++ b/host_core/lib/host_core/wasmcloud/rpc_invocations.ex
@@ -13,6 +13,9 @@ defmodule HostCore.WasmCloud.RpcInvocations do
   @chunk_rpc_timeout 15_000
   @rpc_event_prefix "wasmbus.rpcevt"
 
+  @wasmcloud_logging "wasmcloud:builtin:logging"
+  @wasmcloud_numbergen "wasmcloud:builtin:numbergen"
+
   # TARGET
 
   def identify_target(token) do
@@ -79,9 +82,6 @@ defmodule HostCore.WasmCloud.RpcInvocations do
   end
 
   # LINKS
-
-  # Built-in Providers do not have link definitions
-  # their implementations are already handled either in the NIF or in wasmCloud runtime
 
   # default behavior is to allow actor-to-actor calls
   def verify_link(%{target: {:actor, _, _}} = token) do

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.lock
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.lock
@@ -1581,7 +1581,6 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "data-encoding",
- "env_logger 0.10.0",
  "futures",
  "lazy_static",
  "log",

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.lock
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.lock
@@ -1581,6 +1581,7 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "data-encoding",
+ "env_logger 0.10.0",
  "futures",
  "lazy_static",
  "log",

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.toml
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.toml
@@ -37,4 +37,4 @@ bindle = { version = "0.9", default-features = false, features = ["client", "cac
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 nats = "0.24.0"
 anyhow = "1.0.69"
-
+env_logger = "0.10.0"

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.toml
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.toml
@@ -37,4 +37,3 @@ bindle = { version = "0.9", default-features = false, features = ["client", "cac
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 nats = "0.24.0"
 anyhow = "1.0.69"
-env_logger = "0.10.0"

--- a/host_core/native/hostcore_wasmcloud_native/src/atoms.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/atoms.rs
@@ -21,5 +21,7 @@ rustler::atoms! {
 
     // calls to erlang processes
     returned_function_call,
-    invoke_callback
+    invoke_callback,
+
+    perform_actor_log,
 }

--- a/host_core/native/hostcore_wasmcloud_native/src/environment.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/environment.rs
@@ -1,9 +1,6 @@
 use std::sync::{Condvar, Mutex};
 
-use rustler::{
-    resource::ResourceArc, types::tuple, Atom, Binary, Encoder, Env, Error, ListIterator,
-    MapIterator, OwnedEnv, Term,
-};
+use rustler::Env;
 
 pub struct CallbackTokenResource {
     pub token: CallbackToken,

--- a/host_core/native/hostcore_wasmcloud_native/src/lib.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/lib.rs
@@ -42,14 +42,6 @@ static TOKIO: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
         .expect("Failed to start tokio runtime")
 });
 
-pub(crate) fn spawn<T>(task: T) -> JoinHandle<T::Output>
-where
-    T: Future + Send + 'static,
-    T::Output: Send + 'static,
-{
-    TOKIO.spawn(task)
-}
-
 const CHONKY_THRESHOLD_BYTES: usize = 1024 * 700; // 700KB
 
 pub(crate) const CORELABEL_ARCH: &str = "hostcore.arch";

--- a/host_core/native/hostcore_wasmcloud_native/src/wasmruntime.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/wasmruntime.rs
@@ -2,7 +2,6 @@ use anyhow::{self, bail, Context};
 use async_trait::async_trait;
 use log::{error, trace};
 use rand::{thread_rng, Rng, RngCore};
-use serde::Serialize;
 
 use crate::{environment::CallbackToken, TOKIO};
 use rustler::{
@@ -172,10 +171,6 @@ pub fn new<'a>(
     env: rustler::Env<'a>,
     ExRuntimeConfig { host_id }: ExRuntimeConfig,
 ) -> Result<ResourceArc<RuntimeResource>, rustler::Error> {
-    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
-        .format_timestamp(None)
-        .try_init();
-
     let handler: Box<dyn Handle<capability::Invocation>> = Box::new(ElixirHandler {
         pid: env.pid(),
         host_id,

--- a/host_core/test/host_core/actors_test.exs
+++ b/host_core/test/host_core/actors_test.exs
@@ -166,7 +166,14 @@ defmodule HostCore.ActorsTest do
           }
         )
 
-      :ok = wait_for_actor_start(evt_watcher, @kvcounter_unpriv_key)
+      # await one start for each of the 5 instances being started
+      :ok =
+        HostCoreTest.EventWatcher.wait_for_event(
+          evt_watcher,
+          :actor_started,
+          %{"public_key" => @kvcounter_unpriv_key},
+          5
+        )
 
       actors = ActorSupervisor.all_actors(config.host_key)
       kv_counters = Map.get(actors, @kvcounter_unpriv_key)


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Version 0.62 does not currently emit any information when actors log using the builtin capability provider. This adds that support back in a way that is compatible with previous hosts.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
This supercedes @rvolosatovs 's PR #591 because, in all honesty, I couldn't figure out how to make a PR off of his PR and didn't have rights to force push to his PR

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->
0.62

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->
All deployments of wasmCloud relying on actor log emissions with or without structured host logging.

## Testing
<!---
Declare the testing information for this pull request
--->
There is an explicit actor test for performing logging and random number generation to exercise the builtins

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->
` test/host_core/actors_test.exs:639` is the test that exercises builtins (including logging). This test passes and produces the expected output in stdout.

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
Manually verified this works as well as unit tested using the "rando logger" actor.

Log emissions look as follows:
```
14:21:41.872 [debug] actor_id=MCLOGOFFRJ4WK5XC6Z6WM7A3SAVHPHKDAVG6OMZVOOC6RQCN5IOKPTQL [MCLOGOFFRJ4WK5XC6Z6WM7A3SAVHPHKDAVG6OMZVOOC6RQCN5IOKPTQL] a debug!
14:21:41.872 [info] actor_id=MCLOGOFFRJ4WK5XC6Z6WM7A3SAVHPHKDAVG6OMZVOOC6RQCN5IOKPTQL [MCLOGOFFRJ4WK5XC6Z6WM7A3SAVHPHKDAVG6OMZVOOC6RQCN5IOKPTQL] an info!
14:21:41.872 [warning] actor_id=MCLOGOFFRJ4WK5XC6Z6WM7A3SAVHPHKDAVG6OMZVOOC6RQCN5IOKPTQL [MCLOGOFFRJ4WK5XC6Z6WM7A3SAVHPHKDAVG6OMZVOOC6RQCN5IOKPTQL] a warn!
14:21:41.872 [error] actor_id=MCLOGOFFRJ4WK5XC6Z6WM7A3SAVHPHKDAVG6OMZVOOC6RQCN5IOKPTQL [MCLOGOFFRJ4WK5XC6Z6WM7A3SAVHPHKDAVG6OMZVOOC6RQCN5IOKPTQL] an error!
14:21:41.872 [info] actor_id=MCLOGOFFRJ4WK5XC6Z6WM7A3SAVHPHKDAVG6OMZVOOC6RQCN5IOKPTQL [MCLOGOFFRJ4WK5XC6Z6WM7A3SAVHPHKDAVG6OMZVOOC6RQCN5IOKPTQL] a manual info!
```
