### PR TITLE
add annotations to actor_stopped and provider_stopped events

### DIFF
--- a/host_core/lib/host_core/actors/actor_module.ex
+++ b/host_core/lib/host_core/actors/actor_module.ex
@@ -283,12 +283,13 @@ defmodule HostCore.Actors.ActorModule do
     instance_id = contents.instance_id
     lattice_prefix = contents.lattice_prefix
     host_id = contents.host_id
+    annotations = contents.annotations
 
     Logger.debug("Terminating instance of actor #{public_key} (#{name})",
       actor_id: public_key
     )
 
-    publish_actor_stopped(host_id, lattice_prefix, public_key, instance_id)
+    publish_actor_stopped(host_id, lattice_prefix, public_key, instance_id, annotations)
 
     # PRO TIP - if you return :normal here as the stop reason, the GenServer will NOT auto-terminate
     # all of its children. If you want all children established via start_link to be terminated here,
@@ -805,10 +806,11 @@ defmodule HostCore.Actors.ActorModule do
     |> CloudEvent.publish(prefix)
   end
 
-  def publish_actor_stopped(host_id, lattice_prefix, actor_pk, instance_id) do
+  def publish_actor_stopped(host_id, lattice_prefix, actor_pk, instance_id, annotations) do
     %{
       public_key: actor_pk,
-      instance_id: instance_id
+      instance_id: instance_id,
+      annotations: annotations
     }
     |> CloudEvent.new("actor_stopped", host_id)
     |> CloudEvent.publish(lattice_prefix)

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -273,6 +273,7 @@ defmodule HostCore.Providers.ProviderModule do
         state.link_name,
         state.instance_id,
         state.contract_id,
+        state.annotations,
         "normal"
       )
 
@@ -345,6 +346,7 @@ defmodule HostCore.Providers.ProviderModule do
       state.link_name,
       state.instance_id,
       state.contract_id,
+      state.annotations,
       "normal"
     )
 
@@ -365,6 +367,7 @@ defmodule HostCore.Providers.ProviderModule do
       state.link_name,
       state.instance_id,
       state.contract_id,
+      state.annotations,
       "#{reason}"
     )
 
@@ -438,20 +441,22 @@ defmodule HostCore.Providers.ProviderModule do
     |> CloudEvent.publish(state.lattice_prefix)
   end
 
-  def publish_provider_stopped(
-        host_id,
-        lattice_prefix,
-        public_key,
-        link_name,
-        instance_id,
-        contract_id,
-        reason
-      ) do
+  defp publish_provider_stopped(
+         host_id,
+         lattice_prefix,
+         public_key,
+         link_name,
+         instance_id,
+         contract_id,
+         annotations,
+         reason
+       ) do
     %{
       public_key: public_key,
       link_name: link_name,
       contract_id: contract_id,
       instance_id: instance_id,
+      annotaions: annotations,
       reason: reason
     }
     |> CloudEvent.new("provider_stopped", host_id)


### PR DESCRIPTION
## Feature or Problem
This adds `annotations` to the `actor_stopped` and `provider_stopped` events

## Related Issues
Resolves https://github.com/wasmCloud/wasmcloud-otp/issues/609

## Release Information
Next

## Consumer Impact
wadm can read annotations off stop events now

## Testing

### Manual Verification

Notice both started and stopped events have annotations on them:
```
{"data":{"annotations":{"foo":"bar"},"api_version":"n/a","claims":{"call_alias":null,"caps":["wasmcloud:httpserver"],"expires_human":"never","issuer":"ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW","name":"Echo","not_before_human":"immediately","revision":4,"tags":[],"version":"0.3.4"},"image_ref":"wasmcloud.azurecr.io/echo:0.3.4","instance_id":"a7bf8b1a-5162-450d-b28c-90ed5fb7b92b","public_key":"MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5"},"datacontenttype":"application/json","id":"88410ca3-ac67-48c8-9517-b923e1d9b4be","source":"NDDVDHNK5CALTETFF3LXLU67MYWENIR2CRZXPIKF3K6GRFFUOXMXSPFW","specversion":"1.0","time":"2023-04-10T23:36:15.711366Z","type":"com.wasmcloud.lattice.actor_started"}

{"data":{"annotations":{"foo":"bar"},"claims":{"expires_human":"never","issuer":"ACOJJN6WUP4ODD75XEBKKTCCUJJCY5ZKQ56XVKYK4BEJWGVAOOQHZMCW","name":"HTTP Server","not_before_human":"immediately","tags":null,"version":"0.17.0"},"contract_id":"wasmcloud:httpserver","image_ref":"wasmcloud.azurecr.io/httpserver:0.17.0","instance_id":"e8a6e19f-451b-4b09-b4e8-cf3fc6d36ae9","link_name":"default","public_key":"VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M"},"datacontenttype":"application/json","id":"7a716481-2bf3-4e6c-9a2b-8dad911b698d","source":"NDDVDHNK5CALTETFF3LXLU67MYWENIR2CRZXPIKF3K6GRFFUOXMXSPFW","specversion":"1.0","time":"2023-04-10T23:36:20.930599Z","type":"com.wasmcloud.lattice.provider_started"}

{"data":{"annotations":{"foo":"bar"},"instance_id":"a7bf8b1a-5162-450d-b28c-90ed5fb7b92b","public_key":"MBCFOPM6JW2APJLXJD3Z5O4CN7CPYJ2B4FTKLJUR5YR5MITIU7HD3WD5"},"datacontenttype":"application/json","id":"cd74c99e-79f3-46c4-980d-d38fe02cb297","source":"NDDVDHNK5CALTETFF3LXLU67MYWENIR2CRZXPIKF3K6GRFFUOXMXSPFW","specversion":"1.0","time":"2023-04-10T23:36:28.519520Z","type":"com.wasmcloud.lattice.actor_stopped"}

{"data":{"annotaions":{"foo":"bar"},"contract_id":"wasmcloud:httpserver","instance_id":"e8a6e19f-451b-4b09-b4e8-cf3fc6d36ae9","link_name":"default","public_key":"VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M","reason":"normal"},"datacontenttype":"application/json","id":"7751b426-e6fa-4672-8f4d-37f19cbe10c9","source":"NDDVDHNK5CALTETFF3LXLU67MYWENIR2CRZXPIKF3K6GRFFUOXMXSPFW","specversion":"1.0","time":"2023-04-10T23:36:29.420499Z","type":"com.wasmcloud.lattice.provider_stopped"}
```