### PR TITLE
Fix/washboard init

### DIFF
--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -1,7 +1,7 @@
 defmodule HostCore.MixProject do
   use Mix.Project
 
-  @app_vsn "0.62.0"
+  @app_vsn "0.62.1"
 
   def project do
     [

--- a/wasmcloud_host/chart/Chart.yaml
+++ b/wasmcloud_host/chart/Chart.yaml
@@ -20,4 +20,4 @@ type: application
 # in one PR, then open a new PR updating this `version` and `appVersion`.
 version: 0.6.11
 
-appVersion: "0.62.0"
+appVersion: "0.62.1"

--- a/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
@@ -119,7 +119,7 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
   # handle cloud events from HostCore PubSub
   @impl true
   def handle_info({:lattice_event, raw_event}, state) do
-    case Cloudevents.from_json(raw_event) do
+    state = case Cloudevents.from_json(raw_event) do
       {:ok, event} ->
         process_event(state, event)
 

--- a/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
+++ b/wasmcloud_host/lib/wasmcloud_host/lattice/state_monitor.ex
@@ -119,15 +119,16 @@ defmodule WasmcloudHost.Lattice.StateMonitor do
   # handle cloud events from HostCore PubSub
   @impl true
   def handle_info({:lattice_event, raw_event}, state) do
-    state = case Cloudevents.from_json(raw_event) do
-      {:ok, event} ->
-        process_event(state, event)
+    state =
+      case Cloudevents.from_json(raw_event) do
+        {:ok, event} ->
+          process_event(state, event)
 
-      # No-op
-      _ ->
-        Logger.warning("Received event that couldn't be parsed as a Cloudevent, ignoring")
-        state
-    end
+        # No-op
+        _ ->
+          Logger.warning("Received event that couldn't be parsed as a Cloudevent, ignoring")
+          state
+      end
 
     {:noreply, state}
   end

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -1,7 +1,7 @@
 defmodule WasmcloudHost.MixProject do
   use Mix.Project
 
-  @app_vsn "0.62.0"
+  @app_vsn "0.62.1"
 
   def project do
     [


### PR DESCRIPTION
## Feature or Problem
With the release of v0.62.0, the washboard state would get cleared on refresh. This was caused by not assigning a new value to `state`. Oops.

## Related Issues
N/A

## Release Information
v0.62.1, which I've bumped in this PR. I can leave that out if we want to wait

## Consumer Impact
The washboard should show the correct state upon refresh again

## Testing

### Manual Verification
Tested manually with `make run`