### PR TITLE
[WIP] Support correlation IDs on ctl commands

### DIFF
--- a/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
+++ b/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
@@ -82,7 +82,7 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
         # * notify internal consumers via pubsub (publish)
         # * notify capability providers via RPC (publish)
         LinkdefsManager.cache_link_definition(lattice_prefix, ld)
-        LinkdefsManager.publish_link_definition(lattice_prefix, ld)
+        LinkdefsManager.publish_link_definition(lattice_prefix, ld, nil)
 
       {:error, e} ->
         Logger.error("Failed to deserialize linkdef from metadata cache: #{inspect(e)}")
@@ -93,7 +93,7 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
     Logger.debug("Removing cached reference for linkdef ID #{ldid}")
 
     case LinkdefsManager.lookup_link_definition(lattice_prefix, ldid) do
-      {:ok, ld} -> LinkdefsManager.publish_link_definition_deleted(lattice_prefix, ld)
+      {:ok, ld} -> LinkdefsManager.publish_link_definition_deleted(lattice_prefix, ld, nil)
       _ -> Logger.warn("Failed to look up link definition with ID #{ldid}")
     end
 

--- a/host_core/lib/host_core/refmaps/manager.ex
+++ b/host_core/lib/host_core/refmaps/manager.ex
@@ -27,10 +27,10 @@ defmodule HostCore.Refmaps.Manager do
     :ets.insert(rt, {oci_url, public_key})
   end
 
-  def put_refmap(host_id, lattice_prefix, oci_url, public_key) do
+  def put_refmap(host_id, lattice_prefix, oci_url, public_key, correlation_id) do
     cache_refmap(lattice_prefix, oci_url, public_key)
 
-    publish_refmap(host_id, lattice_prefix, oci_url, public_key)
+    publish_refmap(host_id, lattice_prefix, oci_url, public_key, correlation_id)
   end
 
   def ocis_for_key(lattice_prefix, public_key) when is_binary(public_key) do
@@ -41,7 +41,7 @@ defmodule HostCore.Refmaps.Manager do
     |> Enum.map(fn {ociref, _pk} -> ociref end)
   end
 
-  def publish_refmap(host_id, lattice_prefix, oci_url, public_key) do
+  def publish_refmap(host_id, lattice_prefix, oci_url, public_key, correlation_id) do
     config = VirtualHost.config(host_id)
 
     data = %{
@@ -61,7 +61,7 @@ defmodule HostCore.Refmaps.Manager do
     broadcast_event(:refmap_added, data, lattice_prefix)
 
     data
-    |> CloudEvent.new("refmap_set", host_id)
+    |> CloudEvent.new("refmap_set", host_id, correlation_id)
     |> CloudEvent.publish(lattice_prefix)
   end
 

--- a/host_core/lib/host_core/vhost/heartbeats.ex
+++ b/host_core/lib/host_core/vhost/heartbeats.ex
@@ -72,7 +72,8 @@ defmodule HostCore.Vhost.Heartbeats do
         uptime_human: ut_human
       },
       "host_heartbeat",
-      config.host_key
+      config.host_key,
+      nil
     )
   end
 end

--- a/host_core/lib/host_core/wasmcloud/rpc_invocations.ex
+++ b/host_core/lib/host_core/wasmcloud/rpc_invocations.ex
@@ -250,7 +250,7 @@ defmodule HostCore.WasmCloud.RpcInvocations do
       operation: operation,
       bytes: payload_bytes
     }
-    |> CloudEvent.new(evt_type, host_id)
+    |> CloudEvent.new(evt_type, host_id, nil)
     |> CloudEvent.publish(prefix, @rpc_event_prefix)
   end
 

--- a/host_core/test/host_core_test.exs
+++ b/host_core/test/host_core_test.exs
@@ -52,7 +52,7 @@ defmodule HostCoreTest do
         httpserver_key
       )
 
-    VirtualHost.purge(pid)
+    VirtualHost.purge(pid, nil)
 
     :ok = HostCoreTest.EventWatcher.wait_for_actor_stop(evt_watcher, @echo_key)
 


### PR DESCRIPTION
## Feature or Problem
This PR adds in an additional, optional, field that we pull off of each control interface command that has resulting events. Notably, start/scale/update/stop actor, start/stop provider, and stop host. 

The correlation ID is then passed down through the resulting functions, and then attached to resulting events from that command. This is very useful to know when a command _you_ publish directly results in an actor starting, especially if there's more than one control client that is sending a host commands. The primary use case that we envisioned in this PR is to have [wadm](https://github.com/wasmCloud/wadm) be able to publish a command from one of its scalers, and then monitor events on the lattice that correspond to a particular command in order to know when a specific event happens because of a ctl request.

## Related Issues
#618

## Release Information
`0.63.0`

## Consumer Impact
This is backwards compatible with older control interface clients so no changes will be necessary for this host version.

## Testing
WIP. Still some combing through code needed, though tests all pass locally.

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
