### PR TITLE
Corrected workspace path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,6 @@
 			}
 		}
 	},
-	"workspaceMount": "source=${localWorkspaceFolder},target=/wash,type=bind,consistency=cached",
+	"workspaceMount": "source=${localWorkspaceFolder},target=/wasmcloud-otp,type=bind,consistency=cached",
 	"workspaceFolder": "/wasmcloud-otp"
 }


### PR DESCRIPTION
## Feature or Problem
This PR simply fixes a small issue I found when trying out our codespace, little copy/paste fail from the wash codespace.

## Related Issues
N/A

## Release Information
N/A

## Consumer Impact
Folks won't have to select the `wash` workspace manually

## Testing
Made sure it worked in the branch 

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [x] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [x] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
