### PR TITLE
Bumped chart version

### DIFF
--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -18,6 +18,6 @@ type: application
 # Note: Ensure you bump this `version` field in a separate PR than what you plan
 # to tag as the updated wasmCloud version. To be safe, bump and release wasmCloud
 # in one PR, then open a new PR updating this `version` and `appVersion`.
-version: 0.6.10
+version: 0.6.11
 
 appVersion: "0.62.0"


### PR DESCRIPTION
Bumps chart version to `0.6.11` which includes the v0.62.0 release