### PR TITLE
fix(ci): Builds docker images for both supported arches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,25 +333,12 @@ jobs:
     # ```
     # Error: buildx failed with: ERROR: invalid tag "wasmcloud.azurecr.io/wasmcloud_host:616/merge": invalid reference format
     # ```
-    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/')
     strategy:
       matrix:
-        config:
-        - app-name: host_core
-          target: aarch64_linux_gnu
-          platform: linux/arm64
-
-        - app-name: host_core
-          target: x86_64_linux_gnu
-          platform: linux/amd64
-
-        - app-name: wasmcloud_host
-          target: aarch64_linux_gnu
-          platform: linux/arm64
-
-        - app-name: wasmcloud_host
-          target: x86_64_linux_gnu
-          platform: linux/amd64
+        app-name:
+          - host_core
+          - wasmcloud_host
 
     runs-on: ubuntu-22.04
     needs:
@@ -386,25 +373,32 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: ${{ matrix.config.app-name }}_${{ matrix.config.target }}
-          path: ${{ matrix.config.app-name }}
-      - run: chmod +x ${{ matrix.config.app-name }}/${{ matrix.config.app-name }}_${{ matrix.config.target }}
+          name: ${{ matrix.app-name }}_aarch64_linux_gnu
+          path: ${{ matrix.app-name }}
+      - run: chmod +x ${{ matrix.app-name }}/${{ matrix.app-name }}_aarch64_linux_gnu
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.app-name }}_x86_64_linux_gnu
+          path: ${{ matrix.app-name }}
+      - run: chmod +x ${{ matrix.app-name }}/${{ matrix.app-name }}_x86_64_linux_gnu
 
       - name: Build and release docker image
         uses: docker/build-push-action@v3
         with:
           builder: ${{ steps.buildx-builder.outputs.name }}
           push: ${{ startswith(github.ref, 'refs/tags/') }}
-          context: ${{ matrix.config.app-name }}
-          file: ${{ matrix.config.app-name }}/Dockerfile
-          platforms: ${{ matrix.config.platform }}
+          context: ${{ matrix.app-name }}
+          file: ${{ matrix.app-name }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
-            BIN=${{ matrix.config.app-name }}_${{ matrix.config.target }}
+            BIN_ARM64=${{ matrix.app-name }}_aarch64_linux_gnu
+            BIN_AMD64=${{ matrix.app-name }}_x86_64_linux_gnu
           tags: |
-            wasmcloud.azurecr.io/${{ matrix.config.app-name }}:${{ env.app-version }}
-            wasmcloud.azurecr.io/${{ matrix.config.app-name }}:latest
-            wasmcloud/${{ matrix.config.app-name }}:${{ env.app-version }}
-            wasmcloud/${{ matrix.config.app-name }}:latest
+            wasmcloud.azurecr.io/${{ matrix.app-name }}:${{ env.app-version }}
+            wasmcloud/${{ matrix.app-name }}:${{ env.app-version }}
+            wasmcloud.azurecr.io/${{ matrix.app-name }}:latest
+            wasmcloud/${{ matrix.app-name }}:latest
 
   github-release:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push

--- a/host_core/Dockerfile
+++ b/host_core/Dockerfile
@@ -1,11 +1,20 @@
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim AS base
+
+FROM base AS base-amd64
+ARG BIN_AMD64
+ARG BIN=$BIN_AMD64
+
+FROM base AS base-arm64
+ARG BIN_ARM64
+ARG BIN=$BIN_ARM64
+
+FROM base-$TARGETARCH
 
 # Install runtime dependencies
 RUN apt update && \
   apt install -y --no-install-recommends ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 
-ARG BIN
 COPY ${BIN} /usr/local/bin/host_core
 
 RUN host_core maintenance install

--- a/wasmcloud_host/Dockerfile
+++ b/wasmcloud_host/Dockerfile
@@ -1,11 +1,20 @@
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim AS base
+
+FROM base AS base-amd64
+ARG BIN_AMD64
+ARG BIN=$BIN_AMD64
+
+FROM base AS base-arm64
+ARG BIN_ARM64
+ARG BIN=$BIN_ARM64
+
+FROM base-$TARGETARCH
 
 # Install runtime dependencies
 RUN apt update && \
   apt install -y --no-install-recommends ca-certificates && \
   rm -rf /var/lib/apt/lists/*
 
-ARG BIN
 COPY ${BIN} /usr/local/bin/wasmcloud_host
 
 RUN wasmcloud_host maintenance install


### PR DESCRIPTION
Feature or Problem
The current 0.63 builds only have the arm64 architecture available for docker images

Release Information
Next. However, if we can find a way to rebuild the 0.63.1 images using this, that would be nice

Testing
This is being tested with a run of the pipeline before changing back the vars