### PR TITLE
strip leading v from tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
   #   steps:
   #     - uses: actions/checkout@v3
   #     - name: Determine version
-  #       run: echo "app-version=$(grep '@app_vsn "' ${{env.working-directory}}/mix.exs | cut -d '"' -f2)" > $GITHUB_ENV
+  #       run: echo "app-version=${GITHUB_REF_NAME#v} " > $GITHUB_ENV
 
   #     # Download the NIF in the path that Docker expects for x86
   #     - uses: actions/download-artifact@v3
@@ -215,7 +215,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Determine version
-        run: echo "app-version=$GITHUB_REF_NAME" > $GITHUB_ENV
+        run: echo "app-version=${GITHUB_REF_NAME#v} " > $GITHUB_ENV
 
       # Compile phoenix assets for wasmcloud_host outside of image (dart-sass doesn't support arm linux)
       - name: Install erlang and elixir


### PR DESCRIPTION
## Feature or Problem
@brooksmtownsend noticed we published v0.62.0 of the host with the leading `v` included in the tag name. That goes against the convention we've used elsewhere, so I've removed it

## Release Information
Next

## Consumer Impact
N/A

## Testing
Tested with bash:
```bash
❯ GITHUB_REF_NAME=v0.62.0

❯ echo ${GITHUB_REF_NAME#v}
0.62.0

❯ echo ${GITHUB_REF_NAME#z}
v0.62.0
```