### PR TITLE
Blocks multiple concurrent provider starts of the same public key + link name

### DIFF
--- a/host_core/lib/host_core/control_interface/host_server.ex
+++ b/host_core/lib/host_core/control_interface/host_server.ex
@@ -281,7 +281,9 @@ defmodule HostCore.ControlInterface.HostServer do
                 )
 
               :ignore ->
-                Logger.debug("Provider #{start_provider_command["provider_ref"]} (#{start_provider_command["link_name"]}) ignored - already running")
+                Logger.debug(
+                  "Provider #{start_provider_command["provider_ref"]} (#{start_provider_command["link_name"]}) ignored - already running"
+                )
 
               {:error, e} ->
                 Tracer.set_status(:error, inspect(e))

--- a/host_core/lib/host_core/control_interface/host_server.ex
+++ b/host_core/lib/host_core/control_interface/host_server.ex
@@ -280,6 +280,9 @@ defmodule HostCore.ControlInterface.HostServer do
                   "Successfully started provider #{start_provider_command["provider_ref"]} (#{start_provider_command["link_name"]})"
                 )
 
+              :ignore ->
+                Logger.debug("Provider #{start_provider_command["provider_ref"]} (#{start_provider_command["link_name"]}) ignored - already running")
+
               {:error, e} ->
                 Tracer.set_status(:error, inspect(e))
 

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -159,7 +159,6 @@ defmodule HostCore.Providers.ProviderModule do
 
       :ignore
     else
-
       Logger.info("Starting executable capability provider from '#{path}'",
         provider_id: claims.public_key,
         link_name: link_name,
@@ -210,34 +209,34 @@ defmodule HostCore.Providers.ProviderModule do
       :timer.send_interval(@thirty_seconds, self(), :do_health)
 
       {:ok,
-      %State{
-        os_port: port,
-        os_pid: pid,
-        public_key: claims.public_key,
-        link_name: link_name,
-        contract_id: contract_id,
-        instance_id: instance_id,
-        shutdown_delay: shutdown_delay,
-        lattice_prefix: lattice_prefix,
-        executable_path: path,
-        annotations: annotations,
-        host_id: host_id,
-        # until we prove otherwise
-        healthy: false,
-        ociref: oci
-      }, {:continue, :register_provider}}
-      end
+       %State{
+         os_port: port,
+         os_pid: pid,
+         public_key: claims.public_key,
+         link_name: link_name,
+         contract_id: contract_id,
+         instance_id: instance_id,
+         shutdown_delay: shutdown_delay,
+         lattice_prefix: lattice_prefix,
+         executable_path: path,
+         annotations: annotations,
+         host_id: host_id,
+         # until we prove otherwise
+         healthy: false,
+         ociref: oci
+       }, {:continue, :register_provider}}
+    end
   end
 
   @impl true
   def handle_continue(:register_provider, state) do
-      Registry.register(
-        Registry.ProviderRegistry,
-        {state.public_key, state.link_name},
-        state.host_id
-      )
+    Registry.register(
+      Registry.ProviderRegistry,
+      {state.public_key, state.link_name},
+      state.host_id
+    )
 
-      {:noreply, state}
+    {:noreply, state}
   end
 
   @propagated_env_vars ["OTEL_TRACES_EXPORTER", "OTEL_EXPORTER_OTLP_ENDPOINT"]

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -151,7 +151,7 @@ defmodule HostCore.Providers.ProviderModule do
          link_name,
          host_id
        ) do
