### PR TITLE
fix(ci): docker build

### DIFF
--- a/wasmcloud_host/Dockerfile
+++ b/wasmcloud_host/Dockerfile
@@ -81,8 +81,19 @@ RUN apt update && \
 RUN mix local.rebar --force && \
   mix local.hex --force
 
+#################
+# Install: Rust #
+#################
+
+# Get Rust for building NIFs (wasmex)
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+
 # Set PATH to include Rust toolchain
 ENV PATH="/root/.cargo/bin:${PATH}"
+
+#########################
+# Build: wasmcloud_host #
+#########################
 
 WORKDIR ./wasmcloud_host
 RUN mix do deps.compile, compile


### PR DESCRIPTION
## Feature or Problem

Fix broken docker build due to missing `rust` toolchain

## Related Issues

#566 

## Release Information

`next`

## Consumer Impact

Consumers can use docker builds

## Testing

N/A


Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)

### Acceptance or Integration

### Manual Verification

Tested locally via `make build-image`