### PR TITLE
tiny logging improvement

### DIFF
--- a/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
+++ b/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
@@ -63,7 +63,7 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
 
       {:error, e} ->
         Logger.error(
-          "Key added (claioms) handler failed. Failed to deserialize claims from metadata cache: #{inspect(e)}"
+          "Key added (claims) handler failed. Failed to deserialize claims from metadata cache: #{inspect(e)}"
         )
     end
   end

--- a/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
+++ b/host_core/lib/host_core/jetstream/metadata_cache_loader.ex
@@ -25,7 +25,12 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
   # $KV.LATTICEDATA_xxx.key
   # {domain}.$KV.LATTICEDATA_xxx.key
 
+  def error(%{gnat: _gnat, reply_to: _reply_to}, error) do
+    Logger.error("Error in metadata cache loader: #{inspect(error)}")
+  end
+
   def request(%{topic: topic, body: body, headers: headers}) do
+    Logger.debug("Handling metadata cache loader request for #{topic} w/headers")
     tokenmap = tokenize(topic)
 
     if {@operation_header, @operation_del} in headers ||
@@ -39,6 +44,7 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
   end
 
   def request(%{topic: topic, body: body}) do
+    Logger.debug("Handling metadata cache loader request for #{topic}")
     tokenmap = tokenize(topic)
 
     handle_action(:key_added, tokenmap, body)
@@ -56,7 +62,9 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
         ClaimsManager.cache_claims(lattice_prefix, public_key, claims)
 
       {:error, e} ->
-        Logger.error("Failed to deserialize claims from metadata cache: #{inspect(e)}")
+        Logger.error(
+          "Key added (claioms) handler failed. Failed to deserialize claims from metadata cache: #{inspect(e)}"
+        )
     end
   end
 
@@ -67,7 +75,9 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
         RefmapsManager.cache_refmap(lattice_prefix, refmap.oci_url, refmap.public_key)
 
       {:error, e} ->
-        Logger.error("Failed to deserialize refmap from metadata cache: #{inspect(e)}")
+        Logger.error(
+          "Key added (refmap) handler failed. Failed to deserialize refmap from metadata cache: #{inspect(e)}"
+        )
     end
   end
 
@@ -75,7 +85,10 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
     case Jason.decode(body, keys: :atoms) do
       {:ok, ld} ->
         ld = ensure_linkdef_id(ld)
-        Logger.debug("Caching link definition from #{ld.actor_id} on contract #{ld.contract_id}")
+
+        Logger.debug(
+          "Caching link definition from #{ld.actor_id} to provider #{ld.provider_id} on contract #{ld.contract_id}"
+        )
 
         # This data came from the bucket, so we don't need to re-write it to the bucket, just:
         # * store it in memory
@@ -85,17 +98,28 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
         LinkdefsManager.publish_link_definition(lattice_prefix, ld)
 
       {:error, e} ->
-        Logger.error("Failed to deserialize linkdef from metadata cache: #{inspect(e)}")
+        Logger.error(
+          "Key added (linkdef) handler failed. Failed to deserialize linkdef from metadata cache: #{inspect(e)}"
+        )
     end
   end
 
   defp handle_action(:key_deleted, %{key: @linkdef_prefix <> ldid, prefix: lattice_prefix}, _body) do
-    Logger.debug("Removing cached reference for linkdef ID #{ldid}")
-
     case LinkdefsManager.lookup_link_definition(lattice_prefix, ldid) do
-      {:ok, ld} -> LinkdefsManager.publish_link_definition_deleted(lattice_prefix, ld)
-      _ -> Logger.warn("Failed to look up link definition with ID #{ldid}")
+      {:ok, ld} ->
+        Logger.debug(
+          "Link definition uncached. Actor #{ld.actor_id}, Provider #{ld.provider_id}, Link name #{ld.link_name}"
+        )
+
+        LinkdefsManager.publish_link_definition_deleted(lattice_prefix, ld)
+
+      _ ->
+        Logger.warn(
+          "Key delete handler (linkdef) failed. Failed to look up link definition with ID #{ldid}"
+        )
     end
+
+    Logger.debug("Removing cached reference for linkdef ID #{ldid}")
 
     # Remove from in-memory cache. No need to remove from bucket (removal from bucket causes this handler)
     LinkdefsManager.uncache_link_definition(lattice_prefix, ldid)
@@ -138,6 +162,8 @@ defmodule HostCore.Jetstream.MetadataCacheLoader do
         %{}
     end
   end
+
+  defp tokenize(_), do: %{}
 
   def broadcast_event(evt_type, payload, lattice_prefix) do
     PubSub.broadcast(


### PR DESCRIPTION
* Adds a few extra bits of very useful information to the debug logs.
* Adds a couple of fallthrough handlers to avoid the function pattern mismatch type of errors

Note that there were reports of the metadata cache loader "stopping". I can't reproduce this and, more importantly, the way Gnat works it traps the call to `request` in an exception handler so the worst case scenario for a Gnat consumer supervisor would be an error log dump. If it stops getting bucket updates, then that may be caused by something else.

Regardless, the changes made here add more useful troubleshooting information and certainly don't make things worse.