-      Logger.warn("Provider already registered, halting duplicate",
+      Logger.warn("Provider already running on this host, not starting rejected duplicate",
         public_key: claims.public_key,
         link_name: link_name,
         host_id: host_id

--- a/host_core/lib/host_core/providers/provider_module.ex
+++ b/host_core/lib/host_core/providers/provider_module.ex
@@ -146,83 +146,98 @@ defmodule HostCore.Providers.ProviderModule do
       contract_id: contract_id
     )
 
-    Logger.info("Starting executable capability provider from '#{path}'",
-      provider_id: claims.public_key,
-      link_name: link_name,
-      contract_id: contract_id
-    )
-
-    instance_id = UUID.uuid4()
-
-    host_info =
-      VirtualHost.generate_hostinfo_for_provider(
-        host_id,
-        claims.public_key,
-        link_name,
-        instance_id,
-        config_json
+    if HostCore.Providers.ProviderSupervisor.is_running?(
+         claims.public_key,
+         link_name,
+         host_id
+       ) do
+      Logger.warn("Provider already registered, halting duplicate",
+        public_key: claims.public_key,
+        link_name: link_name,
+        host_id: host_id
       )
-      |> Base.encode64()
-      |> to_charlist()
 
-    port = Port.open({:spawn, "#{path}"}, [:binary, {:env, extract_env_vars()}])
-    Port.monitor(port)
-    Port.command(port, "#{host_info}\n")
+      :ignore
+    else
 
-    {:os_pid, pid} = Port.info(port, :os_pid)
+      Logger.info("Starting executable capability provider from '#{path}'",
+        provider_id: claims.public_key,
+        link_name: link_name,
+        contract_id: contract_id
+      )
 
-    # Worth pointing out here that this process doesn't need to subscribe to
-    # the provider's NATS topic. The provider subscribes to that directly
-    # when it starts.
+      instance_id = UUID.uuid4()
 
-    HostCore.Claims.Manager.put_claims(host_id, lattice_prefix, claims)
+      host_info =
+        VirtualHost.generate_hostinfo_for_provider(
+          host_id,
+          claims.public_key,
+          link_name,
+          instance_id,
+          config_json
+        )
+        |> Base.encode64()
+        |> to_charlist()
 
-    publish_provider_started(
-      host_id,
-      lattice_prefix,
-      claims,
-      link_name,
-      contract_id,
-      instance_id,
-      oci,
-      annotations
-    )
+      port = Port.open({:spawn, "#{path}"}, [:binary, {:env, extract_env_vars()}])
+      Port.monitor(port)
+      Port.command(port, "#{host_info}\n")
 
-    if oci != nil && oci != "" do
-      publish_provider_oci_map(host_id, lattice_prefix, claims.public_key, link_name, oci)
-    end
+      {:os_pid, pid} = Port.info(port, :os_pid)
 
-    Process.send_after(self(), :do_health, 5_000)
-    :timer.send_interval(@thirty_seconds, self(), :do_health)
+      # Worth pointing out here that this process doesn't need to subscribe to
+      # the provider's NATS topic. The provider subscribes to that directly
+      # when it starts.
 
-    {:ok,
-     %State{
-       os_port: port,
-       os_pid: pid,
-       public_key: claims.public_key,
-       link_name: link_name,
-       contract_id: contract_id,
-       instance_id: instance_id,
-       shutdown_delay: shutdown_delay,
-       lattice_prefix: lattice_prefix,
-       executable_path: path,
-       annotations: annotations,
-       host_id: host_id,
-       # until we prove otherwise
-       healthy: false,
-       ociref: oci
-     }, {:continue, :register_provider}}
+      HostCore.Claims.Manager.put_claims(host_id, lattice_prefix, claims)
+
+      publish_provider_started(
+        host_id,
+        lattice_prefix,
+        claims,
+        link_name,
+        contract_id,
+        instance_id,
+        oci,
+        annotations
+      )
+
+      if oci != nil && oci != "" do
+        publish_provider_oci_map(host_id, lattice_prefix, claims.public_key, link_name, oci)
+      end
+
+      Process.send_after(self(), :do_health, 5_000)
+      :timer.send_interval(@thirty_seconds, self(), :do_health)
+
+      {:ok,
+      %State{
+        os_port: port,
+        os_pid: pid,
+        public_key: claims.public_key,
+        link_name: link_name,
+        contract_id: contract_id,
+        instance_id: instance_id,
+        shutdown_delay: shutdown_delay,
+        lattice_prefix: lattice_prefix,
+        executable_path: path,
+        annotations: annotations,
+        host_id: host_id,
+        # until we prove otherwise
+        healthy: false,
+        ociref: oci
+      }, {:continue, :register_provider}}
+      end
   end
 
   @impl true
   def handle_continue(:register_provider, state) do
-    Registry.register(
-      Registry.ProviderRegistry,
-      {state.public_key, state.link_name},
-      state.host_id
-    )
+      Registry.register(
+        Registry.ProviderRegistry,
+        {state.public_key, state.link_name},
+        state.host_id
+      )
 
-    {:noreply, state}
+      {:noreply, state}
   end
 
   @propagated_env_vars ["OTEL_TRACES_EXPORTER", "OTEL_EXPORTER_OTLP_ENDPOINT"]

--- a/host_core/lib/host_core/providers/provider_supervisor.ex
+++ b/host_core/lib/host_core/providers/provider_supervisor.ex
@@ -322,9 +322,9 @@ defmodule HostCore.Providers.ProviderSupervisor do
     end
   end
 
-  defp is_running?(key, _, _) when byte_size(key) == 0, do: false
+  def is_running?(key, _, _) when byte_size(key) == 0, do: false
 
-  defp is_running?(key, link_name, host_id) do
+  def is_running?(key, link_name, host_id) do
     Enum.any?(
       all_providers(host_id),
       fn {_pid, public_key, ln, _contract_id, _instance_id} ->


### PR DESCRIPTION
## Feature or Problem
Fixes a bug that allows an edge case race condition to start the same provider twice on the host

## Related Issues
#625

## Release Information
vNext

## Consumer Impact
Probably only reproducible by humans once in a blue moon, but this fix will make CI testing and `wadm` not be able to break the host this way

## Testing
Followed reproduction steps before and after and made sure problem goes away

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
No

### Acceptance or Integration
N/A

### Manual Verification
Manually ran shell script to generate two concurrent launch provider requests, each for a different OCI reference (note the identical timestamps down to the millisecond):

```
10:30:55.549 [debug] Received host control interface request on wasmbus.ctl.default.cmd.NDOYD5XD62SLW7DKUZZOVL3NCYUPQBXVUR3O3QL6AABUGJGHPYYM4APD.lp
10:30:55.549 [debug] Received host control interface request on wasmbus.ctl.default.cmd.NDOYD5XD62SLW7DKUZZOVL3NCYUPQBXVUR3O3QL6AABUGJGHPYYM4APD.lp
```
Then we can see one provider starting:
```
10:31:04.396 [info] contract_id=wasmcloud:messaging host_id=NDOYD5XD62SLW7DKUZZOVL3NCYUPQBXVUR3O3QL6AABUGJGHPYYM4APD lattice_prefix=default link_name=default provider_id=VADNMSIML2XGO2X4TPIONTIC55R2UUQGPPDZPAVSC2QD7E76CR77SPW7 Starting executable capability provider from '/var/folders/hg/wj4rqfbn52n9s5y7qnj2t8080000gn/T/wasmcloudcache/VADNMSIML2XGO2X4TPIONTIC55R2UUQGPPDZPAVSC2QD7E76CR77SPW7/1677588858/wasmcloud_messaging_default'
```
And then we see the second one being blocked from launch:
```
10:31:04.401 [warning] contract_id=wasmcloud:messaging host_id=NDOYD5XD62SLW7DKUZZOVL3NCYUPQBXVUR3O3QL6AABUGJGHPYYM4APD lattice_prefix=default link_name=default provider_id=VADNMSIML2XGO2X4TPIONTIC55R2UUQGPPDZPAVSC2QD7E76CR77SPW7 public_key=VADNMSIML2XGO2X4TPIONTIC55R2UUQGPPDZPAVSC2QD7E76CR77SPW7 Provider already registered, halting duplicate
10:31:04.401 [debug] span_id=12f90028f314a23a trace_id=922209ff2e3118b091a4a9ea48e17892 Successfully started provider wasmcloud.azurecr.io/nats_messaging:0.16.2 (default)
10:31:04.401 [debug] span_id=2b3582a30829aa9c trace_id=60f41221803bdaf7206423647367c841 Provider wasmcloud.azurecr.io/nats_messaging:0.16.1 (default) ignored - already running
```
