### PR TITLE
Numbergen RandomBytes Update

### DIFF
--- a/host_core/lib/host_core/providers/builtin/numbergen.ex
+++ b/host_core/lib/host_core/providers/builtin/numbergen.ex
@@ -28,12 +28,16 @@ defmodule HostCore.Providers.Builtin.Numbergen do
 
   def invoke("NumberGen.RandomBytes", payload) do
     bytes = Msgpax.unpack!(payload)
-        if bytes >= 1024 ->
-           {error, "X is too large"};
-          true ->
-              random_bytes =
-                :crypto.strong_rand_bytes(bytes)
-                |> Msgpax.pack!()
-                |> IO.iodata_to_binary()
+
+    if bytes >= 1024 do
+      "bytes is too large"
+    else
+      random_bytes =
+        :crypto.strong_rand_bytes(bytes)
+        |> Msgpax.pack!()
+        |> IO.iodata_to_binary()
+
+      random_bytes
+    end
   end
 end

--- a/host_core/lib/host_core/providers/builtin/numbergen.ex
+++ b/host_core/lib/host_core/providers/builtin/numbergen.ex
@@ -25,4 +25,12 @@ defmodule HostCore.Providers.Builtin.Numbergen do
     |> Msgpax.pack!()
     |> IO.iodata_to_binary()
   end
+
+  def invoke("NumberGen.RandomBytes", payload) do
+    bytes = Msgpax.unpack!(payload)
+
+    for(_ <- 1..bytes, do: Enum.random(0..255))
+    |> Msgpax.pack!()
+    |> IO.iodata_to_binary()
+  end
 end

--- a/host_core/lib/host_core/providers/builtin/numbergen.ex
+++ b/host_core/lib/host_core/providers/builtin/numbergen.ex
@@ -29,8 +29,10 @@ defmodule HostCore.Providers.Builtin.Numbergen do
   def invoke("NumberGen.RandomBytes", payload) do
     bytes = Msgpax.unpack!(payload)
 
-    for(_ <- 1..bytes, do: Enum.random(0..255))
-    |> Msgpax.pack!()
-    |> IO.iodata_to_binary()
+    # need to put a limit on this number
+    random_bytes =
+      :crypto.strong_rand_bytes(bytes)
+      |> Msgpax.pack!()
+      |> IO.iodata_to_binary()
   end
 end

--- a/host_core/lib/host_core/providers/builtin/numbergen.ex
+++ b/host_core/lib/host_core/providers/builtin/numbergen.ex
@@ -27,17 +27,15 @@ defmodule HostCore.Providers.Builtin.Numbergen do
   end
 
   def invoke("NumberGen.RandomBytes", payload) do
-    bytes = Msgpax.unpack!(payload)
+    params = Msgpax.unpack!(payload)
+    bytes = params["bytes"]
 
     if bytes >= 1024 do
       "bytes is too large"
     else
-      random_bytes =
         :crypto.strong_rand_bytes(bytes)
         |> Msgpax.pack!()
         |> IO.iodata_to_binary()
-
-      random_bytes
     end
   end
 end

--- a/host_core/lib/host_core/providers/builtin/numbergen.ex
+++ b/host_core/lib/host_core/providers/builtin/numbergen.ex
@@ -28,11 +28,12 @@ defmodule HostCore.Providers.Builtin.Numbergen do
 
   def invoke("NumberGen.RandomBytes", payload) do
     bytes = Msgpax.unpack!(payload)
-
-    # need to put a limit on this number
-    random_bytes =
-      :crypto.strong_rand_bytes(bytes)
-      |> Msgpax.pack!()
-      |> IO.iodata_to_binary()
+        if bytes >= 1024 ->
+           {error, "X is too large"};
+          true ->
+              random_bytes =
+                :crypto.strong_rand_bytes(bytes)
+                |> Msgpax.pack!()
+                |> IO.iodata_to_binary()
   end
 end

--- a/host_core/native/hostcore_wasmcloud_native/src/wasmruntime.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/wasmruntime.rs
@@ -109,8 +109,8 @@ impl Handle<capability::Invocation> for ElixirHandler {
                 numbergen::serialize_response(&v).map(Some)
             }
 
-            capability::Invocation::Numbergen(NumbergenInvocation::RandomBytes) => {
-                let v: u32 = todo!();
+            capability::Invocation::Numbergen(NumbergenInvocation::RandomBytes { bytes }) => {
+                let v: [u8; bytes] = thread_rng().gen();
                 trace!("generated random bytes: {v}");
                 numbergen::serialize_response(&v).map(Some)
             }

--- a/host_core/native/hostcore_wasmcloud_native/src/wasmruntime.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/wasmruntime.rs
@@ -109,6 +109,12 @@ impl Handle<capability::Invocation> for ElixirHandler {
                 numbergen::serialize_response(&v).map(Some)
             }
 
+            capability::Invocation::Numbergen(NumbergenInvocation::RandomBytes) => {
+                let v: u32 = todo!();
+                trace!("generated random bytes: {v}");
+                numbergen::serialize_response(&v).map(Some)
+            }
+
             capability::Invocation::Host(HostInvocation {
                 namespace,
                 operation,


### PR DESCRIPTION
Add a function to Numbergen builtin to allow users to generate a random number based on a defined input to indicate the number of bytes.

It is currently cumbersome to generate random numbers that are more than 32 Bits. This operation will make it simple for a user to do so without chaining Numbergen calls.

## Related PR
<https://github.com/wasmCloud/interfaces/pull/107>

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
