### PR TITLE
Adding host support for json schemas in claims

### DIFF
--- a/host_core/lib/host_core/claims/manager.ex
+++ b/host_core/lib/host_core/claims/manager.ex
@@ -16,7 +16,8 @@ defmodule HostCore.Claims.Manager do
           tags: String.t(),
           version: String.t(),
           sub: String.t(),
-          contract_id: String.t() | nil
+          contract_id: String.t() | nil,
+          config_schema: String.t() | nil
         }
 
   @spec lookup_claims(lattice_prefix :: String.t(), public_key :: String.t()) ::
@@ -51,7 +52,7 @@ defmodule HostCore.Claims.Manager do
   def put_claims(host_id, lattice_prefix, claims) do
     public_key = claims.public_key
 
-    claims = %{
+    newclaims = %{
       call_alias:
         if claims.call_alias == nil do
           ""
@@ -88,8 +89,15 @@ defmodule HostCore.Claims.Manager do
       contract_id: Map.get(claims, :contract_id) || ""
     }
 
-    cache_claims(lattice_prefix, public_key, claims)
-    publish_claims(host_id, lattice_prefix, claims)
+    newclaims =
+      if claims.config_schema != nil do
+        Map.put(newclaims, :config_schema, claims.config_schema)
+      else
+        newclaims
+      end
+
+    cache_claims(lattice_prefix, public_key, newclaims)
+    publish_claims(host_id, lattice_prefix, newclaims)
   end
 
   def claims_table_atom(lattice_prefix) do

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.lock
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.lock
@@ -239,7 +239,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -640,7 +640,7 @@ dependencies = [
  "bitflags",
  "clap_derive 3.2.18",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
@@ -693,7 +693,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -992,7 +992,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.12",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1009,7 +1009,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1179,6 +1179,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -1425,7 +1431,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1508,7 +1514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 dependencies = [
  "fallible-iterator",
- "indexmap",
+ "indexmap 1.9.3",
  "stable_deref_trait",
 ]
 
@@ -1524,7 +1530,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1568,6 +1574,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.3",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heck"
@@ -1636,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "hostcore_wasmcloud_native"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1660,6 +1672,7 @@ dependencies = [
  "rustler",
  "serde",
  "serde_bytes",
+ "serde_json",
  "tokio",
  "tokio-stream",
  "uuid",
@@ -1819,6 +1832,16 @@ dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
  "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -2397,7 +2420,7 @@ checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "crc32fast",
  "hashbrown 0.13.2",
- "indexmap",
+ "indexmap 1.9.3",
  "memchr",
 ]
 
@@ -2626,7 +2649,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -2734,26 +2757,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "provider-archive"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91058846d2bdeaea55ce059f375e1af0e57f9cfad83fd6702d539c45e8d26d7"
+checksum = "b3e73940ae67588b3e7f1d29798ee5b76b32217fcfb3d9f64d28bd5d6d72c113"
 dependencies = [
  "async-compression",
  "data-encoding",
  "ring",
+ "serde_json",
  "tokio",
  "tokio-stream",
  "tokio-tar",
- "wascap 0.8.0",
+ "wascap 0.11.0",
 ]
 
 [[package]]
@@ -2778,9 +2802,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
 ]
@@ -3101,7 +3125,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3262,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "3b88756493a5bd5e5395d53baa70b194b05764ab85b59e43e4b8f4e1192fa9b1"
 dependencies = [
  "serde_derive",
 ]
@@ -3290,22 +3314,22 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "6e5c3a298c7f978e53536f95a63bdc4c4a64550582f31a0359a9afda6aede62e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "itoa",
  "ryu",
  "serde",
@@ -3337,7 +3361,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3552,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.12"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3628,7 +3652,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -3721,7 +3745,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -4439,7 +4463,7 @@ version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "url",
 ]
 
@@ -4449,7 +4473,7 @@ version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c437373cac5ea84f1113d648d51f71751ffbe3d90c00ae67618cf20d0b5ee7b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "url",
 ]
 
@@ -4459,7 +4483,7 @@ version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29e3ac9b780c7dda0cac7a52a5d6d2d6707cc6e3451c9db209b6c758f40d7acb"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "semver",
 ]
 
