### PR TITLE
parse invocation errors as strings

### DIFF
--- a/host_core/native/hostcore_wasmcloud_native/src/wasmruntime.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/wasmruntime.rs
@@ -140,7 +140,10 @@ impl Handle<capability::Invocation> for ElixirHandler {
                     (false, e) => {
                         // TODO: verify whether we should return none here or use an Err
                         error!("Elixir callback threw an exception.");
-                        bail!("Host call function failed: {e:?}")
+                        let err_str = String::from_utf8(e.to_vec()).unwrap_or_else(|parse_err| {
+                            format!("failed to parse inv err: {parse_err}")
+                        });
+                        bail!("Host call function failed: {err_str}")
                     }
                 }
             }


### PR DESCRIPTION
## Feature or Problem
When detecting host call errors, the NIF is returning the raw bytes from the error. Now we parse as a string before returning

## Related Issues
Fixes https://github.com/wasmCloud/wasmcloud-otp/issues/606

## Release Information
Next

## Consumer Impact
Much more clear error messages on host calls

## Testing

### Manual Verification
Tested manually with `make run`:
- started the HTTP server provider
- started the XKCD actor
- linked them
- invoked the XKCD actor, which tries to call the HTTP client provider. This isn't running, so the host generates an error, which is now parsed as a string:
```
{"error":"actor: sending req: Host send error Host call function failed: Invocation not authorized: missing link definition for wasmcloud:httpclient on default"}
```