### PR TITLE
build: remove `nix` store paths from releases 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,6 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  FALLBACK_SECRET: 3ImiTAMO0TTD7wrACHrCA+ggkzpw6zGWvE3gtQwlXE6vmnDT9yGP5/WKpLWEJ8fF
-
 jobs:
   erts-linux:
     strategy:
@@ -140,8 +137,8 @@ jobs:
       env:
         SECRET_KEY_BASE: ${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}
       run: |
-        printf '%s' "${SECRET_KEY_BASE:-$FALLBACK_SECRET}" | nix build \
-          --override-input secret-key-base 'file:///dev/stdin' \
+        nix build \
+          --impure \
           --override-input hostcore_wasmcloud_native-${{ matrix.config.arch }}-apple-darwin-mac /tmp/nif \
           -L .#${{ matrix.config.package }}-burrito-${{ matrix.config.arch }}-darwin
 
@@ -192,8 +189,8 @@ jobs:
       env:
         SECRET_KEY_BASE: ${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}
       run: |
-        printf '%s' "${SECRET_KEY_BASE:-$FALLBACK_SECRET}" | nix build \
-          --override-input secret-key-base 'file:///dev/stdin' \
+        nix build \
+          --impure \
           -L .#${{ matrix.config.package }}-burrito-${{ matrix.config.arch }}-linux-${{ matrix.config.libc }}
 
     - uses: actions/upload-artifact@v3
@@ -227,8 +224,8 @@ jobs:
       env:
         SECRET_KEY_BASE: ${{ secrets.WASMCLOUD_HOST_SECRET_KEY_BASE }}
       run: |
-        printf '%s' "${SECRET_KEY_BASE:-$FALLBACK_SECRET}" | nix build \
-          --override-input secret-key-base 'file:///dev/stdin' \
+        nix build \
+          --impure \
           --override-input hostcore_wasmcloud_native-x86_64-pc-windows-msvc /tmp/nif \
           -L .#${{ matrix.package }}-burrito-x86_64-windows
 

--- a/flake.lock
+++ b/flake.lock
@@ -362,8 +362,7 @@
         "nixify": "nixify",
         "nixlib": "nixlib_2",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-old": "nixpkgs-old",
-        "secret-key-base": "secret-key-base"
+        "nixpkgs-old": "nixpkgs-old"
       }
     },
     "rust-analyzer-src": {
@@ -431,18 +430,6 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "type": "github"
-      }
-    },
-    "secret-key-base": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-d6xi4mKdjkX2JFicDIv5niSzpyI0m/Hnm8GGAIU04kY=",
-        "type": "file",
-        "url": "file:/dev/null"
-      },
-      "original": {
-        "type": "file",
-        "url": "file:/dev/null"
       }
     },
     "systems": {

--- a/host_core/lib/remove_nix_store_refs.ex
+++ b/host_core/lib/remove_nix_store_refs.ex
@@ -1,0 +1,29 @@
+defmodule HostCore.RemoveNixStoreRefs do
+  alias Burrito.Builder.Step
+  @behaviour Step
+
+  @impl Step
+  def execute(%Burrito.Builder.Context{} = context) do
+    store = Regex.compile!("/nix/store/[[:alnum:]-.]+")
+
+    elixir =
+      Path.join(context.work_dir, [
+        "releases",
+        "/#{context.mix_release.version}",
+        "/elixir"
+      ])
+
+    File.write!(elixir, String.replace(File.read!(elixir), store, ""))
+
+    iex =
+      Path.join(context.work_dir, [
+        "releases",
+        "/#{context.mix_release.version}",
+        "/iex"
+      ])
+
+    File.write!(iex, String.replace(File.read!(iex), store, ""))
+
+    context
+  end
+end

--- a/host_core/mix.exs
+++ b/host_core/mix.exs
@@ -60,7 +60,8 @@ defmodule HostCore.MixProject do
                 ],
                 extra_steps: [
                   patch: [
-                    pre: [HostCore.CopyNIF]
+                    pre: [HostCore.CopyNIF],
+                    post: [HostCore.RemoveNixStoreRefs]
                   ]
                 ]
               ]

--- a/wasmcloud_host/mix.exs
+++ b/wasmcloud_host/mix.exs
@@ -61,7 +61,8 @@ defmodule WasmcloudHost.MixProject do
                 ],
                 extra_steps: [
                   patch: [
-                    pre: [HostCore.CopyNIF]
+                    pre: [HostCore.CopyNIF],
+                    post: [HostCore.RemoveNixStoreRefs]
                   ]
                 ]
               ]


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

- fix `nix flake show`
- remove the `secret-key-base` hack, use actual env variables and `--impure`
- remove `/nix/store` references from Elixir releases. This one is a fun one, Elixir is used to build the project and then copies itself to the release - we would not be able to build using "patched" Elixir, since `/bin/sh` etc. does not (and should not) exist in `nix` sandbox during build, therefore we patch these out as part of the `mix` build

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

Pull an artifact from a CI run as usual and test in a Docker container, e.g. `docker run --rm -it -v$(pwd):$(pwd) -w$(pwd) ubuntu` from a directory containing the binary. Run (let it fail) and inspect `~/.local/share/.burrito/*`. Currently there's just one shebang with `nix` store ref, in cgi handler, but we should not use that anyway

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
See `Testing`