@@ -4483,7 +4507,7 @@ dependencies = [
  "bincode",
  "cfg-if",
  "encoding_rs",
- "indexmap",
+ "indexmap 1.9.3",
  "libc",
  "log",
  "object",
@@ -4580,7 +4604,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "object",
  "serde",
@@ -4658,7 +4682,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "encoding_rs",
- "indexmap",
+ "indexmap 1.9.3",
  "libc",
  "log",
  "mach",
@@ -5025,7 +5049,7 @@ checksum = "f887c3da527a51b321076ebe6a7513026a4757b6d4d144259946552d6fc728b3"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 1.9.3",
  "log",
  "pulldown-cmark",
  "unicode-xid",
@@ -5069,7 +5093,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.12",
+ "syn 2.0.27",
 ]
 
 [[package]]

--- a/host_core/native/hostcore_wasmcloud_native/Cargo.toml
+++ b/host_core/native/hostcore_wasmcloud_native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hostcore_wasmcloud_native"
-version = "0.1.2"
+version = "0.2.0"
 authors = []
 edition = "2021"
 
@@ -16,6 +16,7 @@ lazy_static = "1.0"
 async-trait = "0.1.66"
 serde = {version = "1.0.126", features = ["derive"] }
 serde_bytes = "0.11.5"
+serde_json = "1.0.103"
 nkeys = "0.3.0"
 futures = "0.3.27"
 wascap = "0.11"
@@ -27,7 +28,7 @@ data-encoding = "2.3.2"
 rmp = "0.8.10"
 rmp-serde = "1.0.0"
 oci-distribution = { version = "0.9.1", default-features = false, features = ["rustls-tls"] }
-provider-archive = "0.6.0"
+provider-archive = "0.8.0"
 tokio = {version = "1.26.0", features = ["rt", "rt-multi-thread"] }
 once_cell = "1.2.0"
 chrono-humanize = "0.2.1"

--- a/host_core/native/hostcore_wasmcloud_native/src/lib.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/lib.rs
@@ -78,6 +78,7 @@ pub struct Claims {
     caps: Option<Vec<String>>,
     expires_human: String,
     not_before_human: String,
+    config_schema: Option<String>
 }
 
 impl From<wascap::jwt::Claims<wascap::jwt::CapabilityProvider>> for crate::Claims {
@@ -511,6 +512,7 @@ fn extract_claims(binary: Binary) -> Result<(Atom, Claims), Error> {
         tags: m.tags,
         expires_human: v.expires_human,
         not_before_human: v.not_before_human,
+        config_schema: None
     };
 
     Ok((atoms::ok(), out))

--- a/host_core/native/hostcore_wasmcloud_native/src/par.rs
+++ b/host_core/native/hostcore_wasmcloud_native/src/par.rs
@@ -34,6 +34,8 @@ pub(crate) fn extract_claims(par: &ProviderArchive) -> Result<crate::Claims, Err
                 tags: None,
                 version: metadata.ver,
                 name: metadata.name,
+                // the unwrap here is safe because we know it's a valid JSON value
+                config_schema: metadata.config_schema.map(|s| serde_json::to_string(&s).unwrap()),
                 expires_human: stamp_to_human(c.expires).unwrap_or_else(|| "never".to_string()),
                 not_before_human: stamp_to_human(c.not_before)
                     .unwrap_or_else(|| "immediately".to_string()),

--- a/wasmcloud_host/package-lock.json
+++ b/wasmcloud_host/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "wasmcloud_host",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This adds support for the `config_schema` field in capability provider claims. It is supposed by both the internal claims cache and the KV bucket, as well as extraction from the PAR file itself.

Querying claims from the lattice (asking the host):
```
wash ctl get claims -o json
[warn] `wash ctl get claims` has been deprecated in favor of `wash get claims` and will be removed in a future version.

{
  "claims": {
    "claims": [
      {
        "call_alias": "",
        "caps": "",
        "config_schema": "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"description\":\"wasmCloud HTTP Server Provider Link Definition configuration specfiication\",\"properties\":{\"address\":{\"default\":\"127.0.0.1:4000\",\"description\":\"An address and port combination on which to listen.\",\"type\":\"string\"},\"config_b64\":{\"description\":\"A base64 encoded version of the config_json property. See that property for schema\",\"type\":\"string\"},\"config_file\":{\"default\":\"\",\"description\":\"The path to a file containing JSON configuration. Use this sparingly as it affects portability\",\"type\":\"string\"},\"config_json\":{\"description\":\"Raw JSON configuration for the link definition\",\"properties\":{\"address\":{\"default\":\"127.0.0.1:4000\",\"description\":\"An address and port combination on which to listen.\",\"type\":\"string\"},\"cache_control\":{\"description\":\"Cache control header information\",\"type\":\"string\"},\"max_content_len\":{\"description\":\"Duration string\",\"type\":\"string\"},\"readonly_mode\":{\"description\":\"Enforce only read operations\",\"type\":\"boolean\"},\"timeout_ms\":{\"description\":\"Timeout in milliseconds for requests\",\"type\":\"integer\"},\"tls\":{\"properties\":{\"cert_file\":{\"description\":\"tbd\",\"type\":\"string\"},\"priv_key_file\":{\"description\":\"tbd\",\"type\":\"string\"}},\"type\":\"object\"}},\"type\":\"object\"},\"port\":{\"default\":\"\",\"description\":\"A port number on which to listen\",\"type\":\"string\"}},\"title\":\"HTTP Server Provider Configuration\",\"type\":\"object\",\"x-taplo-info\":{\"authors\":[\"wasmCloud Team\"]}}",
        "contract_id": "wasmcloud:httpserver",
        "iss": "ACM7TOENKEIO6Q6J66FX53AKXRHH6TH2WZ6K6SZQULNSWLDUIQHSRRSS",
        "name": "HTTP Server",
        "rev": "1689871835",
        "sub": "VDASU74EOUFQPSDCER7PCLFFQUZSHHB7AKZQM2DOJS77BLXSKXNT7CZ6",
        "tags": "",
        "version": "0.18.2"
      }
    ]
  },
  "success": true
}
```

note that the `config_schema` field, as managed by the hosts, is an escaped string and not managed as raw JSON.

Querying directly from the bucket:
```
nats kv get LATTICEDATA_default CLAIMS_VDASU74EOUFQPSDCER7PCLFFQUZSHHB7AKZQM2DOJS77BLXSKXNT7CZ6 --raw
{"call_alias":"","caps":"","config_schema":"{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"description\":\"wasmCloud HTTP Server Provider Link Definition configuration specfiication\",\"properties\":{\"address\":{\"default\":\"127.0.0.1:4000\",\"description\":\"An address and port combination on which to listen.\",\"type\":\"string\"},\"config_b64\":{\"description\":\"A base64 encoded version of the config_json property. See that property for schema\",\"type\":\"string\"},\"config_file\":{\"default\":\"\",\"description\":\"The path to a file containing JSON configuration. Use this sparingly as it affects portability\",\"type\":\"string\"},\"config_json\":{\"description\":\"Raw JSON configuration for the link definition\",\"properties\":{\"address\":{\"default\":\"127.0.0.1:4000\",\"description\":\"An address and port combination on which to listen.\",\"type\":\"string\"},\"cache_control\":{\"description\":\"Cache control header information\",\"type\":\"string\"},\"max_content_len\":{\"description\":\"Duration string\",\"type\":\"string\"},\"readonly_mode\":{\"description\":\"Enforce only read operations\",\"type\":\"boolean\"},\"timeout_ms\":{\"description\":\"Timeout in milliseconds for requests\",\"type\":\"integer\"},\"tls\":{\"properties\":{\"cert_file\":{\"description\":\"tbd\",\"type\":\"string\"},\"priv_key_file\":{\"description\":\"tbd\",\"type\":\"string\"}},\"type\":\"object\"}},\"type\":\"object\"},\"port\":{\"default\":\"\",\"description\":\"A port number on which to listen\",\"type\":\"string\"}},\"title\":\"HTTP Server Provider Configuration\",\"type\":\"object\",\"x-taplo-info\":{\"authors\":[\"wasmCloud Team\"]}}","contract_id":"wasmcloud:httpserver","iss":"ACM7TOENKEIO6Q6J66FX53AKXRHH6TH2WZ6K6SZQULNSWLDUIQHSRRSS","name":"HTTP Server","rev":"1689871835","sub":"VDASU74EOUFQPSDCER7PCLFFQUZSHHB7AKZQM2DOJS77BLXSKXNT7CZ6","tags":"","version":"0.18.2"}
```